### PR TITLE
Bumped checkstyle dependencies to latest - CVE-2019-9658 CVE-2019-10782 

### DIFF
--- a/broker/client/src/main/java/org/eclipse/kapua/broker/client/message/JmsUtil.java
+++ b/broker/client/src/main/java/org/eclipse/kapua/broker/client/message/JmsUtil.java
@@ -48,7 +48,7 @@ public class JmsUtil {
      * Return the topic for the message's destination
      *
      * @param jmsMessage
-     * @return
+     * @return test
      * @throws JMSException
      */
     public static String getJmsTopic(ActiveMQMessage jmsMessage) throws JMSException {
@@ -129,7 +129,7 @@ public class JmsUtil {
      * @param jmsTopic
      * @param queuedOn
      * @param connectionId
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static CamelKapuaMessage<?> convertToCamelKapuaMessage(ProtocolDescriptor connectorDescriptor, MessageType messageType, byte[] messageBody, String jmsTopic, Date queuedOn,
@@ -147,7 +147,7 @@ public class JmsUtil {
      * @param messageBody
      * @param jmsTopic
      * @param queuedOn
-     * @return
+     * @return test
      * @throws KapuaException
      */
     private static KapuaMessage<?, ?> convertToKapuaMessage(Class<? extends DeviceMessage<?, ?>> deviceMessageType, Class<? extends KapuaMessage<?, ?>> kapuaMessageType, byte[] messageBody,
@@ -173,7 +173,7 @@ public class JmsUtil {
      * @param connectorDescriptor
      * @param messageType
      * @param kapuaMessage
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JmsMessage convertToJmsMessage(ProtocolDescriptor connectorDescriptor, MessageType messageType, KapuaMessage<?, ?> kapuaMessage) throws KapuaException, ClassNotFoundException {
@@ -198,7 +198,7 @@ public class JmsUtil {
      * sub tree &gt; #
      *
      * @param jmsTopic
-     * @return
+     * @return test
      */
     public static String convertJmsWildCardToMqtt(String jmsTopic) {
         String processedTopic = null;
@@ -231,7 +231,7 @@ public class JmsUtil {
      * sub tree &gt; #
      *
      * @param mqttTopic
-     * @return
+     * @return test
      */
     public static String convertMqttWildCardToJms(String mqttTopic) {
         String processedTopic = null;

--- a/broker/client/src/main/java/org/eclipse/kapua/broker/client/pool/JmsAssistantProducerPool.java
+++ b/broker/client/src/main/java/org/eclipse/kapua/broker/client/pool/JmsAssistantProducerPool.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.client.pool;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.eclipse.kapua.broker.client.setting.BrokerClientSetting;
 import org.eclipse.kapua.broker.client.setting.BrokerClientSettingKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class is needed by KapuaSecurityBrokerFilter to handle a vm connection.<BR>
@@ -53,7 +53,7 @@ public class JmsAssistantProducerPool extends GenericObjectPool<JmsAssistantProd
     private static Map<DESTINATIONS, JmsAssistantProducerPool> pools;
 
     static {
-        pools = new HashMap<JmsAssistantProducerPool.DESTINATIONS, JmsAssistantProducerPool>();
+        pools = new HashMap<>();
         logger.info("Create pools (internal broker use)...");
         logger.info("Create NoDestination pool...");
         pools.put(DESTINATIONS.NO_DESTINATION,
@@ -90,7 +90,7 @@ public class JmsAssistantProducerPool extends GenericObjectPool<JmsAssistantProd
      * Return a JmsAssistantProducerPool for the given destination
      *
      * @param destination
-     * @return
+     * @return test
      */
     public static JmsAssistantProducerPool getIOnstance(DESTINATIONS destination) {
         return pools.get(destination);

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/Acl.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/Acl.java
@@ -39,7 +39,7 @@ public class Acl {
     /**
      * Has read rights
      *
-     * @return
+     * @return test
      */
     public boolean isRead() {
         return readPermission;
@@ -48,7 +48,7 @@ public class Acl {
     /**
      * Has write rights
      *
-     * @return
+     * @return test
      */
     public boolean isWrite() {
         return writePermission;
@@ -57,7 +57,7 @@ public class Acl {
     /**
      * Has admin rights
      *
-     * @return
+     * @return test
      */
     public boolean isAdmin() {
         return adminPermission;

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/BrokerIdResolver.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/BrokerIdResolver.java
@@ -25,7 +25,7 @@ public interface BrokerIdResolver {
      * Resolve the broker id
      *
      * @param brokerFilter
-     * @return
+     * @return test
      */
     String getBrokerId(BrokerFilter brokerFilter);
 

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/BrokerIpResolver.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/BrokerIpResolver.java
@@ -22,7 +22,7 @@ public interface BrokerIpResolver {
     /**
      * Resolve the broker address (private ip)
      *
-     * @return
+     * @return test
      */
     String getBrokerIpOrHostName();
 

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -66,9 +66,9 @@ import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.AuthenticationService;
 import org.eclipse.kapua.service.authentication.CredentialsFactory;
-import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationErrorCodes;
 import org.eclipse.kapua.service.authentication.KapuaPrincipal;
 import org.eclipse.kapua.service.authentication.LoginCredentials;
+import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationErrorCodes;
 import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationException;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.device.registry.Device;
@@ -351,7 +351,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
      * Pass through connection is a connection with null connector (Advisory topic connection) or embedded broker connection (connection string starts by vm://)
      *
      * @param context
-     * @return
+     * @return test
      */
     private boolean isPassThroughConnection(ConnectionContext context) {
         if (context != null) {
@@ -388,7 +388,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
      * Return true if
      *
      * @param context
-     * @return
+     * @return test
      */
     private boolean isTrustedContext(ConnectionContext context) {
         if (context == null) {
@@ -454,7 +454,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
             LoginCredentials credentials = credentialsFactory.newUsernamePasswordCredentials(info.getUserName(), info.getPassword());
             AccessToken accessToken = authenticationService.login(credentials);
 
-            final Account account = getAccount(accessToken.getScopeId());
+            Account account = getAccount(accessToken.getScopeId());
 
             KapuaPrincipal principal = new KapuaPrincipalImpl(accessToken,
                     info.getUserName(),
@@ -570,7 +570,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
     }
 
     private Account getAccount(KapuaId scopeId) {
-        final Account account;
+        Account account;
         try {
             account = KapuaSecurityUtils.doPrivileged(() -> accountService.find(scopeId));
         } catch (AuthenticationException e) {
@@ -734,7 +734,6 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
     // ------------------------------------------------------------------
 
     protected void buildAuthorization(KapuaSecurityContext kapuaSecurityContext, List<org.eclipse.kapua.broker.core.plugin.authentication.AuthorizationEntry> authorizationEntries) {
-        @SuppressWarnings("rawtypes")
         List<DestinationMapEntry> entries = new ArrayList<>();
         for (org.eclipse.kapua.broker.core.plugin.authentication.AuthorizationEntry entry : authorizationEntries) {
             entries.add(createAuthorizationEntry(kapuaSecurityContext, entry.getAcl(), entry.getAddress()));

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
@@ -12,16 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin;
 
-import java.math.BigInteger;
-import java.security.Principal;
-import java.security.cert.Certificate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.activemq.command.ConnectionInfo;
 import org.apache.activemq.security.AuthorizationMap;
 import org.apache.activemq.security.SecurityContext;
@@ -35,6 +25,16 @@ import org.eclipse.kapua.service.authentication.KapuaPrincipal;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Kapua security context implementation of ActiveMQ broker {@link SecurityContext}
@@ -88,12 +88,12 @@ public class KapuaSecurityContext extends SecurityContext {
     }
 
     public KapuaSecurityContext(KapuaPrincipal principal, String brokerId, String brokerIpOrHostName, String accountName, ConnectionInfo info, String connectorName) {
-        super(principal!=null ? principal.getName() : null);
+        super(principal != null ? principal.getName() : null);
         this.principal = principal;
         this.brokerId = brokerId;
         this.brokerIpOrHostName = brokerIpOrHostName;
         this.accountName = accountName;
-        principals = new HashSet<Principal>();
+        principals = new HashSet<>();
         if (principal != null) {
             userId = principal.getUserId();
             scopeId = principal.getAccountId();
@@ -113,7 +113,7 @@ public class KapuaSecurityContext extends SecurityContext {
         if (connectorDescriptor == null) {
             throw new IllegalStateException(String.format("Unable to find connector descriptor for connector '%s'", connectorName));
         }
-        if(info.getTransportContext() instanceof Certificate[]) {
+        if (info.getTransportContext() instanceof Certificate[]) {
             clientCertificates = (Certificate[]) info.getTransportContext();
         }
         updateFullClientId();
@@ -127,6 +127,7 @@ public class KapuaSecurityContext extends SecurityContext {
         return principal;
     }
 
+    @Override
     public Set<Principal> getPrincipals() {
         return principals;
     }
@@ -268,16 +269,14 @@ public class KapuaSecurityContext extends SecurityContext {
     }
 
     /**
-     *
      * @param key
      * @param defaultValue
-     *
+     * @return test
      * @throws ClassCastException if the property object is different from what expected by the caller (in other words no check before casting is done!)
-     * @return
      */
     public <T> T getProperty(String key, T defaultValue) {
-        T value = (T)properties.get(key);
-        return value!=null ? value : defaultValue;
+        T value = (T) properties.get(key);
+        return value != null ? value : defaultValue;
     }
 
     public void addAuthDestinationToLog(String message) {

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthenticationLogic.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthenticationLogic.java
@@ -16,8 +16,8 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.BrokerDomains;
 import org.eclipse.kapua.broker.core.plugin.Acl;
 import org.eclipse.kapua.broker.core.plugin.KapuaBrokerErrorCodes;
-import org.eclipse.kapua.broker.core.plugin.KapuaSecurityContext;
 import org.eclipse.kapua.broker.core.plugin.KapuaIllegalDeviceStateException;
+import org.eclipse.kapua.broker.core.plugin.KapuaSecurityContext;
 import org.eclipse.kapua.broker.core.plugin.metric.ClientMetric;
 import org.eclipse.kapua.broker.core.plugin.metric.LoginMetric;
 import org.eclipse.kapua.broker.core.plugin.metric.PublishMetric;
@@ -76,6 +76,7 @@ public abstract class AuthenticationLogic {
     protected DeviceConnectionService deviceConnectionService = KapuaLocator.getInstance().getService(DeviceConnectionService.class);
 
     private static final String USER_NOT_AUTHORIZED = "User not authorized!";
+
     /**
      * Default constructor
      *
@@ -92,7 +93,7 @@ public abstract class AuthenticationLogic {
      * Execute the connect logic returning the authorization list (ACL)
      *
      * @param kapuaSecurityContext
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public abstract List<org.eclipse.kapua.broker.core.plugin.authentication.AuthorizationEntry> connect(KapuaSecurityContext kapuaSecurityContext)
@@ -110,7 +111,7 @@ public abstract class AuthenticationLogic {
 
     /**
      * @param kapuaSecurityContext
-     * @return
+     * @return test
      */
     protected abstract List<AuthorizationEntry> buildAuthorizationMap(KapuaSecurityContext kapuaSecurityContext);
 
@@ -119,7 +120,7 @@ public abstract class AuthenticationLogic {
      *
      * @param pattern
      * @param kapuaSecurityContext
-     * @return
+     * @return test
      */
     protected String formatAcl(String pattern, KapuaSecurityContext kapuaSecurityContext) {
         return MessageFormat.format(pattern, kapuaSecurityContext.getAccountName());
@@ -130,7 +131,7 @@ public abstract class AuthenticationLogic {
      *
      * @param pattern
      * @param kapuaSecurityContext
-     * @return
+     * @return test
      */
     protected String formatAclFull(String pattern, KapuaSecurityContext kapuaSecurityContext) {
         return MessageFormat.format(pattern, kapuaSecurityContext.getAccountName(), kapuaSecurityContext.getClientId());
@@ -142,7 +143,7 @@ public abstract class AuthenticationLogic {
      * @param kapuaSecurityContext
      * @param acl
      * @param address
-     * @return
+     * @return test
      */
     protected AuthorizationEntry createAuthorizationEntry(KapuaSecurityContext kapuaSecurityContext, Acl acl, String address) {
         AuthorizationEntry entry = new AuthorizationEntry(address, acl);
@@ -243,7 +244,7 @@ public abstract class AuthenticationLogic {
      * <b>Utility method used by the connection logic</b>
      *
      * @param options
-     * @return
+     * @return test
      */
     protected ConnectionUserCouplingMode loadConnectionUserCouplingModeFromConfig(Map<String, Object> options) {
         String tmp = (String) options.get("deviceConnectionUserCouplingDefaultMode");// TODO move to constants
@@ -263,12 +264,12 @@ public abstract class AuthenticationLogic {
     }
 
     protected boolean isStealingLink(KapuaSecurityContext kapuaSecurityContext, Throwable error) {
-        if(isIllegalState(kapuaSecurityContext, error)) {
+        if (isIllegalState(kapuaSecurityContext, error)) {
             return true;
         }
 
         KapuaIllegalDeviceStateException illegalStateException = null;
-        if(error instanceof KapuaIllegalDeviceStateException) {
+        if (error instanceof KapuaIllegalDeviceStateException) {
             illegalStateException = (KapuaIllegalDeviceStateException) error;
         } else if (error != null && error.getCause() != null && error.getCause() instanceof KapuaIllegalDeviceStateException) {
             illegalStateException = (KapuaIllegalDeviceStateException) error.getCause();
@@ -281,14 +282,13 @@ public abstract class AuthenticationLogic {
         boolean isIllegalState = false;
         if (kapuaSecurityContext.getOldConnectionId() != null) {
             isIllegalState = !kapuaSecurityContext.getOldConnectionId().equals(kapuaSecurityContext.getConnectionId());
-        }
-        else {
+        } else {
             logger.error("Cannot find connection id for client id {} on connection map. Correct connection id is {} - IP: {}",
                     kapuaSecurityContext.getClientId(),
                     kapuaSecurityContext.getConnectionId(),
                     kapuaSecurityContext.getClientIp());
         }
-        if (!isIllegalState && (error instanceof KapuaIllegalDeviceStateException || (error!=null && error.getCause() instanceof KapuaIllegalDeviceStateException))) {
+        if (!isIllegalState && (error instanceof KapuaIllegalDeviceStateException || (error != null && error.getCause() instanceof KapuaIllegalDeviceStateException))) {
             isIllegalState = true;
             logger.warn("Detected Stealing link for cliend id {} - account id {} - last connection id was {} - current connection id is {} - IP: {} - No disconnection info will be added!",
                     kapuaSecurityContext.getClientId(),

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/Authenticator.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/Authenticator.java
@@ -12,16 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin.authentication;
 
-import java.util.List;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.plugin.KapuaSecurityContext;
 
+import java.util.List;
+
 /**
  * Authenticator api
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface Authenticator {
 
@@ -33,34 +32,32 @@ public interface Authenticator {
 
     /**
      * Execute the connect logic returning the authorization list (ACL)
-     * 
+     *
      * @param kapuaSecurityContext
-     * @return
-     * @throws KapuaException
-     *             if any checks fails (credential not valid, profile missing, ...)
+     * @return test
+     * @throws KapuaException if any checks fails (credential not valid, profile missing, ...)
      */
     public abstract List<org.eclipse.kapua.broker.core.plugin.authentication.AuthorizationEntry> connect(KapuaSecurityContext kapuaSecurityContext)
             throws KapuaException;
 
     /**
      * Execute the disconnect logic
-     * 
+     *
      * @param kapuaSecurityContext
-     * @param error
-     *            not null if the disconnection is due to an error not related to the client (network I/O error, server side error, ...)
+     * @param error                not null if the disconnection is due to an error not related to the client (network I/O error, server side error, ...)
      */
     public abstract void disconnect(KapuaSecurityContext kapuaSecurityContext, Throwable error);
 
     /**
      * Send the connect message (this message is mainly for internal use to enforce the stealing link)
-     * 
+     *
      * @param kapuaSecurityContext
      */
     public abstract void sendConnectMessage(KapuaSecurityContext kapuaSecurityContext);
 
     /**
      * Send the disconnect message (this message is mainly for internal use)
-     * 
+     *
      * @param kapuaSecurityContext
      */
     public abstract void sendDisconnectMessage(KapuaSecurityContext kapuaSecurityContext);

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Transport.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Transport.java
@@ -55,8 +55,7 @@ public interface Transport {
      * last known state.
      * </p>
      *
-     * @param listener
-     *            the listener to transport state changes
+     * @param listener the listener to transport state changes
      */
     public ListenerHandle listen(Listener listener);
 
@@ -84,30 +83,28 @@ public interface Transport {
      * });
      * </pre>
      *
-     * @param events
-     *            code to update the {@link TransportEvents}
-     * @return
-     *
+     * @param events code to update the {@link TransportEvents}
+     * @return test
      */
-    public default ListenerHandle events(final Consumer<TransportEvents> events) {
+    public default ListenerHandle events(Consumer<TransportEvents> events) {
         class TransportEventsImpl implements TransportEvents {
 
             private Runnable connected;
             private Runnable disconnected;
 
             @Override
-            public void connected(final Runnable runnable) {
+            public void connected(Runnable runnable) {
                 connected = runnable;
             }
 
             @Override
-            public void disconnected(final Runnable runnable) {
+            public void disconnected(Runnable runnable) {
                 disconnected = runnable;
             }
 
         }
 
-        final TransportEventsImpl impl = new TransportEventsImpl();
+        TransportEventsImpl impl = new TransportEventsImpl();
 
         events.accept(impl);
 
@@ -130,15 +127,13 @@ public interface Transport {
      * <b>Note:</b> This method will reset the transport listeners.
      * </p>
      *
-     * @param transport
-     *            to wait on
-     * @throws InterruptedException
-     *             if the wait got interrupted
+     * @param transport to wait on
+     * @throws InterruptedException if the wait got interrupted
      */
-    public static void waitForConnection(final Transport transport) throws InterruptedException {
+    public static void waitForConnection(Transport transport) throws InterruptedException {
         Objects.requireNonNull(transport);
 
-        final Semaphore sem = new Semaphore(0);
+        Semaphore sem = new Semaphore(0);
 
         try (ListenerHandle handle = transport.listen(state -> {
             if (state) {
@@ -155,18 +150,15 @@ public interface Transport {
      * <b>Note:</b> This method will reset the transport listeners.
      * </p>
      *
-     * @param transport
-     *            to wait on
-     * @param timeout
-     *            the timeout
-     * @throws InterruptedException
-     *             if the wait got interrupted
+     * @param transport to wait on
+     * @param timeout   the timeout
+     * @throws InterruptedException if the wait got interrupted
      */
-    public static boolean waitForConnection(final Transport transport, final Duration timeout) throws InterruptedException {
+    public static boolean waitForConnection(Transport transport, Duration timeout) throws InterruptedException {
         Objects.requireNonNull(transport);
         Objects.requireNonNull(timeout);
 
-        final Semaphore sem = new Semaphore(0);
+        Semaphore sem = new Semaphore(0);
 
         try (ListenerHandle handle = transport.listen(state -> {
             if (state) {

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxy.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxy.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.client.gateway.spi.util;
 
+import org.eclipse.kapua.client.gateway.Transport;
+
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executor;
-
-import org.eclipse.kapua.client.gateway.Transport;
 
 public final class TransportProxy implements Transport, AutoCloseable {
 
@@ -32,7 +32,7 @@ public final class TransportProxy implements Transport, AutoCloseable {
 
     private boolean lastKnownState;
 
-    private TransportProxy(final Transport transport, final Executor executor) {
+    private TransportProxy(Transport transport, Executor executor) {
         this.transport = transport;
         this.executor = executor;
     }
@@ -43,7 +43,7 @@ public final class TransportProxy implements Transport, AutoCloseable {
     }
 
     @Override
-    public synchronized ListenerHandle listen(final Listener listener) {
+    public synchronized ListenerHandle listen(Listener listener) {
         Objects.requireNonNull(listener);
 
         checkClosed();
@@ -86,22 +86,21 @@ public final class TransportProxy implements Transport, AutoCloseable {
      * If the proxy instance is already closed, this method will <b>not</b> throw any exception
      * </p>
      *
-     * @param listener
-     *            the listener to remove
+     * @param listener the listener to remove
      */
-    private synchronized void removeListener(final Listener listener) {
+    private synchronized void removeListener(Listener listener) {
 
         // simply remove listener
 
         listeners.remove(listener);
     }
 
-    private synchronized void handleChange(final boolean state) {
+    private synchronized void handleChange(boolean state) {
         lastKnownState = state;
         fireEvent(state, new CopyOnWriteArraySet<>(listeners));
     }
 
-    private void fireEvent(final boolean state, final Set<Listener> listeners) {
+    private void fireEvent(boolean state, Set<Listener> listeners) {
         executor.execute(() -> {
             listeners.stream().forEach(l -> l.stateChange(state));
         });
@@ -129,12 +128,11 @@ public final class TransportProxy implements Transport, AutoCloseable {
     }
 
     /**
-     *
      * @param transport
      * @param executor
-     * @return
+     * @return test
      */
-    public static TransportProxy proxy(final Transport transport, final Executor executor) {
+    public static TransportProxy proxy(Transport transport, Executor executor) {
         Objects.requireNonNull(transport);
         Objects.requireNonNull(executor);
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/Cache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/Cache.java
@@ -15,11 +15,8 @@ package org.eclipse.kapua.commons.cache;
 /**
  * Kapua cache definition
  *
- * @param <K>
- *            keys type
- * @param <V>
- *            values type
- *
+ * @param <K> keys type
+ * @param <V> values type
  * @since 1.0
  */
 public interface Cache<K, V> {
@@ -27,7 +24,7 @@ public interface Cache<K, V> {
     /**
      * Return the metric namespace
      *
-     * @return
+     * @return test
      */
     public String getNamespace();
 
@@ -42,7 +39,7 @@ public interface Cache<K, V> {
      * Return the cache value for the given key
      *
      * @param k
-     * @return
+     * @return test
      */
     public V get(K k);
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
@@ -12,28 +12,23 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.cache;
 
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.cache.CacheBuilder;
-
 /**
  * Default Kapua cache implementation
  *
- * @param <K>
- *            keys type
- * @param <V>
- *            values type
- *
+ * @param <K> keys type
+ * @param <V> values type
  * @since 1.0
  */
 public class LocalCache<K, V> implements Cache<K, V> {
 
-    @SuppressWarnings("unused")
     private static final Logger logger = LoggerFactory.getLogger(LocalCache.class);
 
     private String namespace;
@@ -43,14 +38,11 @@ public class LocalCache<K, V> implements Cache<K, V> {
     /**
      * Construct local cache setting the provided max size, expire time and default value
      *
-     * @param sizeMax
-     *            max cache size
-     * @param expireAfter
-     *            values ttl
-     * @param defaultValue
-     *            default value (if no value is found for a specific key)
+     * @param sizeMax      max cache size
+     * @param expireAfter  values ttl
+     * @param defaultValue default value (if no value is found for a specific key)
      */
-    public LocalCache(int sizeMax, int expireAfter, final V defaultValue) {
+    public LocalCache(int sizeMax, int expireAfter, V defaultValue) {
         this.defaultValue = defaultValue;
         cache = CacheBuilder.newBuilder().maximumSize(sizeMax).expireAfterWrite(expireAfter, TimeUnit.SECONDS).build();
     }
@@ -58,12 +50,10 @@ public class LocalCache<K, V> implements Cache<K, V> {
     /**
      * Construct local cache setting the provided max size and default value. <b>ttl is disabled, so no time based eviction will be performed.</b>
      *
-     * @param sizeMax
-     *            max cache size
-     * @param defaultValue
-     *            default value (if no value is found for a specific key)
+     * @param sizeMax      max cache size
+     * @param defaultValue default value (if no value is found for a specific key)
      */
-    public LocalCache(int sizeMax, final V defaultValue) {
+    public LocalCache(int sizeMax, V defaultValue) {
         this.defaultValue = defaultValue;
         // from google javadoc ("https://google.github.io/guava/releases/19.0/api/docs/com/google/common/cache/CacheBuilder.html")
         // By default cache instances created by CacheBuilder will not perform any type of eviction.
@@ -96,10 +86,10 @@ public class LocalCache<K, V> implements Cache<K, V> {
     /**
      * Return the list of all the keys present in the cache
      *
-     * @return
+     * @return test
      */
     public List<K> getAllKeys() {
-        ArrayList<K> keys = new ArrayList<K>();
+        ArrayList<K> keys = new ArrayList<>();
         if (cache != null) {
             keys.addAll(cache.asMap().keySet());
         }

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration;
 
-import java.util.Properties;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
+
+import java.util.Properties;
 
 /**
  * Configuration service definition.
@@ -32,6 +32,7 @@ public interface ServiceConfig extends KapuaUpdatableEntity {
     /**
      * Return the service type
      */
+    @Override
     public default String getType() {
         return TYPE;
     }
@@ -39,7 +40,7 @@ public interface ServiceConfig extends KapuaUpdatableEntity {
     /**
      * Return service pid
      *
-     * @return
+     * @return test
      */
     public String getPid();
 
@@ -53,7 +54,7 @@ public interface ServiceConfig extends KapuaUpdatableEntity {
     /**
      * Return service configurations
      *
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public Properties getConfigurations() throws KapuaException;

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreator.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration;
 
-import java.util.Properties;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
+
+import java.util.Properties;
 
 /**
  * Service configuration creator definition.
@@ -27,7 +27,7 @@ public interface ServiceConfigCreator extends KapuaUpdatableEntityCreator<Servic
     /**
      * Return service pid
      *
-     * @return
+     * @return test
      */
     public String getPid();
 
@@ -41,7 +41,7 @@ public interface ServiceConfigCreator extends KapuaUpdatableEntityCreator<Servic
     /**
      * Return service configurations
      *
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public Properties getConfigurations() throws KapuaException;

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigDAO.java
@@ -24,7 +24,6 @@ import org.eclipse.kapua.model.query.KapuaQuery;
  * Service configuration DAO
  *
  * @since 1.0
- *
  */
 public class ServiceConfigDAO extends ServiceDAO {
 
@@ -33,7 +32,7 @@ public class ServiceConfigDAO extends ServiceDAO {
      *
      * @param em
      * @param serviceConfigCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static ServiceConfigImpl create(EntityManager em, ServiceConfigCreatorImpl serviceConfigCreator)
@@ -53,7 +52,7 @@ public class ServiceConfigDAO extends ServiceDAO {
      *
      * @param em
      * @param serviceConfig
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static ServiceConfig update(EntityManager em, ServiceConfig serviceConfig)
@@ -71,7 +70,7 @@ public class ServiceConfigDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param userId
-     * @return
+     * @return test
      */
     public static ServiceConfig find(EntityManager em, KapuaId scopeId, KapuaId userId) {
         return ServiceDAO.find(em, ServiceConfigImpl.class, scopeId, userId);
@@ -82,7 +81,7 @@ public class ServiceConfigDAO extends ServiceDAO {
      *
      * @param em
      * @param name
-     * @return
+     * @return test
      */
     public static ServiceConfig findByName(EntityManager em, String name) {
         return ServiceDAO.findByField(em, ServiceConfigImpl.class, KapuaNamedEntityAttributes.NAME, name);
@@ -93,7 +92,7 @@ public class ServiceConfigDAO extends ServiceDAO {
      *
      * @param em
      * @param serviceConfigQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static ServiceConfigListResult query(EntityManager em, KapuaQuery serviceConfigQuery)
@@ -106,7 +105,7 @@ public class ServiceConfigDAO extends ServiceDAO {
      *
      * @param em
      * @param serviceConfigQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery serviceConfigQuery)

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ValueTokenizer.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ValueTokenizer.java
@@ -68,69 +68,69 @@ public class ValueTokenizer {
         for (int i = 0; i < valuesStr.length(); i++) {
             char c1 = valuesStr.charAt(i);
             switch (c1) {
-            case DELIMITER:
-                // When the delimiter is encountered, add the extracted
-                // token to the result and prepare the buffer to receive the
-                // next token.
-                values.add(buffer.toString());
-                buffer.delete(0, buffer.length());
-                break;
-            case ESCAPE:
-                // When the escape is encountered, add the immediately
-                // following character to the token, unless the end of the
-                // input has been reached. Note this will result in loop
-                // counter 'i' being incremented twice, once here and once
-                // at the end of the loop.
-                if (i + 1 < valuesStr.length()) {
-                    buffer.append(valuesStr.charAt(++i));
-                } else {
-                    // If the ESCAPE character occurs as the last character
-                    // of the string, log the error and ignore it.
-                    LOG.error(VALUE_INVALID);
-                }
-                break;
-            default:
-                // For all other characters, add them to the current token
-                // unless dealing with unescaped whitespace at the beginning
-                // or end. We know the whitespace is unescaped because it
-                // would have been handled in the ESCAPE case otherwise.
-                if (Character.isWhitespace(c1)) {
-                    // Ignore unescaped whitespace at the beginning of the
-                    // token.
-                    if (buffer.length() == 0) {
-                        continue;
+                case DELIMITER:
+                    // When the delimiter is encountered, add the extracted
+                    // token to the result and prepare the buffer to receive the
+                    // next token.
+                    values.add(buffer.toString());
+                    buffer.delete(0, buffer.length());
+                    break;
+                case ESCAPE:
+                    // When the escape is encountered, add the immediately
+                    // following character to the token, unless the end of the
+                    // input has been reached. Note this will result in loop
+                    // counter 'i' being incremented twice, once here and once
+                    // at the end of the loop.
+                    if (i + 1 < valuesStr.length()) {
+                        buffer.append(valuesStr.charAt(++i));
+                    } else {
+                        // If the ESCAPE character occurs as the last character
+                        // of the string, log the error and ignore it.
+                        LOG.error(VALUE_INVALID);
                     }
-                    // If the whitespace is not at the beginning, look
-                    // forward, starting with the next character, to see if
-                    // it's in the middle or at the end. Unescaped
-                    // whitespace in the middle is okay.
-                    for (int j = i + 1; j < valuesStr.length(); j++) {
-                        // Keep looping until the end of the string is
-                        // reached or a non-whitespace character other than
-                        // the escape is seen.
-                        char c2 = valuesStr.charAt(j);
-                        if (!Character.isWhitespace(c2)) {
-                            // If the current character is not the DELIMITER, all whitespace
-                            // characters are significant and should be added to the token.
-                            // Otherwise, they're at the end and should be ignored. But watch
-                            // out for an escape character at the end of the input. Ignore it
-                            // and any previous insignificant whitespace if it exists.
-                            if (c2 == ESCAPE && j + 1 >= valuesStr.length()) {
-                                continue;
-                            }
-                            if (c2 != DELIMITER) {
-                                buffer.append(valuesStr.substring(i, j));
-                            }
-                            // Let loop counter i catch up with the inner loop but keep in
-                            // mind it will still be incremented at the end of the outer loop.
-                            i = j - 1;
-                            break;
+                    break;
+                default:
+                    // For all other characters, add them to the current token
+                    // unless dealing with unescaped whitespace at the beginning
+                    // or end. We know the whitespace is unescaped because it
+                    // would have been handled in the ESCAPE case otherwise.
+                    if (Character.isWhitespace(c1)) {
+                        // Ignore unescaped whitespace at the beginning of the
+                        // token.
+                        if (buffer.length() == 0) {
+                            continue;
                         }
+                        // If the whitespace is not at the beginning, look
+                        // forward, starting with the next character, to see if
+                        // it's in the middle or at the end. Unescaped
+                        // whitespace in the middle is okay.
+                        for (int j = i + 1; j < valuesStr.length(); j++) {
+                            // Keep looping until the end of the string is
+                            // reached or a non-whitespace character other than
+                            // the escape is seen.
+                            char c2 = valuesStr.charAt(j);
+                            if (!Character.isWhitespace(c2)) {
+                                // If the current character is not the DELIMITER, all whitespace
+                                // characters are significant and should be added to the token.
+                                // Otherwise, they're at the end and should be ignored. But watch
+                                // out for an escape character at the end of the input. Ignore it
+                                // and any previous insignificant whitespace if it exists.
+                                if (c2 == ESCAPE && j + 1 >= valuesStr.length()) {
+                                    continue;
+                                }
+                                if (c2 != DELIMITER) {
+                                    buffer.append(valuesStr.substring(i, j));
+                                }
+                                // Let loop counter i catch up with the inner loop but keep in
+                                // mind it will still be incremented at the end of the outer loop.
+                                i = j - 1;
+                                break;
+                            }
+                        }
+                    } else {
+                        // For non-whitespace characters.
+                        buffer.append(c1);
                     }
-                } else {
-                    // For non-whitespace characters.
-                    buffer.append(c1);
-                }
             }
         }
         // Don't forget to add the last token.
@@ -140,7 +140,7 @@ public class ValueTokenizer {
     /**
      * Return values as Vector.
      *
-     * @return
+     * @return test
      */
     public Collection<String> getValues() {
         return Collections.unmodifiableList(values);
@@ -149,7 +149,7 @@ public class ValueTokenizer {
     /**
      * Return values as String[] or null.
      *
-     * @return
+     * @return test
      */
     public String[] getValuesAsArray() {
         if (values.isEmpty()) {
@@ -162,7 +162,7 @@ public class ValueTokenizer {
     /**
      * Return values as String
      *
-     * @return
+     * @return test
      */
     public String getValuesAsString() {
         if (values.isEmpty()) {
@@ -185,7 +185,7 @@ public class ValueTokenizer {
      * Validate Tad
      *
      * @param ad
-     * @return
+     * @return test
      */
     public String validate(KapuaTad ad) {
         // An empty list means the original value was null. Null is never valid.
@@ -217,92 +217,92 @@ public class ValueTokenizer {
                 Object maxVal = null;
                 TscalarImpl adScalarType = TscalarImpl.fromValue(ad.getType().value());
                 switch (adScalarType) {
-                case PASSWORD:
-                case STRING:
-                    minVal = ad.getMin() == null ? null : Integer.valueOf(ad.getMin());
-                    maxVal = ad.getMax() == null ? null : Integer.valueOf(ad.getMax());
-                    if (minVal != null && s.length() < (Integer) maxVal) {
-                        rangeError = true;
-                    } else if (maxVal != null && s.length() > (Integer) maxVal) {
-                        rangeError = true;
-                    }
-                    break;
-                case INTEGER:
-                    minVal = ad.getMin() == null ? null : Integer.valueOf(ad.getMin());
-                    maxVal = ad.getMax() == null ? null : Integer.valueOf(ad.getMax());
-                    Integer intVal = Integer.valueOf(s);
-                    if (minVal != null && intVal.compareTo((Integer) minVal) < 0) {
-                        rangeError = true;
-                    } else if (maxVal != null && intVal.compareTo((Integer) maxVal) > 0) {
-                        rangeError = true;
-                    }
-                    break;
-                case LONG:
-                    minVal = ad.getMin() == null ? null : Long.valueOf(ad.getMin());
-                    maxVal = ad.getMax() == null ? null : Long.valueOf(ad.getMax());
-                    Long longVal = Long.valueOf(s);
-                    if (ad.getMin() != null && longVal.compareTo((Long) minVal) < 0) {
-                        rangeError = true;
-                    } else if (maxVal != null && longVal.compareTo((Long) maxVal) > 0) {
-                        rangeError = true;
-                    }
-                    break;
-                case DOUBLE:
-                    minVal = ad.getMin() == null ? null : Double.valueOf(ad.getMin());
-                    maxVal = ad.getMax() == null ? null : Double.valueOf(ad.getMax());
-                    Double doubleVal = Double.valueOf(s);
-                    if (minVal != null && doubleVal.compareTo((Double) minVal) < 0) {
-                        rangeError = true;
-                    } else if (maxVal != null && doubleVal.compareTo((Double) maxVal) > 0) {
-                        rangeError = true;
-                    }
-                    break;
-                case BOOLEAN:
-                    // Any string can be converted into a boolean via Boolean.valueOf(String).
-                    // Seems unnecessary to impose any further restrictions.
-                    break;
-                case CHAR:
-                    minVal = ad.getMin() == null ? null : ad.getMin().charAt(0);
-                    maxVal = ad.getMax() == null ? null : ad.getMax().charAt(0);
-                    Character charVal = s.charAt(0);
-                    if (minVal != null && charVal.compareTo((Character) minVal) < 0) {
-                        rangeError = true;
-                    } else if (maxVal != null && charVal.compareTo((Character) maxVal) > 0) {
-                        rangeError = true;
-                    }
-                    break;
-                case FLOAT:
-                    minVal = ad.getMin() == null ? null : Float.valueOf(ad.getMin());
-                    maxVal = ad.getMax() == null ? null : Float.valueOf(ad.getMax());
-                    Float floatVal = Float.valueOf(s);
-                    if (minVal != null && floatVal.compareTo((Float) minVal) < 0) {
-                        rangeError = true;
-                    } else if (maxVal != null && floatVal.compareTo((Float) maxVal) > 0) {
-                        rangeError = true;
-                    }
-                    break;
-                case SHORT:
-                    minVal = ad.getMin() == null ? null : Short.valueOf(ad.getMin());
-                    maxVal = ad.getMax() == null ? null : Short.valueOf(ad.getMax());
-                    Short shortVal = Short.valueOf(s);
-                    if (minVal != null && shortVal.compareTo((Short) minVal) < 0) {
-                        rangeError = true;
-                    } else if (maxVal != null && shortVal.compareTo((Short) maxVal) > 0) {
-                        rangeError = true;
-                    }
-                    break;
-                case BYTE:
-                    minVal = ad.getMin() == null ? null : Byte.valueOf(ad.getMin());
-                    maxVal = ad.getMax() == null ? null : Byte.valueOf(ad.getMax());
-                    Byte byteVal = Byte.valueOf(s);
-                    if (minVal != null && byteVal.compareTo((Byte) minVal) < 0) {
-                        rangeError = true;
-                    } else if (maxVal != null && byteVal.compareTo((Byte) maxVal) > 0) {
-                        rangeError = true;
-                    }
-                    break;
-                default:
-                    throw new IllegalStateException();
+                    case PASSWORD:
+                    case STRING:
+                        minVal = ad.getMin() == null ? null : Integer.valueOf(ad.getMin());
+                        maxVal = ad.getMax() == null ? null : Integer.valueOf(ad.getMax());
+                        if (minVal != null && s.length() < (Integer) maxVal) {
+                            rangeError = true;
+                        } else if (maxVal != null && s.length() > (Integer) maxVal) {
+                            rangeError = true;
+                        }
+                        break;
+                    case INTEGER:
+                        minVal = ad.getMin() == null ? null : Integer.valueOf(ad.getMin());
+                        maxVal = ad.getMax() == null ? null : Integer.valueOf(ad.getMax());
+                        Integer intVal = Integer.valueOf(s);
+                        if (minVal != null && intVal.compareTo((Integer) minVal) < 0) {
+                            rangeError = true;
+                        } else if (maxVal != null && intVal.compareTo((Integer) maxVal) > 0) {
+                            rangeError = true;
+                        }
+                        break;
+                    case LONG:
+                        minVal = ad.getMin() == null ? null : Long.valueOf(ad.getMin());
+                        maxVal = ad.getMax() == null ? null : Long.valueOf(ad.getMax());
+                        Long longVal = Long.valueOf(s);
+                        if (ad.getMin() != null && longVal.compareTo((Long) minVal) < 0) {
+                            rangeError = true;
+                        } else if (maxVal != null && longVal.compareTo((Long) maxVal) > 0) {
+                            rangeError = true;
+                        }
+                        break;
+                    case DOUBLE:
+                        minVal = ad.getMin() == null ? null : Double.valueOf(ad.getMin());
+                        maxVal = ad.getMax() == null ? null : Double.valueOf(ad.getMax());
+                        Double doubleVal = Double.valueOf(s);
+                        if (minVal != null && doubleVal.compareTo((Double) minVal) < 0) {
+                            rangeError = true;
+                        } else if (maxVal != null && doubleVal.compareTo((Double) maxVal) > 0) {
+                            rangeError = true;
+                        }
+                        break;
+                    case BOOLEAN:
+                        // Any string can be converted into a boolean via Boolean.valueOf(String).
+                        // Seems unnecessary to impose any further restrictions.
+                        break;
+                    case CHAR:
+                        minVal = ad.getMin() == null ? null : ad.getMin().charAt(0);
+                        maxVal = ad.getMax() == null ? null : ad.getMax().charAt(0);
+                        Character charVal = s.charAt(0);
+                        if (minVal != null && charVal.compareTo((Character) minVal) < 0) {
+                            rangeError = true;
+                        } else if (maxVal != null && charVal.compareTo((Character) maxVal) > 0) {
+                            rangeError = true;
+                        }
+                        break;
+                    case FLOAT:
+                        minVal = ad.getMin() == null ? null : Float.valueOf(ad.getMin());
+                        maxVal = ad.getMax() == null ? null : Float.valueOf(ad.getMax());
+                        Float floatVal = Float.valueOf(s);
+                        if (minVal != null && floatVal.compareTo((Float) minVal) < 0) {
+                            rangeError = true;
+                        } else if (maxVal != null && floatVal.compareTo((Float) maxVal) > 0) {
+                            rangeError = true;
+                        }
+                        break;
+                    case SHORT:
+                        minVal = ad.getMin() == null ? null : Short.valueOf(ad.getMin());
+                        maxVal = ad.getMax() == null ? null : Short.valueOf(ad.getMax());
+                        Short shortVal = Short.valueOf(s);
+                        if (minVal != null && shortVal.compareTo((Short) minVal) < 0) {
+                            rangeError = true;
+                        } else if (maxVal != null && shortVal.compareTo((Short) maxVal) > 0) {
+                            rangeError = true;
+                        }
+                        break;
+                    case BYTE:
+                        minVal = ad.getMin() == null ? null : Byte.valueOf(ad.getMin());
+                        maxVal = ad.getMax() == null ? null : Byte.valueOf(ad.getMax());
+                        Byte byteVal = Byte.valueOf(s);
+                        if (minVal != null && byteVal.compareTo((Byte) minVal) < 0) {
+                            rangeError = true;
+                        } else if (maxVal != null && byteVal.compareTo((Byte) maxVal) > 0) {
+                            rangeError = true;
+                        }
+                        break;
+                    default:
+                        throw new IllegalStateException();
                 }
                 if (rangeError) {
                     return MessageFormat.format(VALUE_OUT_OF_RANGE, s);

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/exception/KapuaConfigurationException.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/exception/KapuaConfigurationException.java
@@ -62,7 +62,7 @@ public class KapuaConfigurationException extends KapuaException {
      * and optional arguments for the associated exception message.
      *
      * @param message
-     * @return
+     * @return test
      */
     public static KapuaConfigurationException internalError(String message) {
         return new KapuaConfigurationException(KapuaConfigurationErrorCodes.INTERNAL_ERROR, null, message);

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/Password.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/Password.java
@@ -33,7 +33,7 @@ public class Password {
     /**
      * Get password
      *
-     * @return
+     * @return test
      */
     public String getPassword() {
         return password;

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TscalarImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TscalarImpl.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration.metatype;
 
+import org.eclipse.kapua.model.config.metatype.KapuaTscalar;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.config.metatype.KapuaTscalar;
 
 /**
  * <p>
@@ -93,7 +93,7 @@ public enum TscalarImpl implements KapuaTscalar {
      * Convert a String value to a {@link TscalarImpl}
      *
      * @param v
-     * @return
+     * @return test
      */
     public static TscalarImpl fromValue(String v) {
         for (TscalarImpl c : TscalarImpl.values()) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventBusManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventBusManager.java
@@ -62,7 +62,7 @@ public class ServiceEventBusManager {
     /**
      * Get the event bus instance
      *
-     * @return
+     * @return test
      * @throws ServiceEventBusException
      */
     public static ServiceEventBus getInstance() throws ServiceEventBusException {

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventMarshaler.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventMarshaler.java
@@ -27,7 +27,7 @@ public interface ServiceEventMarshaler {
     /**
      * Return the encoded content type
      *
-     * @return
+     * @return test
      */
     String getContentType();
 
@@ -35,7 +35,7 @@ public interface ServiceEventMarshaler {
      * Unmarshal the message received from the bus
      *
      * @param message
-     * @return
+     * @return test
      * @throws KapuaException
      */
     ServiceEvent unmarshal(String message) throws KapuaException;

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventScope.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventScope.java
@@ -33,7 +33,7 @@ public class ServiceEventScope {
     /**
      * Append the Kapua event to the current thread context Kapua event stack (setting a new context id in the Kapua event)
      *
-     * @return
+     * @return test
      */
     public static ServiceEvent begin() {
 
@@ -74,7 +74,7 @@ public class ServiceEventScope {
     /**
      * Get the current Kapua event from the thread context Kapua event stack
      *
-     * @return
+     * @return test
      */
     public static ServiceEvent get() {
         Stack<ServiceEvent> tmp = eventContextThdLocal.get();

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceMap.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceMap.java
@@ -79,7 +79,7 @@ public class ServiceMap {
      * Get the address associated to the specific service
      *
      * @param serviceName
-     * @return
+     * @return test
      */
     public static String getAddress(String serviceName) {
         return AVAILABLE_SERVICES.get(serviceName);

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManager.java
@@ -97,7 +97,7 @@ public class EntityManager {
     /**
      * Return the transaction status
      *
-     * @return
+     * @return test
      */
     public boolean isTransactionActive() {
         return (javaxPersitenceEntityManager != null &&
@@ -171,7 +171,7 @@ public class EntityManager {
      *
      * @param clazz
      * @param id
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public <E extends Serializable> E findWithLock(Class<E> clazz, Object id) {
@@ -240,7 +240,7 @@ public class EntityManager {
     /**
      * Return the {@link javax.persistence.criteria.CriteriaBuilder}
      *
-     * @return
+     * @return test
      */
     public CriteriaBuilder getCriteriaBuilder() {
         return javaxPersitenceEntityManager.getCriteriaBuilder();
@@ -250,7 +250,7 @@ public class EntityManager {
      * Return the typed query based on the criteria
      *
      * @param criteriaSelectQuery
-     * @return
+     * @return test
      */
     public <E> TypedQuery<E> createQuery(CriteriaQuery<E> criteriaSelectQuery) {
         return javaxPersitenceEntityManager.createQuery(criteriaSelectQuery);
@@ -261,7 +261,7 @@ public class EntityManager {
      *
      * @param queryName
      * @param clazz
-     * @return
+     * @return test
      */
     public <E> TypedQuery<E> createNamedQuery(String queryName, Class<E> clazz) {
         return javaxPersitenceEntityManager.createNamedQuery(queryName, clazz);
@@ -271,7 +271,7 @@ public class EntityManager {
      * Return native query based on provided sql query
      *
      * @param querySelectUuidShort
-     * @return
+     * @return test
      */
     public <E> Query createNativeQuery(String querySelectUuidShort) {
         return javaxPersitenceEntityManager.createNativeQuery(querySelectUuidShort);

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerCallback.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerCallback.java
@@ -28,11 +28,11 @@ public interface EntityManagerCallback<T> {
      * WARNING!<br>
      * The transactionality (if needed by the code) must be managed internally to this method.<br>
      * The caller method performs only a rollback (if the transaction is active and an error occurred)!<br>
-     * @see EntityManagerSession#doAction(EntityManagerContainer)
      *
      * @param entityManager
-     * @return
+     * @return test
      * @throws KapuaException
+     * @see EntityManagerSession#doAction(EntityManagerContainer)
      */
     T onAction(EntityManager entityManager) throws KapuaException;
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerFactory.java
@@ -24,7 +24,7 @@ public interface EntityManagerFactory {
     /**
      * Creates an instance of {@link EntityManager}
      *
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public EntityManager createEntityManager() throws KapuaException;

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerSession.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerSession.java
@@ -62,7 +62,7 @@ public class EntityManagerSession {
      * This method performs only a rollback (if the transaction is active and an error occurred)!<br>
      *
      * @param resultHandler
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public <T> T doAction(EntityManagerCallback<T> resultHandler) throws KapuaException {
@@ -79,7 +79,7 @@ public class EntityManagerSession {
      * The transactionality is managed by this method so the called entityManagerResultCallback must leave the transaction open<br>
      *
      * @param resultHandler
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public <T> T doTransactedAction(EntityManagerCallback<T> resultHandler) throws KapuaException {
@@ -93,13 +93,13 @@ public class EntityManagerSession {
      * The maximum allowed retry is set by {@link SystemSettingKey#KAPUA_INSERT_MAX_RETRY}.<br>
      * <br>
      * This method allows to set the before and after result handler calls
-     *
+     * <p>
      * WARNING!<br>
      * The transactionality (if needed by the code) must be managed internally to the entityManagerCallback.<br>
      * This method performs only a rollback (if the transaction is active and an error occurred)!<br>
      *
      * @param container
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public <T> T doAction(EntityManagerContainer<T> container) throws KapuaException {
@@ -113,12 +113,12 @@ public class EntityManagerSession {
      * The maximum allowed retry is set by {@link SystemSettingKey#KAPUA_INSERT_MAX_RETRY}.<br>
      * <br>
      * This method allows to set the before and after result handler calls
-     *
+     * <p>
      * WARNING!<br>
      * The transactionality is managed by this method so the called entityManagerResultCallback must leave the transaction open<br>
      *
      * @param container
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public <T> T doTransactedAction(EntityManagerContainer<T> container) throws KapuaException {

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolver.java
@@ -22,7 +22,7 @@ public interface JdbcConnectionUrlResolver {
     /**
      * Return the jdbc connection url
      *
-     * @return
+     * @return test
      */
     String connectionUrl();
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/ResourceSqlScriptExecutor.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/ResourceSqlScriptExecutor.java
@@ -37,7 +37,7 @@ public class ResourceSqlScriptExecutor {
     /**
      * Return the query list string
      *
-     * @return
+     * @return test
      */
     public List<String> getQueries() {
         return Collections.unmodifiableList(queryStrings);
@@ -47,7 +47,7 @@ public class ResourceSqlScriptExecutor {
      * Add a queries to the query string list
      *
      * @param sqlStrings
-     * @return
+     * @return test
      */
     public ResourceSqlScriptExecutor addQueries(List<String> sqlStrings) {
         if (sqlStrings == null) {
@@ -63,7 +63,7 @@ public class ResourceSqlScriptExecutor {
      * Add a query to the query string list
      *
      * @param sqlString single sql script
-     * @return
+     * @return test
      */
     public ResourceSqlScriptExecutor addQuery(String sqlString) {
         if (sqlString == null) {
@@ -79,7 +79,7 @@ public class ResourceSqlScriptExecutor {
      * Execute all the queries using the provided entity manager
      *
      * @param entityManager
-     * @return
+     * @return test
      */
     public int executeUpdate(EntityManager entityManager) {
         int i = 0;
@@ -90,8 +90,8 @@ public class ResourceSqlScriptExecutor {
             StringBuilder sqlStringBuilder = new StringBuilder();
             try {
                 try (
-                    InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(qStr);
-                    BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
+                        InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(qStr);
+                        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
 
                     String sqlLine;
                     while ((sqlLine = bufferedReader.readLine()) != null) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/SimpleSqlScriptExecutor.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/SimpleSqlScriptExecutor.java
@@ -12,16 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.jpa;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.Query;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.persistence.Query;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Sql script executor bean. Used to invoke the execution of sql scripts to update database schema.
@@ -58,7 +57,7 @@ public class SimpleSqlScriptExecutor {
     /**
      * Return the query list string
      *
-     * @return
+     * @return test
      */
     public List<String> getQueries() {
         return Collections.unmodifiableList(queryStrings);
@@ -67,11 +66,9 @@ public class SimpleSqlScriptExecutor {
     /**
      * Creates and configure a {@link SimpleSqlScriptExecutor} adding all the sql scripts matching the filter in the specified path
      *
-     * @param scanPath
-     *            path to be scanned
-     * @param filenameFilter
-     *            name filter matching <b>(must be not null!)</b>
-     * @return
+     * @param scanPath       path to be scanned
+     * @param filenameFilter name filter matching <b>(must be not null!)</b>
+     * @return test
      */
     public SimpleSqlScriptExecutor scanScripts(String scanPath, String filenameFilter) {
 
@@ -83,8 +80,8 @@ public class SimpleSqlScriptExecutor {
             suffix = filenameFilter.substring(pos + 1);
         }
 
-        final String finalPrefix = prefix;
-        final String finalSuffix = suffix;
+        String finalPrefix = prefix;
+        String finalSuffix = suffix;
 
         FilenameFilter sqlfilter = (dir, name) -> {
             if (finalPrefix.isEmpty() && finalSuffix.isEmpty()) {
@@ -102,7 +99,7 @@ public class SimpleSqlScriptExecutor {
             return true;
         };
 
-        String[] dirContents = new String[] {};
+        String[] dirContents = new String[]{};
         File sqlDir = new File(scanPath);
         if (sqlDir.isDirectory()) {
             dirContents = sqlDir.list(sqlfilter);
@@ -141,9 +138,8 @@ public class SimpleSqlScriptExecutor {
     /**
      * Creates and configure a {@link SimpleSqlScriptExecutor} adding the SQL script from the resources that matches the supplied name
      *
-     * @param resourceName
-     *            the name of the requested resource file
-     * @return
+     * @param resourceName the name of the requested resource file
+     * @return test
      */
     public SimpleSqlScriptExecutor scanResources(String resourceName) {
 
@@ -156,7 +152,7 @@ public class SimpleSqlScriptExecutor {
      * Creates and configure a {@link SimpleSqlScriptExecutor} adding all the sql scripts matching the filter in the default path {@link SimpleSqlScriptExecutor#DEFAULT_SCRIPTS_PATH}
      *
      * @param filenameFilter
-     * @return
+     * @return test
      */
     public SimpleSqlScriptExecutor scanScripts(String filenameFilter) {
         return scanScripts(DEFAULT_SCRIPTS_PATH, filenameFilter);
@@ -166,7 +162,7 @@ public class SimpleSqlScriptExecutor {
      * Add a query to the query string list
      *
      * @param sqlString
-     * @return
+     * @return test
      */
     public SimpleSqlScriptExecutor addQuery(String sqlString) {
         queryStrings.add(sqlString);
@@ -177,7 +173,7 @@ public class SimpleSqlScriptExecutor {
      * Add a queries to the query string list
      *
      * @param sqlStrings
-     * @return
+     * @return test
      */
     public SimpleSqlScriptExecutor addQueries(List<String> sqlStrings) {
         if (sqlStrings == null) {
@@ -193,7 +189,7 @@ public class SimpleSqlScriptExecutor {
      * Execute all the queries using the provided entity manager
      *
      * @param entityManager
-     * @return
+     * @return test
      */
     public int executeUpdate(EntityManager entityManager) {
         int i = 0;

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricServiceFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricServiceFactory.java
@@ -28,7 +28,7 @@ public class MetricServiceFactory {
     /**
      * Get the {@link MetricsService} singleton instance
      *
-     * @return
+     * @return test
      */
     public static MetricsService getInstance() {
         if (instance == null) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsService.java
@@ -12,20 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.metric;
 
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.service.KapuaService;
-
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.KapuaService;
 
 /**
  * Metric service definition
  *
  * @since 1.0
- *
  */
 public interface MetricsService extends KapuaService {
 
@@ -35,7 +33,7 @@ public interface MetricsService extends KapuaService {
      * @param module
      * @param component
      * @param names
-     * @return
+     * @return test
      */
     public Counter getCounter(String module, String component, String... names);
 
@@ -45,7 +43,7 @@ public interface MetricsService extends KapuaService {
      * @param module
      * @param component
      * @param names
-     * @return
+     * @return test
      */
     public Histogram getHistogram(String module, String component, String... names);
 
@@ -55,7 +53,7 @@ public interface MetricsService extends KapuaService {
      * @param module
      * @param component
      * @param names
-     * @return
+     * @return test
      */
     public Timer getTimer(String module, String component, String... names);
 
@@ -65,8 +63,7 @@ public interface MetricsService extends KapuaService {
      * @param module
      * @param component
      * @param names
-     * @throws KapuaException
-     *             if the metric is already defined
+     * @throws KapuaException if the metric is already defined
      */
     public void registerGauge(Gauge<?> gauge, String module, String component, String... names) throws KapuaException;
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
@@ -63,7 +63,7 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     private void enableJmxSupport() {
-        final Builder builder = JmxReporter.forRegistry(this.metricRegistry);
+        Builder builder = JmxReporter.forRegistry(this.metricRegistry);
         builder.convertDurationsTo(TimeUnit.MILLISECONDS);
         builder.convertRatesTo(TimeUnit.SECONDS);
         builder.inDomain("org.eclipse.kapua");
@@ -129,7 +129,7 @@ public class MetricsServiceImpl implements MetricsService {
      * @param module
      * @param component
      * @param metricsName
-     * @return
+     * @return test
      */
     private String getMetricName(String module, String component, String... metricsName) {
         return MessageFormat.format(METRICS_NAME_FORMAT, module, component, convertToDotNotation(metricsName));
@@ -139,7 +139,7 @@ public class MetricsServiceImpl implements MetricsService {
      * Convert the metric names to a concatenated dot separated string
      *
      * @param metricsName
-     * @return
+     * @return test
      */
     private String convertToDotNotation(String... metricsName) {
         StringBuilder builder = new StringBuilder();

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/IdGenerator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/IdGenerator.java
@@ -36,7 +36,7 @@ public class IdGenerator {
      * Generate a {@link BigInteger} random value.<br>
      * For more detail refer to: {@link SystemSettingKey#KAPUA_KEY_SIZE}
      *
-     * @return
+     * @return test
      */
     public static BigInteger generate() {
         return new BigInteger(ID_SIZE, RANDOM);

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/FieldSortCriteriaImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/FieldSortCriteriaImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.model.query.SortOrder;
  * Field sort criteria.
  *
  * @since 1.0
- *
  */
 public class FieldSortCriteriaImpl implements FieldSortCriteria {
 
@@ -47,7 +46,7 @@ public class FieldSortCriteriaImpl implements FieldSortCriteria {
     /**
      * Get the sort attribute name
      *
-     * @return
+     * @return test
      */
     @Override
     public String getAttributeName() {
@@ -57,7 +56,7 @@ public class FieldSortCriteriaImpl implements FieldSortCriteria {
     /**
      * Get the sort attribute order
      *
-     * @return
+     * @return test
      */
     @Override
     public SortOrder getSortOrder() {

--- a/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSession.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSession.java
@@ -90,7 +90,7 @@ public class KapuaSession implements Serializable {
     /**
      * Creates a {@link KapuaSession} copy with trusted mode flag set to true (to be used only from trusted classes)
      *
-     * @return
+     * @return test
      */
     public static KapuaSession createFrom() {
         if (isCallerClassTrusted()) {
@@ -109,7 +109,7 @@ public class KapuaSession implements Serializable {
     /**
      * Creates a new {@link KapuaSession} with trusted mode flag set to true (to be used only from trusted classes)
      *
-     * @return
+     * @return test
      */
     public static KapuaSession createFrom(KapuaId scopeId, KapuaId userId) {
         if (isCallerClassTrusted()) {
@@ -125,7 +125,7 @@ public class KapuaSession implements Serializable {
     /**
      * Check if the caller is included in the caller list allowed to change the trusted mode flag.
      *
-     * @return
+     * @return test
      */
     private static boolean isCallerClassTrusted() {
         // the stack trace should be like
@@ -149,8 +149,8 @@ public class KapuaSession implements Serializable {
      * @param userId
      */
     public KapuaSession(AccessToken accessToken,
-            KapuaId scopeId,
-            KapuaId userId) {
+                        KapuaId scopeId,
+                        KapuaId userId) {
         this();
         this.accessToken = accessToken;
         this.scopeId = scopeId;
@@ -186,7 +186,7 @@ public class KapuaSession implements Serializable {
     /**
      * Get the access token
      *
-     * @return
+     * @return test
      */
     public AccessToken getAccessToken() {
         return accessToken;
@@ -195,7 +195,7 @@ public class KapuaSession implements Serializable {
     /**
      * Get the scope identifier
      *
-     * @return
+     * @return test
      */
     public KapuaId getScopeId() {
         return scopeId;
@@ -204,7 +204,7 @@ public class KapuaSession implements Serializable {
     /**
      * Get the user identifier
      *
-     * @return
+     * @return test
      */
     public KapuaId getUserId() {
         return userId;
@@ -213,7 +213,7 @@ public class KapuaSession implements Serializable {
     /**
      * Get the OpenID Connect idToken
      *
-     * @return
+     * @return test
      */
     public String getOpenIDidToken() {
         return openIDidToken;
@@ -231,7 +231,7 @@ public class KapuaSession implements Serializable {
      * Return the trusted mode status.<br>
      * If true every rights check will be skipped, in other word <b>the user is trusted so he is allowed to execute every operation</b> defined in the system.
      *
-     * @return
+     * @return test
      */
     public final boolean isTrustedMode() {
         return trustedMode;

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreService.java
@@ -32,7 +32,7 @@ public interface EventStoreService extends KapuaEntityService<EventStoreRecord, 
      * Finds the kapuaEvent by kapuaEvent identifiers
      *
      * @param id
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public EventStoreRecord find(KapuaId id)

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreXmlRegistry.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreXmlRegistry.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.service.event.store.api;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class EventStoreXmlRegistry {
@@ -26,7 +26,7 @@ public class EventStoreXmlRegistry {
     /**
      * Creates a new kapuaEvent instance
      *
-     * @return
+     * @return test
      */
     public EventStoreRecord newEventStoreRecord() {
         return kapuaEventFactory.newEntity(null);
@@ -35,7 +35,7 @@ public class EventStoreXmlRegistry {
     /**
      * Creates a new kapuaEvent creator instance
      *
-     * @return
+     * @return test
      */
     public EventStoreRecordCreator newEventStoreRecordCreator() {
         return kapuaEventFactory.newCreator(null);
@@ -44,7 +44,7 @@ public class EventStoreXmlRegistry {
     /**
      * Creates a new kapuaEvent list result instance
      *
-     * @return
+     * @return test
      */
     public EventStoreRecordListResult newEventStoreRecordListResult() {
         return kapuaEventFactory.newListResult();

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/ServiceEventUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/ServiceEventUtil.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.commons.service.event.store.internal.EventStoreRecordIm
  * Utility to convert event from/to entity event
  *
  * @since 1.0
- *
  */
 public class ServiceEventUtil {
 
@@ -31,7 +30,7 @@ public class ServiceEventUtil {
      * Convert the service event entity to the service bus object
      *
      * @param serviceEventEntity
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      */
     public static org.eclipse.kapua.event.ServiceEvent toServiceEventBus(EventStoreRecord serviceEventEntity) throws KapuaIllegalArgumentException {
@@ -60,9 +59,8 @@ public class ServiceEventUtil {
      * {@link #mergeToEntity(EventStoreRecord, org.eclipse.kapua.event.ServiceEvent)} method)
      *
      * @param serviceEventBus
-     * @return
-     * @throws KapuaIllegalArgumentException
-     *             if the service event bus id is not null
+     * @return test
+     * @throws KapuaIllegalArgumentException if the service event bus id is not null
      */
     public static EventStoreRecord fromServiceEventBus(org.eclipse.kapua.event.ServiceEvent serviceEventBus) throws KapuaIllegalArgumentException {
         if (serviceEventBus.getId() != null) {
@@ -72,12 +70,10 @@ public class ServiceEventUtil {
     }
 
     /**
-     *
      * @param serviceEventEntity
      * @param serviceEventBus
-     * @return
-     * @throws KapuaIllegalArgumentException
-     *             if the service event bus id is null or differs to the service event entity
+     * @return test
+     * @throws KapuaIllegalArgumentException if the service event bus id is null or differs to the service event entity
      */
     public static EventStoreRecord mergeToEntity(EventStoreRecord serviceEventEntity, org.eclipse.kapua.event.ServiceEvent serviceEventBus) throws KapuaIllegalArgumentException {
         if (serviceEventEntity.getId() == null) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreDAO.java
@@ -31,7 +31,7 @@ public class EventStoreDAO {
      *
      * @param em
      * @param kapuaEvent
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static EventStoreRecord create(EntityManager em, EventStoreRecord kapuaEvent)
@@ -44,7 +44,7 @@ public class EventStoreDAO {
      *
      * @param em
      * @param kapuaEvent
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static EventStoreRecord update(EntityManager em, EventStoreRecord kapuaEvent)
@@ -61,7 +61,7 @@ public class EventStoreDAO {
      * @param em
      * @param scopeId
      * @param eventId
-     * @return
+     * @return test
      */
     public static EventStoreRecord find(EntityManager em, KapuaId scopeId, KapuaId eventId) {
         return ServiceDAO.find(em, EventStoreRecordImpl.class, scopeId, eventId);
@@ -72,7 +72,7 @@ public class EventStoreDAO {
      *
      * @param em
      * @param kapuaEventQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static EventStoreRecordListResult query(EntityManager em, KapuaQuery kapuaEventQuery)
@@ -85,7 +85,7 @@ public class EventStoreDAO {
      *
      * @param em
      * @param kapuaEventQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery kapuaEventQuery)

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreServiceImpl.java
@@ -168,7 +168,7 @@ public class EventStoreServiceImpl extends AbstractKapuaService implements Event
      * Find an {@link EventStoreRecord} without authorization checks.
      *
      * @param kapuaEventId
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -949,7 +949,7 @@ public class ServiceDAO {
      * @param domain
      * @param groupPermissions
      * @param permission
-     * @return
+     * @return test
      * @since 1.0.0
      */
     private static boolean checkGroupPermission(@NonNull Domain domain, @NonNull List<Permission> groupPermissions, @NonNull Permission permission) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -610,7 +610,7 @@ public class ServiceDAO {
      * <li>{@link AttributePredicate}</li>
      * <li>{@link AndPredicate}</li>
      * <li>{@link OrPredicate}</li>
-     * </ol>
+     * </ul>
      * <p>
      * It can be invoked recursively (i.e. to handle {@link AttributePredicate}s of the {@link AndPredicate}.
      *

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractBaseKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractBaseKapuaSetting.java
@@ -12,18 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.setting;
 
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.DataConfiguration;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration.PropertyConverter;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.DataConfiguration;
-import org.apache.commons.configuration.MapConfiguration;
-import org.apache.commons.configuration.PropertyConverter;
 
 /**
  * An abstract base class which does not make any assumptions on where the
@@ -53,7 +52,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
 
     protected final DataConfiguration config;
 
-    public AbstractBaseKapuaSetting(final DataConfiguration dataConfiguration) {
+    public AbstractBaseKapuaSetting(DataConfiguration dataConfiguration) {
         this.config = dataConfiguration;
         systemPropertyHotSwap = config.getBoolean(SystemSettingKey.SETTINGS_HOTSWAP.key(), false);
     }
@@ -63,7 +62,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param cls
      * @param key
-     * @return
+     * @return test
      * @deprecated since 1.0. Use typed get instead.
      */
     @Deprecated
@@ -77,7 +76,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * @param cls
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      * @deprecated since 1.0. Use typed get instead.
      */
     @Deprecated
@@ -90,7 +89,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param cls
      * @param key
-     * @return
+     * @return test
      */
     public <T> List<T> getList(Class<T> cls, K key) {
         return config.getList(cls, key.key());
@@ -102,7 +101,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * @param valueType
      * @param prefixKey
      * @param regex
-     * @return
+     * @return test
      */
     public <V> Map<String, V> getMap(Class<V> valueType, K prefixKey, String regex) {
         Map<String, V> map = new HashMap<>();
@@ -122,7 +121,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param valueType
      * @param prefixKey
-     * @return
+     * @return test
      */
     public <V> Map<String, V> getMap(Class<V> valueType, K prefixKey) {
         Map<String, V> map = new HashMap<>();
@@ -139,7 +138,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * Get an integer property
      *
      * @param key
-     * @return
+     * @return test
      */
     public int getInt(K key) {
         if (systemPropertyHotSwap) {
@@ -156,7 +155,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public int getInt(K key, int defaultValue) {
         if (systemPropertyHotSwap) {
@@ -173,7 +172,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public int getInt(K key, Integer defaultValue) {
         if (systemPropertyHotSwap) {
@@ -189,7 +188,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * Get a boolean property
      *
      * @param key
-     * @return
+     * @return test
      */
     public boolean getBoolean(K key) {
         if (systemPropertyHotSwap) {
@@ -206,7 +205,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public boolean getBoolean(K key, boolean defaultValue) {
         if (systemPropertyHotSwap) {
@@ -223,7 +222,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public boolean getBoolean(K key, Boolean defaultValue) {
         if (systemPropertyHotSwap) {
@@ -239,7 +238,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * Get a String property
      *
      * @param key
-     * @return
+     * @return test
      */
     public String getString(K key) {
         if (systemPropertyHotSwap) {
@@ -256,7 +255,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public String getString(K key, String defaultValue) {
         if (systemPropertyHotSwap) {
@@ -272,7 +271,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * Get a long property
      *
      * @param key
-     * @return
+     * @return test
      */
     public long getLong(K key) {
         if (systemPropertyHotSwap) {
@@ -289,7 +288,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public long getLong(K key, long defaultValue) {
         if (systemPropertyHotSwap) {
@@ -306,7 +305,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public long getLong(K key, Long defaultValue) {
         if (systemPropertyHotSwap) {
@@ -322,7 +321,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * Get a float property
      *
      * @param key
-     * @return
+     * @return test
      */
     public float getFloat(K key) {
         if (systemPropertyHotSwap) {
@@ -339,7 +338,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public float getFloat(K key, float defaultValue) {
         if (systemPropertyHotSwap) {
@@ -356,7 +355,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public float getFloat(K key, Float defaultValue) {
         if (systemPropertyHotSwap) {
@@ -372,7 +371,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * Get a double property
      *
      * @param key
-     * @return
+     * @return test
      */
     public double getDouble(K key) {
         if (systemPropertyHotSwap) {
@@ -389,7 +388,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public double getDouble(K key, double defaultValue) {
         if (systemPropertyHotSwap) {
@@ -406,7 +405,7 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      *
      * @param key
      * @param defaultValue
-     * @return
+     * @return test
      */
     public double getDouble(K key, Double defaultValue) {
         if (systemPropertyHotSwap) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ClassUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ClassUtil.java
@@ -41,7 +41,7 @@ public class ClassUtil {
      *
      * @param clazz
      * @param defaultInstance
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static <T> T newInstance(String clazz, Class<T> defaultInstance) throws KapuaException {
@@ -55,7 +55,7 @@ public class ClassUtil {
      * @param defaultInstance
      * @param parameterTypes  constructor parameters type
      * @param parameters      constructor parameters value
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static <T> T newInstance(String clazz, Class<T> defaultInstance, Class<?>[] parameterTypes, Object[] parameters) throws KapuaException {
@@ -70,10 +70,9 @@ public class ClassUtil {
             } catch (ClassNotFoundException e) {
                 throw new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, e, String.format(CANNOT_LOAD_INSTANCE_ERROR_MSG, clazz, clazzToInstantiate));
             }
-        } else if (defaultInstance!=null) {
+        } else if (defaultInstance != null) {
             logger.info("Initializing instance of. Instantiate default instance {} ...", defaultInstance);
-        }
-        else {
+        } else {
             throw new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, String.format(CANNOT_LOAD_INSTANCE_ERROR_MSG, clazz, clazzToInstantiate));
         }
         if (parameterTypes == null || parameterTypes.length <= 0) {
@@ -89,7 +88,8 @@ public class ClassUtil {
             try {
                 Constructor<T> constructor = clazzToInstantiate.getDeclaredConstructor(parameterTypes);
                 instance = constructor.newInstance(parameters);
-            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException |
+                     InvocationTargetException e) {
                 throw new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, e, String.format(CANNOT_LOAD_INSTANCE_ERROR_MSG, clazz, clazzToInstantiate));
             }
         }

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDateUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDateUtils.java
@@ -18,7 +18,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-//import java.time.format.ResolverStyle;
 import java.util.Date;
 import java.util.Locale;
 
@@ -45,6 +44,7 @@ public final class KapuaDateUtils {
             .ofPattern(ISO_DATE_PATTERN)
             .withLocale(KapuaDateUtils.getLocale())
             .withZone(getTimeZone());
+
     /**
      * Get current date
      *
@@ -66,7 +66,7 @@ public final class KapuaDateUtils {
      * Parse the provided String using the {@link KapuaDateUtils#ISO_DATE_PATTERN default pattern}
      *
      * @param date
-     * @return
+     * @return test
      * @throws ParseException
      */
     public static Date parseDate(String date) throws ParseException {
@@ -81,7 +81,7 @@ public final class KapuaDateUtils {
      * Format the provided Date using the {@link KapuaDateUtils#ISO_DATE_PATTERN default pattern}
      *
      * @param date
-     * @return
+     * @return test
      * @throws ParseException
      */
     public static String formatDate(Date date) throws ParseException {

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/SemanticVersion.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/SemanticVersion.java
@@ -15,7 +15,7 @@ package org.eclipse.kapua.commons.util;
 /**
  * Utility class to handle comparison between component versions.
  *
- * @see <a href="https://semver.org/">Semantic Versioning</a>.
+ * @see <a href="https://semver.org/">Semantic Versioning</a>
  * @since 1.2.0
  */
 public class SemanticVersion {

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/StringUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/StringUtil.java
@@ -12,14 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.metatype.Password;
 import org.eclipse.kapua.commons.configuration.metatype.TscalarImpl;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Utilities to manipulate string
@@ -38,7 +37,7 @@ public class StringUtil {
      * Split the string using the delimiter {@link StringUtil#DELIMITER}
      *
      * @param strValues
-     * @return
+     * @return test
      */
     public static String[] splitValues(String strValues) {
         // List<String> defaultValues = new ArrayList<String>();
@@ -137,10 +136,10 @@ public class StringUtil {
     /**
      * Convert the string to the appropriate Object based on type
      *
-     * @param type              allowed values are {@link TscalarImpl}
-     * @param string            the input value
-     * @return                  the output value
-     * @throws KapuaException   when something goes wrong
+     * @param type   allowed values are {@link TscalarImpl}
+     * @param string the input value
+     * @return the output value
+     * @throws KapuaException when something goes wrong
      */
     public static Object stringToValue(String type, String string) throws KapuaException {
         if (string == null) {
@@ -201,7 +200,7 @@ public class StringUtil {
      * It supports also arrays such as Integer[], Boolean[], ... Password[]). For the arrays the converted String will be a comma separated concatenation.
      *
      * @param value
-     * @return
+     * @return test
      */
     public static String valueToString(Object value) {
         String result = null;
@@ -356,7 +355,7 @@ public class StringUtil {
      * Escaped values are '\' ',' and ' '
      *
      * @param s
-     * @return
+     * @return test
      */
     public static String escapeString(String s) {
         String escaped = s;
@@ -370,7 +369,7 @@ public class StringUtil {
      * Remove the escaped values from the string (remove escape prefix, if present, for ',' ' ' and the spaces at the beginning and the end of the String
      *
      * @param s
-     * @return
+     * @return test
      */
     public static String unescapeString(String s) {
         String value = s;

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/SystemUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/SystemUtils.java
@@ -12,17 +12,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.util;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * System utilities.
  *
  * @since 1.0
- *
  */
 public class SystemUtils {
 
@@ -32,7 +31,7 @@ public class SystemUtils {
     /**
      * Get the broker url. Gets the broker schema, host and port from the {@link SystemSetting}
      *
-     * @return
+     * @return test
      * @throws URISyntaxException
      */
     public static URI getNodeURI()

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/JAXBContextProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/JAXBContextProvider.java
@@ -12,22 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.util.xml;
 
-import javax.xml.bind.JAXBContext;
-
 import org.eclipse.kapua.KapuaException;
+
+import javax.xml.bind.JAXBContext;
 
 /**
  * Jaxb context provider service definition.
  *
  * @since 1.0
- *
  */
 public interface JAXBContextProvider {
 
     /**
      * Get the jaxb context
      *
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public JAXBContext getJAXBContext() throws KapuaException;

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionIdGenerator.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionIdGenerator.java
@@ -31,7 +31,7 @@ public class CollisionIdGenerator {
     /**
      * Generate a {@link BigInteger} fixed value until fixedValueGenerationCount is reached. After that the value will be incremental from the startIncrementalValue<br>
      *
-     * @return
+     * @return test
      */
     public BigInteger generate() {
         if (++extractedValues < fixedValueGenerationCount) {

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/service/GwtAccountService.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/service/GwtAccountService.java
@@ -12,21 +12,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.account.shared.service;
 
-import java.util.List;
-
+import com.extjs.gxt.ui.client.data.ListLoadResult;
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
+import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccountCreator;
+import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccountQuery;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtConfigComponent;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
-import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
-import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccountCreator;
-import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccountQuery;
 
-import com.extjs.gxt.ui.client.data.ListLoadResult;
-import com.extjs.gxt.ui.client.data.PagingLoadConfig;
-import com.extjs.gxt.ui.client.data.PagingLoadResult;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+import java.util.List;
 
 /**
  * The client side stub for the RPC service.
@@ -39,7 +38,7 @@ public interface GwtAccountService extends RemoteService {
      * to seed users into the MQTT broker instance.
      *
      * @param gwtAccountCreator
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     public GwtAccount create(GwtXSRFToken xsfrToken, GwtAccountCreator gwtAccountCreator)
@@ -49,7 +48,7 @@ public interface GwtAccountService extends RemoteService {
      * Returns a GwtAccount by its Id or null if an account with such Id does not exist.
      *
      * @param accountId
-     * @return
+     * @return test
      */
     public GwtAccount find(String accountId)
             throws GwtKapuaException;
@@ -67,7 +66,7 @@ public interface GwtAccountService extends RemoteService {
      * Get account info ad name values pairs
      *
      * @param gwtAccountId
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     public ListLoadResult<GwtGroupedNVPair> getAccountInfo(String gwtScopeId, String gwtAccountId)
@@ -78,7 +77,7 @@ public interface GwtAccountService extends RemoteService {
      *
      * @param xsfrToken
      * @param gwtAccount
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     public GwtAccount updateAccountProperties(GwtXSRFToken xsfrToken, GwtAccount gwtAccount)
@@ -89,7 +88,7 @@ public interface GwtAccountService extends RemoteService {
      *
      * @param xsfrToken
      * @param gwtAccount
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     public GwtAccount update(GwtXSRFToken xsfrToken, GwtAccount gwtAccount)
@@ -107,7 +106,7 @@ public interface GwtAccountService extends RemoteService {
 
     /**
      * Lists GwtAccounts.
-     *
+     * <p>
      * FIXME: Add query predicates, ordering and pagination.
      *
      * @throws GwtKapuaException
@@ -118,11 +117,9 @@ public interface GwtAccountService extends RemoteService {
     /**
      * Lists GwtAccounts child of the given accountId.
      *
-     * @param accountId
-     *            The account id for which to find children
-     * @param includeSelf
-     *            If true the given account is also included in the list, otherwise it's not
-     * @return
+     * @param accountId   The account id for which to find children
+     * @param includeSelf If true the given account is also included in the list, otherwise it's not
+     * @return test
      * @throws GwtKapuaException
      */
     ListLoadResult<GwtAccount> findChildren(String accountId, boolean includeSelf)
@@ -132,7 +129,7 @@ public interface GwtAccountService extends RemoteService {
      * Returns the configuration of an Account as the list of all the configurable components.
      *
      * @param scopeId
-     * @return
+     * @return test
      */
     public List<GwtConfigComponent> findServiceConfigurations(String scopeId)
             throws GwtKapuaException;
@@ -141,9 +138,8 @@ public interface GwtAccountService extends RemoteService {
      * Returns the list of all Account matching the query.
      *
      * @param gwtAccountQuery
-     * @return
+     * @return test
      * @throws GwtKapuaException
-     *
      */
     PagingLoadResult<GwtAccount> query(PagingLoadConfig loadConfig, GwtAccountQuery gwtAccountQuery)
             throws GwtKapuaException;

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/GwtKapuaException.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/GwtKapuaException.java
@@ -73,7 +73,7 @@ public class GwtKapuaException extends Exception {
      *
      * @param cause
      * @param message
-     * @return
+     * @return test
      */
     public static GwtKapuaException internalError(Throwable cause, String message) {
         return new GwtKapuaException(GwtKapuaErrorCode.INTERNAL_ERROR, cause, message);

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/util/KapuaGwtCommonsModelConverter.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/util/KapuaGwtCommonsModelConverter.java
@@ -531,7 +531,7 @@ public class KapuaGwtCommonsModelConverter {
 
 //    /**
 //     * @param client
-//     * @return
+//     * @return test
 //     */
 //    public static GwtDatastoreDevice convertToDatastoreDevice(ClientInfo client) {
 //        return new GwtDatastoreDevice(client.getClientId(), client.getLastMessageOn());
@@ -540,7 +540,7 @@ public class KapuaGwtCommonsModelConverter {
 //    /**
 //     * @param message
 //     * @param headers
-//     * @return
+//     * @return test
 //     */
 //    public static GwtMessage convertToMessage(DatastoreMessage message, List<GwtHeader> headers) {
 //        GwtMessage gwtMessage = new GwtMessage();

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/service/GwtCredentialService.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/service/GwtCredentialService.java
@@ -12,16 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authentication.shared.service;
 
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredential;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialCreator;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialQuery;
-
-import com.extjs.gxt.ui.client.data.PagingLoadConfig;
-import com.extjs.gxt.ui.client.data.PagingLoadResult;
-import com.google.gwt.user.client.rpc.RemoteService;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
 @RemoteServiceRelativePath("credential")
 public interface GwtCredentialService extends RemoteService {
@@ -30,7 +29,7 @@ public interface GwtCredentialService extends RemoteService {
      * Returns the list of all Credentials matching the query.
      *
      * @param gwtCredentialQuery
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     public PagingLoadResult<GwtCredential> query(PagingLoadConfig loadConfig, GwtCredentialQuery gwtCredentialQuery)

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtRoleService.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtRoleService.java
@@ -12,22 +12,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authorization.shared.service;
 
-import com.google.gwt.user.client.rpc.RemoteService;
-import java.util.List;
-import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
-import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
-import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
-
 import com.extjs.gxt.ui.client.data.ListLoadResult;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
+import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
+import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRoleCreator;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRolePermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRolePermissionCreator;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRoleQuery;
+
+import java.util.List;
 
 @RemoteServiceRelativePath("role")
 public interface GwtRoleService extends RemoteService {
@@ -45,9 +45,8 @@ public interface GwtRoleService extends RemoteService {
      * Returns the list of all Roles which belong to an account.
      *
      * @param scopeIdStirng
-     * @return
+     * @return test
      * @throws GwtKapuaException
-     *
      */
     public List<GwtRole> findAll(String scopeIdStirng)
             throws GwtKapuaException;

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/service/GwtDataService.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/service/GwtDataService.java
@@ -12,26 +12,23 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.data.shared.service;
 
-import java.util.Date;
-import java.util.List;
-
+import com.extjs.gxt.ui.client.data.ListLoadResult;
+import com.extjs.gxt.ui.client.data.LoadConfig;
 import com.extjs.gxt.ui.client.data.ModelData;
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.google.gwt.user.client.rpc.RemoteService;
-
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.data.client.GwtTopic;
 import org.eclipse.kapua.app.console.module.data.client.util.GwtMessage;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDataChannelInfoQuery;
-
-import com.extjs.gxt.ui.client.data.ListLoadResult;
-import com.extjs.gxt.ui.client.data.LoadConfig;
-import com.extjs.gxt.ui.client.data.PagingLoadConfig;
-import com.extjs.gxt.ui.client.data.PagingLoadResult;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
-
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreAsset;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreDevice;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtHeader;
+
+import java.util.Date;
+import java.util.List;
 
 @RemoteServiceRelativePath("data")
 public interface GwtDataService extends RemoteService {
@@ -41,7 +38,7 @@ public interface GwtDataService extends RemoteService {
      * be fed into the TreeGrid UI widget, so it contains all the topic children.
      *
      * @param scopeId
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     List<GwtTopic> findTopicsTree(String scopeId) throws GwtKapuaException;
@@ -57,7 +54,7 @@ public interface GwtDataService extends RemoteService {
     /**
      * @param config
      * @param scopeId
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     PagingLoadResult<GwtDatastoreDevice> findDevices(PagingLoadConfig config, String scopeId, String filter) throws GwtKapuaException;
@@ -71,7 +68,7 @@ public interface GwtDataService extends RemoteService {
      * @param config
      * @param scopeId
      * @param topic
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     ListLoadResult<GwtHeader> findHeaders(LoadConfig config, String scopeId, GwtTopic topic) throws GwtKapuaException;
@@ -83,7 +80,7 @@ public interface GwtDataService extends RemoteService {
      * @param config
      * @param scopeId
      * @param topic
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     ListLoadResult<GwtHeader> findNumberHeaders(LoadConfig config, String scopeId, GwtTopic topic) throws GwtKapuaException;
@@ -95,7 +92,7 @@ public interface GwtDataService extends RemoteService {
      * @param config
      * @param scopeId
      * @param device
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     ListLoadResult<GwtHeader> findHeaders(LoadConfig config, String scopeId, GwtDatastoreDevice device) throws GwtKapuaException;

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/KapuaGwtDataModelConverter.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/KapuaGwtDataModelConverter.java
@@ -26,7 +26,8 @@ import java.util.List;
 
 public class KapuaGwtDataModelConverter {
 
-    private KapuaGwtDataModelConverter() { }
+    private KapuaGwtDataModelConverter() {
+    }
 
     public static GwtTopic convertToTopic(ChannelInfo channelInfo) {
         return new GwtTopic(channelInfo.getName(), channelInfo.getName(), channelInfo.getName(), channelInfo.getLastMessageOn());
@@ -45,7 +46,7 @@ public class KapuaGwtDataModelConverter {
 
     /**
      * @param client
-     * @return
+     * @return test
      */
     public static GwtDatastoreDevice convertToDatastoreDevice(ClientInfo client) {
         GwtDatastoreDevice device = new GwtDatastoreDevice(client.getClientId(), client.getLastMessageOn());
@@ -56,7 +57,7 @@ public class KapuaGwtDataModelConverter {
     /**
      * @param message
      * @param headers
-     * @return
+     * @return test
      */
     public static GwtMessage convertToMessage(DatastoreMessage message, List<GwtHeader> headers) {
         GwtMessage gwtMessage = new GwtMessage();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceConnectionService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceConnectionService.java
@@ -32,7 +32,7 @@ public interface GwtDeviceConnectionService extends RemoteService {
      * Returns a GwtDeviceConnection by its Id or null if a device connection with such Id does not exist.
      *
      * @param connectionId
-     * @return
+     * @return test
      */
     public GwtDeviceConnection find(String scopeId, String connectionId)
             throws GwtKapuaException;
@@ -41,7 +41,7 @@ public interface GwtDeviceConnectionService extends RemoteService {
      * Get connection info ad name values pairs
      *
      * @param gwtDeviceConnectionId
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     public ListLoadResult<GwtGroupedNVPair> getConnectionInfo(String scopeIdString, String gwtDeviceConnectionId)
@@ -51,7 +51,7 @@ public interface GwtDeviceConnectionService extends RemoteService {
      * Returns the list of all DeviceConnection matching the query.
      *
      * @param gwtDeviceConnectionQuery
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     PagingLoadResult<GwtDeviceConnection> query(PagingLoadConfig loadConfig, GwtDeviceConnectionQuery gwtDeviceConnectionQuery)

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceManagementOperationService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceManagementOperationService.java
@@ -30,7 +30,7 @@ public interface GwtDeviceManagementOperationService extends RemoteService {
      * Returns the list of all {@link org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation}s matching the query.
      *
      * @param gwtDeviceManagementOperationQuery
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     PagingLoadResult<GwtDeviceManagementOperation> query(PagingLoadConfig loadConfig, GwtDeviceManagementOperationQuery gwtDeviceManagementOperationQuery)

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceService.java
@@ -39,7 +39,7 @@ public interface GwtDeviceService extends RemoteService {
      *
      * @param scopeIdString
      * @param deviceIdString
-     * @return
+     * @return test
      */
     GwtDevice findDevice(String scopeIdString, String deviceIdString)
             throws GwtKapuaException;
@@ -49,7 +49,7 @@ public interface GwtDeviceService extends RemoteService {
      *
      * @param loadConfig
      * @param gwtDeviceQuery
-     * @return
+     * @return test
      */
     PagingLoadResult<GwtDevice> query(PagingLoadConfig loadConfig, GwtDeviceQuery gwtDeviceQuery)
             throws GwtKapuaException;
@@ -58,7 +58,7 @@ public interface GwtDeviceService extends RemoteService {
      * Finds devices in an account with query
      *
      * @param gwtDeviceQuery
-     * @return
+     * @return test
      */
     List<GwtDevice> query(GwtDeviceQuery gwtDeviceQuery)
             throws GwtKapuaException;
@@ -68,7 +68,7 @@ public interface GwtDeviceService extends RemoteService {
      *
      * @param xsrfToken
      * @param gwtDeviceCreator
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     GwtDevice createDevice(GwtXSRFToken xsrfToken, GwtDeviceCreator gwtDeviceCreator)
@@ -78,7 +78,7 @@ public interface GwtDeviceService extends RemoteService {
      * Updates a device entity with the given gwtDevice new values for custom attributes, display name and associated tag
      *
      * @param gwtDevice
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     GwtDevice updateAttributes(GwtXSRFToken xsfrToken, GwtDevice gwtDevice)
@@ -91,7 +91,7 @@ public interface GwtDeviceService extends RemoteService {
      * @param gwtDevice  the device to return the events of
      * @param startDate  the start of the date range in milliseconds since epoch (Date.getTime())
      * @param endDate    the end of the date range in milliseconds since epoch (Date.getTime())
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     PagingLoadResult<GwtDeviceEvent> findDeviceEvents(PagingLoadConfig loadConfig, GwtDevice gwtDevice, Date startDate, Date endDate)

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobExecutionService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobExecutionService.java
@@ -27,7 +27,7 @@ public interface GwtJobExecutionService extends RemoteService {
      *
      * @param scopeId
      * @param jobId
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     PagingLoadResult<GwtJobExecution> findByJobId(PagingLoadConfig loadConfig, String scopeId, String jobId)

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobService.java
@@ -34,7 +34,7 @@ public interface GwtJobService extends RemoteService {
      * Creates a new job under the account specified in the JobCreator.
      *
      * @param gwtJobCreator
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     GwtJob create(GwtXSRFToken xsrfToken, GwtJobCreator gwtJobCreator) throws GwtKapuaException;
@@ -43,7 +43,7 @@ public interface GwtJobService extends RemoteService {
      * Returns a Job by its Id or null if a job with such Id does not exist.
      *
      * @param jobId
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     GwtJob find(String accountId, String jobId) throws GwtKapuaException;
@@ -52,7 +52,7 @@ public interface GwtJobService extends RemoteService {
      * Updates a Job in the database and returns the refreshed/reloaded entity instance.
      *
      * @param gwtJob
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     GwtJob update(GwtXSRFToken xsrfToken, GwtJob gwtJob) throws GwtKapuaException;

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobTargetService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobTargetService.java
@@ -42,7 +42,7 @@ public interface GwtJobTargetService extends RemoteService {
      * @param scopeId
      * @param jobId
      * @param gwtJobTargetCreatorList
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     List<GwtJobTarget> create(GwtXSRFToken xsrfToken, String scopeId, String jobId, List<GwtJobTargetCreator> gwtJobTargetCreatorList)

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/service/GwtUserService.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/service/GwtUserService.java
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.user.shared.service;
 
+import com.extjs.gxt.ui.client.data.ListLoadResult;
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
@@ -20,11 +24,6 @@ import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtAccess
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUserCreator;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUserQuery;
-
-import com.extjs.gxt.ui.client.data.ListLoadResult;
-import com.extjs.gxt.ui.client.data.PagingLoadConfig;
-import com.extjs.gxt.ui.client.data.PagingLoadResult;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
 /**
  * The client side stub for the RPC service.
@@ -36,7 +35,7 @@ public interface GwtUserService extends RemoteService {
      * Creates a new user under the account specified in the UserCreator.
      *
      * @param gwtUserCreator
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     public GwtUser create(GwtXSRFToken xsfrToken, GwtUserCreator gwtUserCreator)
@@ -46,7 +45,7 @@ public interface GwtUserService extends RemoteService {
      * Updates an User in the database and returns the refreshed/reloaded entity instance.
      *
      * @param gwtUser
-     * @return
+     * @return test
      * @throws GwtKapuaException
      */
     public GwtUser update(GwtXSRFToken xsfrToken, GwtUser gwtUser)
@@ -65,9 +64,8 @@ public interface GwtUserService extends RemoteService {
      * Returns an User by its Id or null if an account with such Id does not exist.
      *
      * @param userId
-     * @return
+     * @return test
      * @throws GwtKapuaException
-     *
      */
     public GwtUser find(String accountId, String userId)
             throws GwtKapuaException;
@@ -76,9 +74,8 @@ public interface GwtUserService extends RemoteService {
      * Returns the list of all User which belong to an account.
      *
      * @param scopeIdString
-     * @return
+     * @return test
      * @throws GwtKapuaException
-     *
      */
     public ListLoadResult<GwtUser> findAll(String scopeIdString)
             throws GwtKapuaException;
@@ -87,9 +84,8 @@ public interface GwtUserService extends RemoteService {
      * Returns the list of all User matching the query.
      *
      * @param gwtUserQuery
-     * @return
+     * @return test
      * @throws GwtKapuaException
-     *
      */
     public PagingLoadResult<GwtUser> query(PagingLoadConfig loadConfig, GwtUserQuery gwtUserQuery)
             throws GwtKapuaException;

--- a/consumer/commons/src/main/java/org/eclipse/kapua/consumer/commons/camel/CamelUtil.java
+++ b/consumer/commons/src/main/java/org/eclipse/kapua/consumer/commons/camel/CamelUtil.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.consumer.commons.camel;
 
-import javax.jms.JMSException;
-
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.apache.camel.Message;
@@ -21,6 +19,8 @@ import org.eclipse.kapua.broker.client.message.MessageConstants;
 import org.eclipse.kapua.consumer.commons.listener.CamelConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.jms.JMSException;
 
 /**
  * Camel utility methods
@@ -38,7 +38,7 @@ public class CamelUtil {
      * Extract the topic from the {@link Message} looking for Kapua header property that handles this value and inspecting Camel header properties)
      *
      * @param message
-     * @return
+     * @return test
      * @throws JMSException
      */
     public static String getTopic(org.apache.camel.Message message) throws JMSException {

--- a/consumer/commons/src/main/java/org/eclipse/kapua/consumer/commons/listener/AbstractListener.java
+++ b/consumer/commons/src/main/java/org/eclipse/kapua/consumer/commons/listener/AbstractListener.java
@@ -56,7 +56,7 @@ public abstract class AbstractListener {
      * The prefix is described by a combination of constructor parameters name and metricComponentName depending on which constructor will be used.
      *
      * @param names
-     * @return
+     * @return test
      */
     protected Counter registerCounter(String... names) {
         return METRICS_SERVICE.getCounter(metricComponentName, name, names);
@@ -67,7 +67,7 @@ public abstract class AbstractListener {
      * The prefix is described by a combination of constructor parameters name and metricComponentName depending on which constructor will be used.
      *
      * @param names
-     * @return
+     * @return test
      */
     protected Timer registerTimer(String... names) {
         return METRICS_SERVICE.getTimer(metricComponentName, name, names);

--- a/consumer/commons/src/main/java/org/eclipse/kapua/consumer/commons/message/system/SystemMessageCreator.java
+++ b/consumer/commons/src/main/java/org/eclipse/kapua/consumer/commons/message/system/SystemMessageCreator.java
@@ -36,7 +36,7 @@ public interface SystemMessageCreator {
      *
      * @param systemMessageType
      * @param parameters
-     * @return
+     * @return test
      */
     String createMessage(SystemMessageType systemMessageType, Map<Fields, String> parameters);
 

--- a/consumer/lifecycle/src/main/java/org/eclipse/kapua/consumer/lifecycle/converter/KapuaLifeCycleConverter.java
+++ b/consumer/lifecycle/src/main/java/org/eclipse/kapua/consumer/lifecycle/converter/KapuaLifeCycleConverter.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.consumer.lifecycle.converter;
 
+import com.codahale.metrics.Counter;
 import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
 import org.eclipse.kapua.KapuaException;
@@ -22,8 +23,6 @@ import org.eclipse.kapua.consumer.commons.converter.AbstractKapuaConverter;
 import org.eclipse.kapua.consumer.commons.converter.ConverterMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.codahale.metrics.Counter;
 
 /**
  * Kapua message converter used to convert life cycle messages.
@@ -55,8 +54,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
      * @param exchange
      * @param value
      * @return Message container that contains application message
-     * @throws KapuaException
-     *             if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
+     * @throws KapuaException if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
      */
     @Converter
     public CamelKapuaMessage<?> convertToApps(Exchange exchange, Object value) throws KapuaException {
@@ -70,8 +68,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
      * @param exchange
      * @param value
      * @return Message container that contains birth message
-     * @throws KapuaException
-     *             if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
+     * @throws KapuaException if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
      */
     @Converter
     public CamelKapuaMessage<?> convertToBirth(Exchange exchange, Object value) throws KapuaException {
@@ -85,8 +82,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
      * @param exchange
      * @param value
      * @return Message container that contains disconnect message
-     * @throws KapuaException
-     *             if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
+     * @throws KapuaException if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
      */
     @Converter
     public CamelKapuaMessage<?> convertToDisconnect(Exchange exchange, Object value) throws KapuaException {
@@ -100,8 +96,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
      * @param exchange
      * @param value
      * @return Message container that contains missing message
-     * @throws KapuaException
-     *             if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
+     * @throws KapuaException if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
      */
     @Converter
     public CamelKapuaMessage<?> convertToMissing(Exchange exchange, Object value) throws KapuaException {
@@ -114,7 +109,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
      *
      * @param exchange
      * @param value
-     * @return
+     * @return test
      * @throws KapuaException
      */
     @Converter

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionXmlRegistry.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionXmlRegistry.java
@@ -30,7 +30,7 @@ public class QueuedJobExecutionXmlRegistry {
     /**
      * Creates a new job instance
      *
-     * @return
+     * @return test
      */
     public QueuedJobExecution newQueuedJobExecution() {
         return JOB_TARGET_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class QueuedJobExecutionXmlRegistry {
     /**
      * Creates a new job creator instance
      *
-     * @return
+     * @return test
      */
     public QueuedJobExecutionCreator newQueuedJobExecutionCreator() {
         return JOB_TARGET_FACTORY.newCreator(null);
@@ -48,7 +48,7 @@ public class QueuedJobExecutionXmlRegistry {
     /**
      * Creates a new job list result instance
      *
-     * @return
+     * @return test
      */
     public QueuedJobExecutionListResult newQueuedJobExecutionListResult() {
         return JOB_TARGET_FACTORY.newListResult();

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
@@ -193,7 +193,7 @@ public class JobContextWrapper {
 
     /**
      * @return {@link JobContext#getTransientUserData()}.
-     * @see JobContext#getTransientUserData().
+     * @see JobContext#getTransientUserData()
      * @since 1.0.0
      */
     private Object getTransientUserData() {
@@ -202,7 +202,7 @@ public class JobContextWrapper {
 
     /**
      * @param data {@link JobContext#setTransientUserData(Object)}.
-     * @see JobContext#setTransientUserData(Object).
+     * @see JobContext#setTransientUserData(Object)
      * @since 1.0.0
      */
     private void setTransientUserData(Object data) {

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/setting/JobEngineSetting.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/setting/JobEngineSetting.java
@@ -33,7 +33,7 @@ public class JobEngineSetting extends AbstractKapuaSetting<JobEngineSettingKeys>
     /**
      * Return the job engine setting instance (singleton)
      *
-     * @return
+     * @return test
      */
     public static JobEngineSetting getInstance() {
         return INSTANCE;

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionDAO.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionDAO.java
@@ -38,7 +38,7 @@ public class QueuedJobExecutionDAO {
      *
      * @param em
      * @param queuedJobExecutionCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static QueuedJobExecution create(EntityManager em, QueuedJobExecutionCreator queuedJobExecutionCreator)
@@ -58,7 +58,7 @@ public class QueuedJobExecutionDAO {
      *
      * @param em
      * @param queuedJobExecution
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static QueuedJobExecution update(EntityManager em, QueuedJobExecution queuedJobExecution)
@@ -74,7 +74,7 @@ public class QueuedJobExecutionDAO {
      * @param em
      * @param scopeId
      * @param queuedJobExecutionId
-     * @return
+     * @return test
      */
     public static QueuedJobExecution find(EntityManager em, KapuaId scopeId, KapuaId queuedJobExecutionId) {
         return ServiceDAO.find(em, QueuedJobExecutionImpl.class, scopeId, queuedJobExecutionId);
@@ -85,7 +85,7 @@ public class QueuedJobExecutionDAO {
      *
      * @param em
      * @param queuedJobExecutionKapuaQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static QueuedJobExecutionListResult query(EntityManager em, KapuaQuery queuedJobExecutionKapuaQuery)
@@ -98,7 +98,7 @@ public class QueuedJobExecutionDAO {
      *
      * @param em
      * @param queuedJobExecutionKapuaQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery queuedJobExecutionKapuaQuery)

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaChannel.java
@@ -34,7 +34,7 @@ public interface KapuaChannel extends Channel {
     /**
      * Get the channel destination semantic part
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     List<String> getSemanticParts();
@@ -48,7 +48,7 @@ public interface KapuaChannel extends Channel {
     void setSemanticParts(List<String> semanticParts);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     default String toPathString() {

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
@@ -39,7 +39,7 @@ public interface KapuaPayload extends Payload {
     /**
      * Get the metrics map
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "metrics")
@@ -57,7 +57,7 @@ public interface KapuaPayload extends Payload {
     /**
      * Get the message body
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "body")

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataChannelImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataChannelImpl.java
@@ -27,7 +27,7 @@ public class KapuaDataChannelImpl extends KapuaChannelImpl implements KapuaDataC
     /**
      * Gets the client identifier
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getClientId() {

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
         <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
-        <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.0.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
@@ -471,12 +471,15 @@
                         <configLocation>checkstyle/kapua.xml</configLocation>
                         <suppressionsLocation>checkstyle/kapua.suppressions.xml</suppressionsLocation>
 
+                        <excludes>**/target/**/*, **/.settings/**/*, maven/**/*, .maven/**/*, .idea/**/*, **/node/**/*</excludes>
+                        <includes>**/*.java, **/*.xml</includes>
+
                         <includeResources>false</includeResources>
                         <includeTestResources>false</includeTestResources>
 
-                        <sourceDirectory>${project.basedir}</sourceDirectory>
-                        <includes>**/*.java, **/*.xml</includes>
-                        <excludes>**/target/**/*, **/.settings/**/*, maven/**/*, .maven/**/*, .idea/**/*, **/node/**/*</excludes>
+                        <sourceDirectories>
+                            <directory>${project.basedir}</directory>
+                        </sourceDirectories>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
         <maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
 
-        <checkstyle.version>7.6.1</checkstyle.version>
+        <checkstyle.version>9.3</checkstyle.version>
         <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
         <docker-maven-plugin.version>0.40.2</docker-maven-plugin.version>
         <eclipse-lifecycle-mapping.version>1.0.0</eclipse-lifecycle-mapping.version>

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastoreJunit/MessageStoreServiceSslTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastoreJunit/MessageStoreServiceSslTest.java
@@ -263,7 +263,7 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
      * @param deviceId
      * @param capturedOn
      * @param sentOn
-     * @return
+     * @return test
      */
     private KapuaDataMessage createMessage(String clientId, KapuaId scopeId, KapuaId deviceId, Date receivedOn, Date capturedOn, Date sentOn) {
         KapuaDataMessage message = KAPUA_DATA_MESSAGE_FACTORY.newKapuaDataMessage();
@@ -307,7 +307,7 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
     /**
      * Creates a new query setting the default base parameters (fetch style, sort, limit, offset, ...) for the Message schema
      *
-     * @return
+     * @return test
      */
     private MessageQuery getBaseMessageQuery(KapuaId scopeId, int limit) {
         MessageQuery query = MESSAGE_STORE_FACTORY.newQuery(scopeId);
@@ -369,7 +369,7 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
      * <b>WARNING!!!!!!! Current implementation is not compliance with that since it is a temporary implementation that returns the default kapua-sys account</b>
      *
      * @param scopeId
-     * @return
+     * @return test
      * @throws KapuaException
      */
     private Account getTestAccountCreator(KapuaId scopeId) throws KapuaException {

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/model/ByteArrayParam.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/model/ByteArrayParam.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.core.model;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.kapua.model.xml.BinaryXmlAdapter;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.Base64;
 
 /**
- * This class is used to deserialize a {@link Byte}[] {@link javax.ws.rs.QueryParam} from a {@link Base64} encoded {@link String} to a {@link Byte[]}
+ * This class is used to deserialize a {@link Byte}[] {@link javax.ws.rs.QueryParam} from a {@link Base64} encoded {@link String} to a {@link Byte}[].
  *
  * @since 1.0.0
  */

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Streams.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Streams.java
@@ -13,8 +13,8 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
+import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.service.stream.StreamService;
@@ -77,12 +77,12 @@ public class Streams extends AbstractKapuaResource {
      * @param scopeId
      * @param timeout
      * @param requestMessage
-     * @return
+     * @return test
      * @throws KapuaException
      */
     @POST
     @Path("messages")
-    @Consumes({ MediaType.APPLICATION_XML })
+    @Consumes({MediaType.APPLICATION_XML})
     public Response publish(
             @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("timeout") Long timeout,

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/StreamsJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/StreamsJson.java
@@ -13,10 +13,10 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
-import org.eclipse.kapua.app.api.resources.v1.resources.marker.JsonSerializationFixed;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.app.api.core.model.data.JsonKapuaDataMessage;
+import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.app.api.resources.v1.resources.marker.JsonSerializationFixed;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.message.device.data.KapuaDataMessageFactory;
@@ -86,7 +86,7 @@ public class StreamsJson extends AbstractKapuaResource implements JsonSerializat
      * @param scopeId
      * @param timeout
      * @param jsonKapuaDataMessage
-     * @return
+     * @return test
      * @throws KapuaException
      */
     @POST

--- a/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
+++ b/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
@@ -775,7 +775,7 @@ public class AccountServiceSteps extends TestBase {
      *
      * @param name    account name
      * @param scopeId acount scope id
-     * @return
+     * @return test
      */
     private AccountCreator accountCreatorCreator(String name, BigInteger scopeId, Date expiration) {
 

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEvent.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEvent.java
@@ -120,7 +120,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the event id
      *
-     * @return
+     * @return test
      */
     public String getId() {
         return id;
@@ -138,7 +138,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the context id
      *
-     * @return
+     * @return test
      */
     public String getContextId() {
         return contextId;
@@ -156,7 +156,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the event timestamp (event triggered)
      *
-     * @return
+     * @return test
      */
     public Date getTimestamp() {
         return timestamp;
@@ -174,7 +174,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the user id that fired the event
      *
-     * @return
+     * @return test
      */
     public KapuaId getUserId() {
         return userId;
@@ -192,7 +192,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the service name that fired the event
      *
-     * @return
+     * @return test
      */
     public String getService() {
         return service;
@@ -210,7 +210,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the entity type related to the fired event
      *
-     * @return
+     * @return test
      */
     public String getEntityType() {
         return entityType;
@@ -228,7 +228,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the scope id of the user that fired the event
      *
-     * @return
+     * @return test
      */
     public KapuaId getScopeId() {
         return scopeId;
@@ -246,7 +246,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the entity scope id related to the fired event
      *
-     * @return
+     * @return test
      */
     public KapuaId getEntityScopeId() {
         return entityScopeId;
@@ -264,7 +264,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the entity id related to the fired event
      *
-     * @return
+     * @return test
      */
     public KapuaId getEntityId() {
         return entityId;
@@ -282,7 +282,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the operation that fired the event
      *
-     * @return
+     * @return test
      */
     public String getOperation() {
         return operation;
@@ -300,7 +300,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the inputs
      *
-     * @return
+     * @return test
      */
     public String getInputs() {
         return inputs;
@@ -318,7 +318,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the outputs
      *
-     * @return
+     * @return test
      */
     public String getOutputs() {
         return outputs;
@@ -336,7 +336,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the event status
      *
-     * @return
+     * @return test
      */
     public EventStatus getStatus() {
         return status;
@@ -354,7 +354,7 @@ public class ServiceEvent implements Serializable {
     /**
      * Get the notes
      *
-     * @return
+     * @return test
      */
     public String getNote() {
         return note;

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator;
 
-import java.util.ServiceLoader;
-
 import org.eclipse.kapua.KapuaRuntimeErrorCodes;
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ServiceLoader;
 
 /**
  * Interface to load KapuaService instances in a given environment.<br>
@@ -49,7 +49,7 @@ public abstract class KapuaLocator implements KapuaServiceLoader {
     /**
      * Creates the {@link KapuaLocator} instance,
      *
-     * @return
+     * @return test
      */
     private static KapuaLocator createInstance() {
         try {
@@ -84,7 +84,7 @@ public abstract class KapuaLocator implements KapuaServiceLoader {
     /**
      * Return the {@link KapuaLocator} instance (singleton).
      *
-     * @return
+     * @return test
      */
     public static KapuaLocator getInstance() {
         return instance;
@@ -98,7 +98,7 @@ public abstract class KapuaLocator implements KapuaServiceLoader {
      * Get the locator classname implementation looking at the {@link KapuaLocator#LOCATOR_CLASS_NAME_SYSTEM_PROPERTY} system property or falling back to the
      * {@link KapuaLocator#LOCATOR_CLASS_NAME_ENVIRONMENT_PROPERTY} environment variable.
      *
-     * @return
+     * @return test
      */
     static String locatorClassName() {
         String locatorClass = System.getProperty(LOCATOR_CLASS_NAME_SYSTEM_PROPERTY);

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaMetatypeFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaMetatypeFactory.java
@@ -25,14 +25,14 @@ public interface KapuaMetatypeFactory extends KapuaObjectFactory {
     /**
      * Returns a {@link KapuaTocd} instance
      *
-     * @return
+     * @return test
      */
     KapuaTocd newKapuaTocd();
 
     /**
      * Returns a {@link KapuaTad} instance
      *
-     * @return
+     * @return test
      */
     KapuaTad newKapuaTad();
 
@@ -40,42 +40,42 @@ public interface KapuaMetatypeFactory extends KapuaObjectFactory {
      * Returns a {@link KapuaTscalar} instance
      *
      * @param type
-     * @return
+     * @return test
      */
     KapuaTscalar newKapuaTscalar(String type);
 
     /**
      * Returns a {@link KapuaToption} instance
      *
-     * @return
+     * @return test
      */
     KapuaToption newKapuaToption();
 
     /**
      * Returns a {@link KapuaTicon} instance
      *
-     * @return
+     * @return test
      */
     KapuaTicon newKapuaTicon();
 
     /**
      * Returns a {@link KapuaTmetadata} instance
      *
-     * @return
+     * @return test
      */
     KapuaTmetadata newKapuaTmetadata();
 
     /**
      * Returns a {@link KapuaTdesignate} instance
      *
-     * @return
+     * @return test
      */
     KapuaTdesignate newKapuaTdesignate();
 
     /**
      * Returns a {@link KapuaTobject} instance
      *
-     * @return
+     * @return test
      */
     KapuaTobject newKapuaTobject();
 

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/MetatypeXmlRegistry.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/MetatypeXmlRegistry.java
@@ -35,7 +35,7 @@ public class MetatypeXmlRegistry {
     /**
      * Returns a {@link KapuaTocd} instance
      *
-     * @return
+     * @return test
      */
     public KapuaTocd newKapuaTocd() {
         return factory.newKapuaTocd();
@@ -44,7 +44,7 @@ public class MetatypeXmlRegistry {
     /**
      * Returns a {@link KapuaTad} instance
      *
-     * @return
+     * @return test
      */
     public KapuaTad newKapuaTad() {
         return factory.newKapuaTad();
@@ -53,7 +53,7 @@ public class MetatypeXmlRegistry {
     /**
      * Returns a {@link KapuaTicon} instance
      *
-     * @return
+     * @return test
      */
     public KapuaTicon newKapuaTicon() {
         return factory.newKapuaTicon();
@@ -62,7 +62,7 @@ public class MetatypeXmlRegistry {
     /**
      * Returns a {@link KapuaToption} instance
      *
-     * @return
+     * @return test
      */
     public KapuaToption newKapuaToption() {
         return factory.newKapuaToption();
@@ -71,7 +71,7 @@ public class MetatypeXmlRegistry {
     /**
      * Returns a {@link KapuaTmetadata} instance
      *
-     * @return
+     * @return test
      */
     public KapuaTmetadata newKapuaTmetadata() {
         return factory.newKapuaTmetadata();
@@ -80,7 +80,7 @@ public class MetatypeXmlRegistry {
     /**
      * Returns a {@link KapuaTdesignate} instance
      *
-     * @return
+     * @return test
      */
     public KapuaTdesignate newKapuaTdesignate() {
         return factory.newKapuaTdesignate();
@@ -89,7 +89,7 @@ public class MetatypeXmlRegistry {
     /**
      * Returns a {@link KapuaTobject} instance
      *
-     * @return
+     * @return test
      */
     public KapuaTobject newKapuaTobject() {
         return factory.newKapuaTobject();

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/FieldSortCriteria.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/FieldSortCriteria.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.query;
 
-public interface FieldSortCriteria extends KapuaSortCriteria{
+public interface FieldSortCriteria extends KapuaSortCriteria {
     /**
      * Get the sort attribute name
      *
-     * @return
+     * @return test
      */
     public String getAttributeName();
 
     /**
      * Get the sort attribute order
      *
-     * @return
+     * @return test
      */
     public SortOrder getSortOrder();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
@@ -242,7 +242,7 @@ public interface KapuaQuery {
      *
      * @param attributeName The name of the attribute
      * @param sortOrder     The {@link SortOrder}
-     * @return
+     * @return test
      */
     FieldSortCriteria fieldSortCriteria(String attributeName, SortOrder sortOrder);
 

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceComponentConfiguration.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceComponentConfiguration.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.config;
 
+import org.eclipse.kapua.model.config.metatype.KapuaTocd;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -20,8 +22,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Map;
-
-import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 
 /**
  * Service component configuration entity definition.
@@ -41,7 +41,7 @@ public interface ServiceComponentConfiguration {
     /**
      * Get service configuration component identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "id")
     String getId();
@@ -56,7 +56,7 @@ public interface ServiceComponentConfiguration {
     /**
      * Get service configuration component name
      *
-     * @return
+     * @return test
      */
     @XmlAttribute(name = "name")
     String getName();
@@ -71,7 +71,7 @@ public interface ServiceComponentConfiguration {
     /**
      * Get service configuration component definition
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "definition")
     KapuaTocd getDefinition();
@@ -86,7 +86,7 @@ public interface ServiceComponentConfiguration {
     /**
      * Get service configuration component properties
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "properties")
     @XmlJavaTypeAdapter(ServiceXmlConfigPropertiesAdapter.class)

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfiguration.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfiguration.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.config;
 
+import org.eclipse.kapua.KapuaSerializable;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.List;
-
-import org.eclipse.kapua.KapuaSerializable;
 
 /**
  * Service configuration entity definition.
@@ -34,7 +34,7 @@ public interface ServiceConfiguration extends KapuaSerializable {
     /**
      * Get the service component configuration list
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "configuration")
     List<ServiceComponentConfiguration> getComponentConfigurations();

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfigurationFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfigurationFactory.java
@@ -24,14 +24,14 @@ public interface ServiceConfigurationFactory extends KapuaObjectFactory {
     /**
      * Creates a new {@link ServiceComponentConfiguration} using the given component configuration identifier
      *
-     * @return
+     * @return test
      */
     ServiceComponentConfiguration newComponentConfigurationInstance(String componentConfigurationId);
 
     /**
      * Creates a new {@link ServiceConfiguration}
      *
-     * @return
+     * @return test
      */
     ServiceConfiguration newConfigurationInstance();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfigurationXmlRegistry.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfigurationXmlRegistry.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.config;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 /**
  * {@link ServiceConfiguration} xml factory class
@@ -30,7 +30,7 @@ public class ServiceConfigurationXmlRegistry {
     /**
      * Creates a new service configuration
      *
-     * @return
+     * @return test
      */
     public ServiceConfiguration newConfiguration() {
         return SERVICE_CONFIGURATION_FACTORY.newConfigurationInstance();
@@ -39,7 +39,7 @@ public class ServiceConfigurationXmlRegistry {
     /**
      * Creates a new service component configuration
      *
-     * @return
+     * @return test
      */
     public ServiceComponentConfiguration newComponentConfiguration() {
         return SERVICE_CONFIGURATION_FACTORY.newComponentConfigurationInstance(null);

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapted.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapted.java
@@ -36,7 +36,7 @@ public class ServiceXmlConfigPropertiesAdapted {
     /**
      * Get the adapted properties as array
      *
-     * @return
+     * @return test
      */
     public ServiceXmlConfigPropertyAdapted[] getProperties() {
         return properties;

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertyAdapted.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertyAdapted.java
@@ -31,16 +31,35 @@ public class ServiceXmlConfigPropertyAdapted {
 
     @XmlEnum
     public enum ConfigPropertyType {
-        @XmlEnumValue("String")stringType,
-        @XmlEnumValue("Long")longType,
-        @XmlEnumValue("Double")doubleType,
-        @XmlEnumValue("Float")floatType,
-        @XmlEnumValue("Integer")integerType,
-        @XmlEnumValue("Byte")byteType,
-        @XmlEnumValue("Char")charType,
-        @XmlEnumValue("Boolean")booleanType,
-        @XmlEnumValue("Short")shortType,
-//        @XmlEnumValue("Password")passwordType
+        @XmlEnumValue("String")
+        stringType,
+
+        @XmlEnumValue("Long")
+        longType,
+
+        @XmlEnumValue("Double")
+        doubleType,
+
+        @XmlEnumValue("Float")
+        floatType,
+
+        @XmlEnumValue("Integer")
+        integerType,
+
+        @XmlEnumValue("Byte")
+        byteType,
+
+        @XmlEnumValue("Char")
+        charType,
+
+        @XmlEnumValue("Boolean")
+        booleanType,
+
+        @XmlEnumValue("Short")
+        shortType,
+
+        // @XmlEnumValue("Password")
+        // passwordType
     }
 
     /**

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
@@ -321,8 +321,8 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
         }
 
         //issue #
-        final SSLContext finalSslContext = sslContext;
-        final CredentialsProvider finalCredentialsProvider = credentialsProvider;
+        SSLContext finalSslContext = sslContext;
+        CredentialsProvider finalCredentialsProvider = credentialsProvider;
         restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> customizeHttpClient(httpClientBuilder, finalSslContext, finalCredentialsProvider));
 //        restClientBuilder.setFailureListener(new RestElasticsearchFailureListener());
 
@@ -342,11 +342,11 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
 
     private HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder, SSLContext sslContext, CredentialsProvider credentialsProvider) {
         try {
-            if(sslContext != null) {
+            if (sslContext != null) {
                 httpClientBuilder.setSSLContext(sslContext);
             }
 
-            if(credentialsProvider != null) {
+            if (credentialsProvider != null) {
                 httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
             }
 
@@ -371,8 +371,7 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
             });
 
             httpClientBuilder.setConnectionManager(new PoolingNHttpClientConnectionManager(ioReactor));
-        }
-        catch (IOReactorException e) {
+        } catch (IOReactorException e) {
             throw new RuntimeException(e);
         }
 
@@ -423,7 +422,7 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
     /**
      * Gets the {@link ElasticsearchClientSslConfiguration}.
      * <p>
-     * Shortcut for {@link #getClientConfiguration()#getClientSslConfiguration()}
+     * Shortcut for {@link ElasticsearchClientConfiguration#getSslConfiguration()}.
      *
      * @return The {@link ElasticsearchClientSslConfiguration}
      * @since 1.3.0
@@ -435,7 +434,7 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
     /**
      * Gets the {@link ElasticsearchClientReconnectConfiguration}.
      * <p>
-     * Shortcut for {@link #getClientConfiguration()#getClientReconnectConfiguration()}
+     * Shortcut for {@link ElasticsearchClientConfiguration#getReconnectConfiguration()}.
      *
      * @return The {@link ElasticsearchClientReconnectConfiguration}
      * @since 1.3.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
@@ -66,7 +66,7 @@ public interface ChannelInfo extends Storable {
     /**
      * Get the client identifier
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "clientId")
@@ -84,7 +84,7 @@ public interface ChannelInfo extends Storable {
     /**
      * Get the channel name
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "name")
@@ -101,7 +101,7 @@ public interface ChannelInfo extends Storable {
     /**
      * Get the message identifier (of the first message published on this channel)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageId")
@@ -119,7 +119,7 @@ public interface ChannelInfo extends Storable {
     /**
      * Get the message timestamp (of the first message published on this channel)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageOn")
@@ -137,7 +137,7 @@ public interface ChannelInfo extends Storable {
      * Get the message identifier of the last published message for this channel.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageId")
@@ -157,7 +157,7 @@ public interface ChannelInfo extends Storable {
      * Get the timestamp of the last published message for this channel.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageOn")

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoCreator.java
@@ -27,7 +27,7 @@ public interface ChannelInfoCreator extends StorableCreator<ChannelInfo> {
     /**
      * Get the client identifier
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getClientId();
@@ -41,7 +41,7 @@ public interface ChannelInfoCreator extends StorableCreator<ChannelInfo> {
     /**
      * Get the name
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getName();
@@ -57,7 +57,7 @@ public interface ChannelInfoCreator extends StorableCreator<ChannelInfo> {
     /**
      * Get the message identifier (of the first message published on this channel)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     StorableId getMessageId();
@@ -73,7 +73,7 @@ public interface ChannelInfoCreator extends StorableCreator<ChannelInfo> {
     /**
      * Get the message timestamp (of the first message published on this channel)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     Date getMessageTimestamp();

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
@@ -65,7 +65,7 @@ public interface ClientInfo extends Storable {
     /**
      * Get the client identifier
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "clientId")
@@ -82,7 +82,7 @@ public interface ClientInfo extends Storable {
     /**
      * Get the message identifier (of the first message published by this client)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageId")
@@ -100,7 +100,7 @@ public interface ClientInfo extends Storable {
     /**
      * Get the message timestamp (of the first message published by this client)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageOn")
@@ -119,7 +119,7 @@ public interface ClientInfo extends Storable {
      * Get the message identifier of the last published message for this client.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageId")
@@ -139,7 +139,7 @@ public interface ClientInfo extends Storable {
      * Get the identifier of the last published message for this client.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageOn")

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoCreator.java
@@ -28,15 +28,16 @@ public interface ClientInfoCreator extends StorableCreator<ClientInfo> {
     /**
      * Get the account
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
+    @Override
     KapuaId getScopeId();
 
     /**
      * Get the client identifier
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getClientId();
@@ -52,7 +53,7 @@ public interface ClientInfoCreator extends StorableCreator<ClientInfo> {
     /**
      * Get the message identifier (of the first message published by this client)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     StorableId getMessageId();
@@ -68,7 +69,7 @@ public interface ClientInfoCreator extends StorableCreator<ClientInfo> {
     /**
      * Get the message timestamp (of the first message published by this client)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     Date getMessageTimestamp();

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
@@ -56,7 +56,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get the message identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "id")
     UUID getId();
@@ -71,7 +71,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Stored message identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "datastoreId")
     @XmlJavaTypeAdapter(StorableIdXmlAdapter.class)
@@ -85,7 +85,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Stored message timestamp
      *
-     * @return
+     * @return test
      */
     Date getTimestamp();
 
@@ -97,7 +97,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get client identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "clientId")
     String getClientId();
@@ -112,7 +112,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get device identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "deviceId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -128,7 +128,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get the message received on date
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "receivedOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
@@ -144,7 +144,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get the message sent on date
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "sentOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
@@ -160,7 +160,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get the message captured on date
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "capturedOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
@@ -176,7 +176,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get the device position
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "position")
     KapuaPosition getPosition();
@@ -191,7 +191,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get the message channel
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "channel")
     KapuaDataChannel getChannel();
@@ -206,7 +206,7 @@ public interface DatastoreMessage extends Storable {
     /**
      * Get the message payload
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "payload")
     KapuaPayload getPayload();

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
@@ -69,7 +69,7 @@ public interface MetricInfo extends Storable {
     /**
      * Get the client identifier
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "clientId")
@@ -86,7 +86,7 @@ public interface MetricInfo extends Storable {
     /**
      * Get the channel
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "channel")
@@ -137,7 +137,7 @@ public interface MetricInfo extends Storable {
     /**
      * Get the message identifier (of the first message published that containing this metric)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageId")
@@ -155,7 +155,7 @@ public interface MetricInfo extends Storable {
     /**
      * Get the message timestamp (of the first message published that containing this metric)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageOn")
@@ -174,7 +174,7 @@ public interface MetricInfo extends Storable {
      * Get the message identifier of the last published message for this metric.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageId")
@@ -194,7 +194,7 @@ public interface MetricInfo extends Storable {
      * Get the timestamp of the last published message for this metric.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageOn")

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoCreator.java
@@ -28,15 +28,16 @@ public interface MetricInfoCreator<T> extends StorableCreator<MetricInfo> {
     /**
      * Get the account
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
+    @Override
     KapuaId getScopeId();
 
     /**
      * Get the client identifier
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getClientId();
@@ -52,7 +53,7 @@ public interface MetricInfoCreator<T> extends StorableCreator<MetricInfo> {
     /**
      * Get the channel
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getChannel();
@@ -68,7 +69,7 @@ public interface MetricInfoCreator<T> extends StorableCreator<MetricInfo> {
     /**
      * Get the metric name
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getName();
@@ -84,7 +85,7 @@ public interface MetricInfoCreator<T> extends StorableCreator<MetricInfo> {
     /**
      * Get the metric type
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     Class<T> getMetricType();
@@ -100,7 +101,7 @@ public interface MetricInfoCreator<T> extends StorableCreator<MetricInfo> {
     /**
      * Get the message identifier (of the first message published that containing this metric)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     StorableId getMessageId();
@@ -116,7 +117,7 @@ public interface MetricInfoCreator<T> extends StorableCreator<MetricInfo> {
     /**
      * Get the message timestamp (of the first message published that containing this metric)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     Date getMessageTimestamp();

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ChannelInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ChannelInfoXmlRegistry.java
@@ -33,7 +33,7 @@ public class ChannelInfoXmlRegistry {
     /**
      * Creates a {@link ChannelInfoListResult} instance
      *
-     * @return
+     * @return test
      */
     public ChannelInfoListResult newListResult() {
         return CHANNEL_INFO_FACTORY.newListResult();
@@ -42,7 +42,7 @@ public class ChannelInfoXmlRegistry {
     /**
      * Creates a {@link ChannelInfoQuery} instance.
      *
-     * @return
+     * @return test
      */
     public ChannelInfoQuery newQuery() {
         return CHANNEL_INFO_FACTORY.newQuery(null);

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ClientInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ClientInfoXmlRegistry.java
@@ -33,7 +33,7 @@ public class ClientInfoXmlRegistry {
     /**
      * Creates a {@link ClientInfoListResult} instance
      *
-     * @return
+     * @return test
      */
     public ClientInfoListResult newListResult() {
         return CLIENT_INFO_FACTORY.newListResult();
@@ -42,7 +42,7 @@ public class ClientInfoXmlRegistry {
     /**
      * Creates a {@link ClientInfoQuery} instance.
      *
-     * @return
+     * @return test
      */
     public ClientInfoQuery newQuery() {
         return CLIENT_INFO_FACTORY.newQuery(null);

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/DatastoreMessageXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/DatastoreMessageXmlRegistry.java
@@ -33,7 +33,7 @@ public class DatastoreMessageXmlRegistry {
     /**
      * Creates a {@link MessageListResult} instance
      *
-     * @return
+     * @return test
      */
     public MessageListResult newListResult() {
         return MESSAGE_STORE_FACTORY.newListResult();
@@ -42,7 +42,7 @@ public class DatastoreMessageXmlRegistry {
     /**
      * Creates a {@link MessageQuery} instance.
      *
-     * @return
+     * @return test
      */
     public MessageQuery newQuery() {
         return MESSAGE_STORE_FACTORY.newQuery(null);

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/MetricInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/MetricInfoXmlRegistry.java
@@ -33,7 +33,7 @@ public class MetricInfoXmlRegistry {
     /**
      * Creates a {@link MetricInfoListResult} instance
      *
-     * @return
+     * @return test
      */
     public MetricInfoListResult newListResult() {
         return METRIC_INFO_FACTORY.newListResult();
@@ -42,7 +42,7 @@ public class MetricInfoXmlRegistry {
     /**
      * Creates a {@link MetricInfoQuery} instance.
      *
-     * @return
+     * @return test
      */
     public MetricInfoQuery newQuery() {
         return METRIC_INFO_FACTORY.newQuery(null);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -75,7 +75,7 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
      * Update the channel information after a message store operation
      *
      * @param channelInfo
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -153,7 +153,7 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
      *
      * @param scopeId
      * @param id
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -177,7 +177,7 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
      * Find channels informations matching the given query
      *
      * @param query
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -202,7 +202,7 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
      * Get channels informations count matching the given query
      *
      * @param query
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
@@ -75,7 +75,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
      * Update the client information after a message store operation
      *
      * @param clientInfo
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -148,7 +148,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
      *
      * @param scopeId
      * @param id
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -172,7 +172,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
      * Find clients informations matching the given query
      *
      * @param query
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -197,7 +197,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
      * Get clients informations count matching the given query
      *
      * @param query
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProvider.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProvider.java
@@ -29,7 +29,7 @@ public interface ConfigurationProvider {
      * Get the configuration for the given scope
      *
      * @param scopeId
-     * @return
+     * @return test
      * @throws ConfigurationException
      */
     MessageStoreConfiguration getConfiguration(KapuaId scopeId) throws ConfigurationException;
@@ -38,7 +38,7 @@ public interface ConfigurationProvider {
      * Get the message information for the given scope
      *
      * @param scopeId
-     * @return
+     * @return test
      * @throws ConfigurationException
      */
     MessageInfo getInfo(KapuaId scopeId) throws ConfigurationException;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreCacheManager.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreCacheManager.java
@@ -49,7 +49,7 @@ public class DatastoreCacheManager {
     /**
      * Get the cache manager instance
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public static DatastoreCacheManager getInstance() {
@@ -59,7 +59,7 @@ public class DatastoreCacheManager {
     /**
      * Get the channels informations cache
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public LocalCache<String, Boolean> getChannelsCache() {
@@ -69,7 +69,7 @@ public class DatastoreCacheManager {
     /**
      * Get the metrics informations cache
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public LocalCache<String, Boolean> getMetricsCache() {
@@ -79,7 +79,7 @@ public class DatastoreCacheManager {
     /**
      * Get the clients informations cache
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public LocalCache<String, Boolean> getClientsCache() {
@@ -89,7 +89,7 @@ public class DatastoreCacheManager {
     /**
      * Get the metadata informations cache
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public LocalCache<String, Metadata> getMetadataCache() {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -114,7 +114,7 @@ public final class MessageStoreFacade extends AbstractRegistryFacade {
      * Store a message
      *
      * @param message
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -244,7 +244,7 @@ public final class MessageStoreFacade extends AbstractRegistryFacade {
      * @param scopeId
      * @param id
      * @param fetchStyle
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws QueryMappingException
      * @throws ClientException
@@ -272,7 +272,7 @@ public final class MessageStoreFacade extends AbstractRegistryFacade {
      * Find messages matching the given query
      *
      * @param query
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws QueryMappingException
@@ -301,7 +301,7 @@ public final class MessageStoreFacade extends AbstractRegistryFacade {
      * Get messages count matching the given query
      *
      * @param query
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -487,7 +487,7 @@ public final class MessageStoreFacade extends AbstractRegistryFacade {
      * In the MQTT word this method return true if the topic starts with 'account/+/'.
      *
      * @param clientId
-     * @return
+     * @return test
      * @since 1.0.0
      */
     private boolean isAnyClientId(String clientId) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
@@ -77,7 +77,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
      * Update the metric information after a message store operation (for a single metric)
      *
      * @param metricInfo
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -116,7 +116,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
      * Update the metrics informations after a message store operation (for few metrics)
      *
      * @param metricInfos
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -217,7 +217,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
      *
      * @param scopeId
      * @param id
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -241,7 +241,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
      * Find metrics informations matching the given query
      *
      * @param query
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException
@@ -266,7 +266,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
      * Get metrics informations count matching the given query
      *
      * @param query
-     * @return
+     * @return test
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      * @throws ClientException

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoField.java
@@ -79,7 +79,7 @@ public enum ChannelInfoField implements StorableField {
      * @param scopeId
      * @param clientId
      * @param channel
-     * @return
+     * @return test
      */
     private static String getOrDeriveId(StorableId id, KapuaId scopeId, String clientId, String channel) {
         if (id == null) {
@@ -94,7 +94,7 @@ public enum ChannelInfoField implements StorableField {
      *
      * @param id
      * @param channelInfoCreator
-     * @return
+     * @return test
      */
     public static String getOrDeriveId(StorableId id, ChannelInfoCreator channelInfoCreator) {
         return getOrDeriveId(id,
@@ -108,7 +108,7 @@ public enum ChannelInfoField implements StorableField {
      *
      * @param id
      * @param channelInfo
-     * @return
+     * @return test
      */
     public static String getOrDeriveId(StorableId id, ChannelInfo channelInfo) {
         return getOrDeriveId(id,

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoRegistryMediator.java
@@ -32,7 +32,7 @@ public interface ChannelInfoRegistryMediator {
      *
      * @param scopeId
      * @param indexedOn
-     * @return
+     * @return test
      * @throws ClientException
      */
     Metadata getMetadata(KapuaId scopeId, long indexedOn)

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoField.java
@@ -71,7 +71,7 @@ public enum ClientInfoField implements StorableField {
      * @param id
      * @param scopeId
      * @param clientId
-     * @return
+     * @return test
      */
     public static String getOrDeriveId(StorableId id, KapuaId scopeId, String clientId) {
         if (id == null) {
@@ -87,7 +87,7 @@ public enum ClientInfoField implements StorableField {
      *
      * @param id
      * @param clientInfo
-     * @return
+     * @return test
      */
     public static String getOrDeriveId(StorableId id, ClientInfo clientInfo) {
         return getOrDeriveId(id, clientInfo.getScopeId(), clientInfo.getClientId());

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoRegistryMediator.java
@@ -31,7 +31,7 @@ public interface ClientInfoRegistryMediator {
      *
      * @param scopeId
      * @param indexedOn
-     * @return
+     * @return test
      * @throws ClientException
      */
     Metadata getMetadata(KapuaId scopeId, long indexedOn) throws ClientException, MappingException;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreChannel.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreChannel.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.mediator;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Models a topic for messages posted to the Kapua platform.<br>
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
  */
 public class DatastoreChannel {
 
-    @SuppressWarnings("unused")
     private static final Logger logger = LoggerFactory.getLogger(DatastoreChannel.class);
 
     /**
@@ -81,7 +80,7 @@ public class DatastoreChannel {
     /**
      * Return the channel without the multi level wildcard, if any.
      *
-     * @return
+     * @return test
      */
     public String getChannelCleaned() {
         if (isAnyChannel()) {
@@ -97,7 +96,7 @@ public class DatastoreChannel {
      * Check if the channel is an alert channel, so if it has 'ALERT' as third level topic (and no more topics level).<br>
      * In the MQTT word this method return true if the topic is like 'account/client/ALERT'.
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public boolean isAlertTopic() {
@@ -107,7 +106,7 @@ public class DatastoreChannel {
     /**
      * Return true if the channel is single path channel and the last channel part is the {@link DatastoreChannel#MULTI_LEVEL_WCARD} char.
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public boolean isAnyChannel() {
@@ -118,7 +117,7 @@ public class DatastoreChannel {
      * Return true if the channel is multi path channel and the last channel part is the {@link DatastoreChannel#MULTI_LEVEL_WCARD} char.<br>
      * <b>This method returns false if the channel is {@link DatastoreChannel#MULTI_LEVEL_WCARD}.</b>
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public boolean isWildcardChannel() {
@@ -129,17 +128,17 @@ public class DatastoreChannel {
      * Get the channel formatted string given the topic parts
      *
      * @param parts
-     * @return
+     * @return test
      * @since 1.0.0
      */
-    public static String getChannel(final List<String> parts) {
+    public static String getChannel(List<String> parts) {
         return String.join(DatastoreChannel.TOPIC_SEPARATOR, parts);
     }
 
     /**
      * Get the channel
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getChannel() {
@@ -149,7 +148,7 @@ public class DatastoreChannel {
     /**
      * Get the last topic part (leaf)
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getLeafName() {
@@ -159,7 +158,7 @@ public class DatastoreChannel {
     /**
      * Get the parent topic
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getParentTopic() {
@@ -170,7 +169,7 @@ public class DatastoreChannel {
     /**
      * Get the grand parent topic
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getGrandParentTopic() {
@@ -186,7 +185,7 @@ public class DatastoreChannel {
     /**
      * Get the channel parts
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String[] getParts() {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -52,7 +52,7 @@ public class DatastoreUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatastoreUtils.class);
 
-    private enum IndexType { CHANNEL, CLIENT, METRIC }
+    private enum IndexType {CHANNEL, CLIENT, METRIC}
 
     private DatastoreUtils() {
     }
@@ -124,7 +124,7 @@ public class DatastoreUtils {
      * Return the hash code for the provided components (typically components are a sequence of account - client id - channel ...)
      *
      * @param components
-     * @return
+     * @return test
      */
     public static String getHashCode(String... components) {
         String concatString = "";
@@ -190,7 +190,7 @@ public class DatastoreUtils {
      * Return the metric parts for the composed metric name (split the metric name by '.')
      *
      * @param fullName
-     * @return
+     * @return test
      */
     public static String[] getMetricParts(String fullName) {
         return fullName == null ? null : fullName.split(Pattern.quote("."));
@@ -247,11 +247,11 @@ public class DatastoreUtils {
      * Normalize the account index name and and the suffix '-*'
      *
      * @param scopeId
-     * @return
+     * @return test
      */
     public static String getDataIndexName(KapuaId scopeId) {
-        final StringBuilder sb = new StringBuilder();
-        final String prefix = DatastoreSettings.getInstance().getString(DatastoreSettingsKey.INDEX_PREFIX);
+        StringBuilder sb = new StringBuilder();
+        String prefix = DatastoreSettings.getInstance().getString(DatastoreSettingsKey.INDEX_PREFIX);
         if (StringUtils.isNotEmpty(prefix)) {
             sb.append(prefix).append("-");
         }
@@ -265,15 +265,15 @@ public class DatastoreUtils {
      *
      * @param scopeId
      * @param timestamp
-     * @return
+     * @return test
      */
     public static String getDataIndexName(KapuaId scopeId, long timestamp, String indexingWindowOption) throws KapuaException {
-        final StringBuilder sb = new StringBuilder();
-        final String prefix = DatastoreSettings.getInstance().getString(DatastoreSettingsKey.INDEX_PREFIX);
+        StringBuilder sb = new StringBuilder();
+        String prefix = DatastoreSettings.getInstance().getString(DatastoreSettingsKey.INDEX_PREFIX);
         if (StringUtils.isNotEmpty(prefix)) {
             sb.append(prefix).append("-");
         }
-        final String actualName = DatastoreUtils.normalizedIndexName(scopeId.toStringId());
+        String actualName = DatastoreUtils.normalizedIndexName(scopeId.toStringId());
         sb.append(actualName).append('-').append("data-message").append('-');
         DateTimeFormatter formatter;
         switch (indexingWindowOption) {
@@ -312,8 +312,8 @@ public class DatastoreUtils {
      * @since 1.0.0
      */
     private static String getRegistryIndexName(KapuaId scopeId, IndexType indexType) {
-        final StringBuilder sb = new StringBuilder();
-        final String prefix = DatastoreSettings.getInstance().getString(DatastoreSettingsKey.INDEX_PREFIX);
+        StringBuilder sb = new StringBuilder();
+        String prefix = DatastoreSettings.getInstance().getString(DatastoreSettingsKey.INDEX_PREFIX);
         if (StringUtils.isNotEmpty(prefix)) {
             sb.append(prefix).append("-");
         }
@@ -327,7 +327,7 @@ public class DatastoreUtils {
      * Normalize the index ({@link DatastoreUtils#normalizeIndexName(String index)}
      *
      * @param index
-     * @return
+     * @return test
      */
     public static String normalizedIndexName(String index) {
         return normalizeIndexName(index);
@@ -423,7 +423,7 @@ public class DatastoreUtils {
      *
      * @param name
      * @param type
-     * @return
+     * @return test
      */
     public static String getMetricValueQualifier(String name, String type) {
         String shortType = DatastoreUtils.getClientMetricFromAcronym(type);
@@ -503,7 +503,7 @@ public class DatastoreUtils {
      * Check if the metric type is date
      *
      * @param acronym
-     * @return
+     * @return test
      */
     public static boolean isDateMetric(String acronym) {
         return CLIENT_METRIC_TYPE_DATE_ACRONYM.equals(acronym);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageInfo.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageInfo.java
@@ -36,7 +36,7 @@ public class MessageInfo {
     /**
      * Get the account
      *
-     * @return
+     * @return test
      */
     public Account getAccount() {
         return this.account;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
@@ -126,7 +126,7 @@ public class MessageStoreConfiguration {
     /**
      * Get the expiration date parameter ({@link MessageStoreConfiguration#CONFIGURATION_EXPIRATION_DATE_KEY}
      *
-     * @return
+     * @return test
      */
     public Date getExpirationDate() {
         return expirationDate;
@@ -142,7 +142,7 @@ public class MessageStoreConfiguration {
     /**
      * Get the data storage enabled parameter ({@link MessageStoreConfiguration#CONFIGURATION_DATA_STORAGE_ENABLED_KEY}
      *
-     * @return
+     * @return test
      */
     public boolean getDataStorageEnabled() {
         return dataStorageEnabled;
@@ -158,7 +158,7 @@ public class MessageStoreConfiguration {
     /**
      * Get the data time to live in millisecond parameter ({@link MessageStoreConfiguration#CONFIGURATION_DATA_TTL_KEY}
      *
-     * @return
+     * @return test
      */
     public long getDataTimeToLiveMilliseconds() {
         return dataTimeToLive.toMillis();
@@ -167,7 +167,7 @@ public class MessageStoreConfiguration {
     /**
      * Get the data time to live parameter ({@link MessageStoreConfiguration#CONFIGURATION_DATA_TTL_KEY}
      *
-     * @return
+     * @return test
      */
     public long getDataTimeToLive() {
         return dataTimeToLive.toDays();
@@ -187,7 +187,7 @@ public class MessageStoreConfiguration {
     /**
      * Get the rx byte limit parameter ({@link MessageStoreConfiguration#CONFIGURATION_RX_BYTE_LIMIT_KEY}
      *
-     * @return
+     * @return test
      */
     public long getRxByteLimit() {
         return rxByteLimit;
@@ -203,7 +203,7 @@ public class MessageStoreConfiguration {
     /**
      * Get the data index by parameter ({@link MessageStoreConfiguration#CONFIGURATION_DATA_INDEX_BY_KEY}
      *
-     * @return
+     * @return test
      */
     public DataIndexBy getDataIndexBy() {
         return dataIndexBy;
@@ -219,7 +219,7 @@ public class MessageStoreConfiguration {
     /**
      * Get the metrics index by parameter ({@link MessageStoreConfiguration#CONFIGURATION_METRICS_INDEX_BY_KEY}
      *
-     * @return
+     * @return test
      */
     public MetricsIndexBy getMetricsIndexBy() {
         return metricsIndexBy;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreMediator.java
@@ -31,7 +31,7 @@ public interface MessageStoreMediator {
      *
      * @param scopeId
      * @param indexedOn
-     * @return
+     * @return test
      * @throws ClientException
      */
     Metadata getMetadata(KapuaId scopeId, long indexedOn) throws ClientException, MappingException;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/Metric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/Metric.java
@@ -36,7 +36,7 @@ public class Metric {
     /**
      * Get the metric name
      *
-     * @return
+     * @return test
      */
     public String getName() {
         return name;
@@ -45,7 +45,7 @@ public class Metric {
     /**
      * Get the metric type
      *
-     * @return
+     * @return test
      */
     public String getType() {
         return type;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoField.java
@@ -103,7 +103,7 @@ public enum MetricInfoField implements StorableField {
      * @param channel
      * @param metricName
      * @param metricType
-     * @return
+     * @return test
      */
     private static String getOrDeriveId(StorableId id, KapuaId scopeId, String clientId, String channel, String metricName, Class<?> metricType) {
         if (id == null) {
@@ -121,7 +121,7 @@ public enum MetricInfoField implements StorableField {
      *
      * @param id
      * @param metricInfoCreator
-     * @return
+     * @return test
      */
     public static String getOrDeriveId(StorableId id, MetricInfoCreator metricInfoCreator) {
         return getOrDeriveId(id,
@@ -138,7 +138,7 @@ public enum MetricInfoField implements StorableField {
      *
      * @param id
      * @param metricInfo
-     * @return
+     * @return test
      */
     public static String getOrDeriveId(StorableId id, MetricInfo metricInfo) {
         return getOrDeriveId(id,

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoRegistryMediator.java
@@ -30,7 +30,7 @@ public interface MetricInfoRegistryMediator {
      *
      * @param scopeId
      * @param indexedOn
-     * @return
+     * @return test
      * @throws ClientException
      */
     Metadata getMetadata(KapuaId scopeId, long indexedOn)

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -12,15 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link ChannelInfo} schema definition.
@@ -76,7 +75,7 @@ public class ChannelInfoSchema {
      * Create and return the Json representation of the channel info schema
      *
      * @param sourceEnable
-     * @return
+     * @return test
      * @throws MappingException
      * @since 1.0.0
      */
@@ -84,24 +83,24 @@ public class ChannelInfoSchema {
         ObjectNode channelNode = MappingUtils.newObjectNode();
 
         {
-            ObjectNode sourceChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
+            ObjectNode sourceChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
             channelNode.set(SchemaKeys.KEY_SOURCE, sourceChannel);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {
-                ObjectNode channelScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode channelScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(CHANNEL_SCOPE_ID, channelScopeId);
 
-                ObjectNode channelClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode channelClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(CHANNEL_CLIENT_ID, channelClientId);
 
-                ObjectNode channelName = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode channelName = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(CHANNEL_NAME, channelName);
 
-                ObjectNode channelTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
+                ObjectNode channelTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                 propertiesNode.set(CHANNEL_TIMESTAMP, channelTimestamp);
 
-                ObjectNode channelMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode channelMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(CHANNEL_MESSAGE_ID, channelMessageId);
             }
             channelNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -12,15 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link ClientInfo} schema definition.
@@ -74,7 +73,7 @@ public class ClientInfoSchema {
      * Create and return the Json representation of the client info schema
      *
      * @param sourceEnable
-     * @return
+     * @return test
      * @throws MappingException
      * @since 1.0.0
      */
@@ -82,21 +81,21 @@ public class ClientInfoSchema {
 
         ObjectNode clientNode = MappingUtils.newObjectNode();
         {
-            ObjectNode sourceClient = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
+            ObjectNode sourceClient = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
             clientNode.set(SchemaKeys.KEY_SOURCE, sourceClient);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {
-                ObjectNode clientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode clientId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(CLIENT_ID, clientId);
 
-                ObjectNode clientTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
+                ObjectNode clientTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                 propertiesNode.set(CLIENT_TIMESTAMP, clientTimestamp);
 
-                ObjectNode clientScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode clientScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(CLIENT_SCOPE_ID, clientScopeId);
 
-                ObjectNode clientMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode clientMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(CLIENT_MESSAGE_ID, clientMessageId);
             }
             clientNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -12,15 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.kapua.message.Message;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link Message} schema definition.
@@ -271,76 +270,76 @@ public class MessageSchema {
      * Create and return the Json representation of the message schema
      *
      * @param sourceEnable
-     * @return
+     * @return test
      * @throws MappingException
      * @since 1.0.0
      */
     public static JsonNode getMesageTypeSchema(boolean sourceEnable) throws MappingException {
         ObjectNode messageNode = MappingUtils.newObjectNode();
         {
-            ObjectNode sourceMessage = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
+            ObjectNode sourceMessage = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
             messageNode.set(SchemaKeys.KEY_SOURCE, sourceMessage);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {
-                ObjectNode messageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode messageId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(MESSAGE_ID, messageId);
 
-                ObjectNode messageTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
+                ObjectNode messageTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                 propertiesNode.set(MESSAGE_TIMESTAMP, messageTimestamp);
 
-                ObjectNode messageReceivedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
+                ObjectNode messageReceivedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                 propertiesNode.set(MESSAGE_RECEIVED_ON, messageReceivedOn);
 
-                ObjectNode messageIp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_IP) });
+                ObjectNode messageIp = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_IP)});
                 propertiesNode.set(MESSAGE_IP_ADDRESS, messageIp);
 
-                ObjectNode messageScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode messageScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(MESSAGE_SCOPE_ID, messageScopeId);
 
-                ObjectNode messageDeviceId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode messageDeviceId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(MESSAGE_DEVICE_ID, messageDeviceId);
 
-                ObjectNode messageClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode messageClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(MESSAGE_CLIENT_ID, messageClientId);
 
-                ObjectNode messageChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode messageChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 propertiesNode.set(MESSAGE_CHANNEL, messageChannel);
 
-                ObjectNode messageCapturedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
+                ObjectNode messageCapturedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                 propertiesNode.set(MESSAGE_CAPTURED_ON, messageCapturedOn);
 
-                ObjectNode messageSentOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
+                ObjectNode messageSentOn = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                 propertiesNode.set(MESSAGE_SENT_ON, messageSentOn);
 
                 ObjectNode positionNode = MappingUtils.newObjectNode(
-                        new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                                new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false) });
+                        new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
+                                new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false)});
 
                 ObjectNode positionPropertiesNode = MappingUtils.newObjectNode();
                 {
-                    ObjectNode messagePositionPropLocation = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_GEO_POINT) });
+                    ObjectNode messagePositionPropLocation = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_GEO_POINT)});
                     positionPropertiesNode.set(MESSAGE_POS_LOCATION, messagePositionPropLocation);
 
-                    ObjectNode messagePositionPropAlt = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
+                    ObjectNode messagePositionPropAlt = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE)});
                     positionPropertiesNode.set(MESSAGE_POS_ALT, messagePositionPropAlt);
 
-                    ObjectNode messagePositionPropPrec = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
+                    ObjectNode messagePositionPropPrec = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE)});
                     positionPropertiesNode.set(MESSAGE_POS_PRECISION, messagePositionPropPrec);
 
-                    ObjectNode messagePositionPropHead = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
+                    ObjectNode messagePositionPropHead = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE)});
                     positionPropertiesNode.set(MESSAGE_POS_HEADING, messagePositionPropHead);
 
-                    ObjectNode messagePositionPropSpeed = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
+                    ObjectNode messagePositionPropSpeed = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE)});
                     positionPropertiesNode.set(MESSAGE_POS_SPEED, messagePositionPropSpeed);
 
-                    ObjectNode messagePositionPropTime = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
+                    ObjectNode messagePositionPropTime = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                     positionPropertiesNode.set(MESSAGE_POS_TIMESTAMP, messagePositionPropTime);
 
-                    ObjectNode messagePositionPropSat = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER) });
+                    ObjectNode messagePositionPropSat = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER)});
                     positionPropertiesNode.set(MESSAGE_POS_SATELLITES, messagePositionPropSat);
 
-                    ObjectNode messagePositionPropStat = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER) });
+                    ObjectNode messagePositionPropStat = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER)});
                     positionPropertiesNode.set(MESSAGE_POS_STATUS, messagePositionPropStat);
                 }
                 positionNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, positionPropertiesNode);
@@ -350,11 +349,11 @@ public class MessageSchema {
             messageNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
 
             ObjectNode messageMetrics = MappingUtils.newObjectNode(
-                    new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, true) });
+                    new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
+                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, true)});
             propertiesNode.set(MESSAGE_METRICS, messageMetrics);
 
-            ObjectNode messageBody = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_BINARY), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_FALSE) });
+            ObjectNode messageBody = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_BINARY), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_FALSE)});
             propertiesNode.set(MESSAGE_BODY, messageBody);
         }
         return messageNode;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Metadata.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Metadata.java
@@ -40,7 +40,7 @@ public class Metadata {
     /**
      * Get the mappings cache
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public Map<String, Metric> getMessageMappingsCache() {
@@ -63,7 +63,7 @@ public class Metadata {
     /**
      * Get the Elasticsearch data index name
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getDataIndexName() {
@@ -73,7 +73,7 @@ public class Metadata {
     /**
      * Get the Kapua channel index name
      *
-     * @return
+     * @return test
      * @since 1.4.0
      */
     public String getChannelRegistryIndexName() {
@@ -83,7 +83,7 @@ public class Metadata {
     /**
      * Get the Kapua client index name
      *
-     * @return
+     * @return test
      * @since 1.4.0
      */
     public String getClientRegistryIndexName() {
@@ -93,7 +93,7 @@ public class Metadata {
     /**
      * Get the Kapua metric index name
      *
-     * @return
+     * @return test
      * @since 1.4.0
      */
     public String getMetricRegistryIndexName() {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
@@ -12,15 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link MetricInfo} schema definition.
@@ -144,7 +143,7 @@ public class MetricInfoSchema {
      * Create and return the Json representation of the metric info schema
      *
      * @param sourceEnable
-     * @return
+     * @return test
      * @throws MappingException
      * @since 1.0.0
      */
@@ -152,38 +151,38 @@ public class MetricInfoSchema {
 
         ObjectNode metricNode = MappingUtils.newObjectNode();
 
-        ObjectNode sourceMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
+        ObjectNode sourceMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
         metricNode.set(SchemaKeys.KEY_SOURCE, sourceMetric);
 
         ObjectNode propertiesNode = MappingUtils.newObjectNode();
         {
-            ObjectNode metricAccount = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+            ObjectNode metricAccount = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
             propertiesNode.set(METRIC_SCOPE_ID, metricAccount);
 
-            ObjectNode metricClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+            ObjectNode metricClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
             propertiesNode.set(METRIC_CLIENT_ID, metricClientId);
 
-            ObjectNode metricChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+            ObjectNode metricChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
             propertiesNode.set(METRIC_CHANNEL, metricChannel);
 
             ObjectNode metricMtrNode = MappingUtils.newObjectNode(
-                    new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false) });
+                    new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
+                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false)});
             ObjectNode metricMtrPropertiesNode = MappingUtils.newObjectNode();
             {
-                ObjectNode metricMtrNameNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode metricMtrNameNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 metricMtrPropertiesNode.set(METRIC_MTR_NAME, metricMtrNameNode);
 
-                ObjectNode metricMtrTypeNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode metricMtrTypeNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 metricMtrPropertiesNode.set(METRIC_MTR_TYPE, metricMtrTypeNode);
 
-                ObjectNode metricMtrValueNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode metricMtrValueNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 metricMtrPropertiesNode.set(METRIC_MTR_VALUE, metricMtrValueNode);
 
-                ObjectNode metricMtrTimestampNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
+                ObjectNode metricMtrTimestampNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                 metricMtrPropertiesNode.set(METRIC_MTR_TIMESTAMP, metricMtrTimestampNode);
 
-                ObjectNode metricMtrMsgIdNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+                ObjectNode metricMtrMsgIdNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
                 metricMtrPropertiesNode.set(METRIC_MTR_MSG_ID, metricMtrMsgIdNode);
             }
             metricMtrNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, metricMtrPropertiesNode);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -32,7 +32,6 @@ import org.eclipse.kapua.service.elasticsearch.client.model.TypeDescriptor;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +53,7 @@ public class Schema {
      *
      * @param scopeId
      * @param time
-     * @return
+     * @return test
      * @throws ClientException
      * @since 1.0.0
      */
@@ -169,7 +168,7 @@ public class Schema {
 
     /**
      * @param esMetrics
-     * @return
+     * @return test
      * @throws DatamodelMappingException
      * @throws KapuaException
      * @since 1.0.0
@@ -219,7 +218,7 @@ public class Schema {
     /**
      * @param currentMetadata
      * @param esMetrics
-     * @return
+     * @return test
      * @since 1.0.0
      */
     private Map<String, Metric> getMessageMappingDiffs(Metadata currentMetadata, Map<String, Metric> esMetrics) {
@@ -243,7 +242,7 @@ public class Schema {
 
     /**
      * @param idxName
-     * @return
+     * @return test
      * @throws MappingException
      * @since 1.0.0
      */

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
@@ -39,7 +39,7 @@ public class SchemaUtil {
      * @param key
      * @param subKeys
      * @param values
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public static Map<String, Object> getMapOfMap(String key, String[] subKeys, String[] values) {
@@ -56,7 +56,7 @@ public class SchemaUtil {
      * Get the Elasticsearch data index name
      *
      * @param scopeId
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public static String getDataIndexName(KapuaId scopeId) {
@@ -67,7 +67,7 @@ public class SchemaUtil {
      * Get the Kapua data index name
      *
      * @param scopeId
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public static String getChannelIndexName(KapuaId scopeId) {
@@ -78,7 +78,7 @@ public class SchemaUtil {
      * Get the Kapua data index name
      *
      * @param scopeId
-     * @return
+     * @return test
      */
     public static String getClientIndexName(KapuaId scopeId) {
         return DatastoreUtils.getClientIndexName(scopeId);
@@ -88,7 +88,7 @@ public class SchemaUtil {
      * Get the Kapua data index name
      *
      * @param scopeId
-     * @return
+     * @return test
      */
     public static String getMetricIndexName(KapuaId scopeId) {
         return DatastoreUtils.getMetricIndexName(scopeId);

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -12,6 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.steps;
 
+import com.google.inject.Singleton;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.DataTableType;
+import io.cucumber.java.Scenario;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import org.apache.commons.lang.ArrayUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
@@ -97,17 +106,6 @@ import org.eclipse.kapua.service.storable.model.query.predicate.TermPredicate;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.inject.Singleton;
-
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
-import io.cucumber.java.DataTableType;
-import io.cucumber.java.Scenario;
-import io.cucumber.java.en.And;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
 
 import javax.inject.Inject;
 import java.lang.reflect.Field;
@@ -240,9 +238,9 @@ public class DatastoreSteps extends TestBase {
     @DataTableType
     public MetricEntry metricEntry(Map<String, String> entry) {
         return new MetricEntry(
-            entry.get("key"),
-            entry.get("type"),
-            entry.get("value")
+                entry.get("key"),
+                entry.get("type"),
+                entry.get("value")
         );
     }
 
@@ -284,7 +282,7 @@ public class DatastoreSteps extends TestBase {
         this.session = session;
     }
 
-    @After(value="@setup")
+    @After(value = "@setup")
     public void setServices() throws Exception {
         locator = KapuaLocator.getInstance();
         // Get instance of services used in different scenarios
@@ -320,7 +318,7 @@ public class DatastoreSteps extends TestBase {
 
     }
 
-    @After(value="not (@setup or @teardown)", order=10)
+    @After(value = "not (@setup or @teardown)", order = 10)
     public void afterScenario() {
         try {
             deleteIndices();
@@ -375,7 +373,7 @@ public class DatastoreSteps extends TestBase {
 
     @Then("I expect the number of messages for this device to be {long}")
     public void expectNumberOfMessages(long numberOfMessages) throws Exception {
-        final MessageStoreService service = KapuaLocator.getInstance().getService(MessageStoreService.class);
+        MessageStoreService service = KapuaLocator.getInstance().getService(MessageStoreService.class);
         session.withLogin(() -> With.withUserAccount(currentDevice.getAccountName(), account -> {
             MessageQuery query = messageStoreFactory.newQuery(account.getId());
             query.setPredicate(datastorePredicateFactory.newTermPredicate(MessageField.CLIENT_ID, currentDevice.getClientId()));
@@ -391,7 +389,7 @@ public class DatastoreSteps extends TestBase {
 
     @Then("I delete the messages for this device")
     public void deleteMessages() throws Exception {
-        final MessageStoreService service = KapuaLocator.getInstance().getService(MessageStoreService.class);
+        MessageStoreService service = KapuaLocator.getInstance().getService(MessageStoreService.class);
         session.withLogin(() -> With.withUserAccount(currentDevice.getAccountName(), account -> {
             MessageQuery query = messageStoreFactory.newQuery(account.getId());
             query.setPredicate(datastorePredicateFactory.newTermPredicate(MessageField.CLIENT_ID, currentDevice.getClientId()));
@@ -403,7 +401,7 @@ public class DatastoreSteps extends TestBase {
 
     @Then("I expect the latest captured message on channel {string} to have the metrics")
     public void testMessageData(String topic, List<MetricEntry> expectedMetrics) throws Exception {
-        final MessageStoreService service = KapuaLocator.getInstance().getService(MessageStoreService.class);
+        MessageStoreService service = KapuaLocator.getInstance().getService(MessageStoreService.class);
         session.withLogin(() -> With.withUserAccount(currentDevice.getAccountName(), account -> {
             MessageQuery query = messageStoreFactory.newQuery(account.getId());
             AndPredicate and = datastorePredicateFactory.newAndPredicate();
@@ -416,7 +414,7 @@ public class DatastoreSteps extends TestBase {
             DatastoreMessage message = result.getFirstItem();
             Assert.assertEquals(currentDevice.getClientId(), message.getClientId());
             KapuaPayload payload = message.getPayload();
-            final Map<String, Object> properties = payload.getMetrics();
+            Map<String, Object> properties = payload.getMetrics();
             Assert.assertEquals(toData(expectedMetrics), properties);
         }));
     }
@@ -1484,12 +1482,12 @@ public class DatastoreSteps extends TestBase {
     @When("I count for metric info")
     public void countForMetricInfo() throws KapuaException {
         MetricInfoQuery metricInfoQuery = (MetricInfoQuery) stepData.get(METRIC_INFO_QUERY);
-        stepData.put("metricInfoCountResult", (int)metricInfoRegistryService.count(metricInfoQuery));
+        stepData.put("metricInfoCountResult", (int) metricInfoRegistryService.count(metricInfoQuery));
     }
 
     @Then("I get metric info count {int}")
     public void getDesiredMetricInfoCountResult(int desiredCount) {
-        int count = (int)stepData.get("metricInfoCountResult");
+        int count = (int) stepData.get("metricInfoCountResult");
         Assert.assertEquals(desiredCount, count);
     }
 
@@ -1583,13 +1581,13 @@ public class DatastoreSteps extends TestBase {
     // *******************
 
     private static Map<String, Object> toData(List<MetricEntry> metrics) {
-        final Map<String, Object> data = new HashMap<>();
+        Map<String, Object> data = new HashMap<>();
 
-        for (final MetricEntry entry : metrics) {
+        for (MetricEntry entry : metrics) {
 
-            final String key = entry.getKey();
-            final String stringValue = entry.getValue();
-            final String type = entry.getType();
+            String key = entry.getKey();
+            String stringValue = entry.getValue();
+            String type = entry.getType();
 
             switch (type.toUpperCase()) {
                 case "STRING":
@@ -1614,8 +1612,8 @@ public class DatastoreSteps extends TestBase {
         return data;
     }
 
-    private SimulatedDeviceApplication getMockApplication(final String applicationId) {
-        final SimulatedDeviceApplication app = currentDevice.getMockApplications().get(applicationId);
+    private SimulatedDeviceApplication getMockApplication(String applicationId) {
+        SimulatedDeviceApplication app = currentDevice.getMockApplications().get(applicationId);
         if (app == null) {
             throw new IllegalStateException(String.format("Application '%s' not found in current setup", applicationId));
         }
@@ -2029,7 +2027,7 @@ public class DatastoreSteps extends TestBase {
         private final SortField field;
         private final Function<Object, T> valueFunction;
 
-        public OrderConstraint(final SortField field, final Function<Object, T> valueFunction) {
+        public OrderConstraint(SortField field, Function<Object, T> valueFunction) {
             this.field = field;
             this.valueFunction = valueFunction;
         }
@@ -2038,9 +2036,9 @@ public class DatastoreSteps extends TestBase {
             return field;
         }
 
-        public boolean validate(final Object previousItem, final Object currentItem) {
-            final T v1 = valueFunction.apply(previousItem);
-            final T v2 = valueFunction.apply(currentItem);
+        public boolean validate(Object previousItem, Object currentItem) {
+            T v1 = valueFunction.apply(previousItem);
+            T v2 = valueFunction.apply(currentItem);
 
             if (!v2.equals(v1)) {
                 checkNextValueCoherence(field, v2, v1);
@@ -2090,7 +2088,7 @@ public class DatastoreSteps extends TestBase {
      * @param currentValue
      * @param previousValue
      */
-    private static <T extends Comparable<T>> void checkNextValueCoherence(final SortField field, final T currentValue, final T previousValue) {
+    private static <T extends Comparable<T>> void checkNextValueCoherence(SortField field, T currentValue, T previousValue) {
 
         if (SortDirection.ASC.equals(field.getSortDirection())) {
             Assert.assertTrue(String.format("The field [%s] is not correctly ordered as [%s] (%s -> %s)!", field.getField(), field.getSortDirection(), currentValue, previousValue),
@@ -2105,7 +2103,7 @@ public class DatastoreSteps extends TestBase {
      * Return the value of the field name provided (assuming that this value is a Comparable)
      *
      * @param field
-     * @return
+     * @return test
      */
     private static <T> T getValue(Object object, String field, Class<T> clazz) {
 
@@ -2138,7 +2136,7 @@ public class DatastoreSteps extends TestBase {
      * It removes the _ and append the remaining part capitalizing the first letter (if capitalizeFirstLetter = true)
      *
      * @param field
-     * @return
+     * @return test
      */
     private static String getFieldName(String field, boolean capitalizeFirstLetter) {
 
@@ -2178,7 +2176,7 @@ public class DatastoreSteps extends TestBase {
      * @param objetcClass
      * @param field
      * @param prefix
-     * @return
+     * @return test
      */
     private static Method getMethod(Class<?> objetcClass, String field, String prefix) {
 
@@ -2201,9 +2199,9 @@ public class DatastoreSteps extends TestBase {
      *
      * @param objectClass
      * @param field
-     * @return
+     * @return test
      */
-    private static Field getField(Class<?> objectClass, final String field) {
+    private static Field getField(Class<?> objectClass, String field) {
 
         Field objField = null;
         do {

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/event/KapuaManagementEventChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/event/KapuaManagementEventChannel.java
@@ -62,7 +62,7 @@ public interface KapuaManagementEventChannel extends KapuaEventChannel {
     /**
      * Get the request resources
      *
-     * @return
+     * @return test
      * @since 2.0.0
      */
     String[] getResources();

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyChannel.java
@@ -24,7 +24,7 @@ public interface KapuaNotifyChannel extends KapuaAppChannel {
     /**
      * Get the request resources
      *
-     * @return
+     * @return test
      * @since 1.2.0
      */
     String[] getResources();

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/event/DeviceManagementEventChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/event/DeviceManagementEventChannel.java
@@ -56,7 +56,7 @@ public interface DeviceManagementEventChannel extends DeviceChannel {
     /**
      * Get the request resources
      *
-     * @return
+     * @return test
      * @since 2.0.0
      */
     String[] getResources();

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssets.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssets.java
@@ -12,15 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.model.asset;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.kapua.KapuaException;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import org.eclipse.kapua.KapuaException;
-
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * {@link KuraAssets} list definition.
@@ -34,8 +33,7 @@ public class KuraAssets {
     /**
      * Get the assets list
      *
-     * @return
-     *
+     * @return test
      * @since 1.0.0
      */
     public List<KuraAsset> getAssets() {
@@ -50,7 +48,6 @@ public class KuraAssets {
      * Set the assets list
      *
      * @param assets
-     *
      * @since 1.0.0
      */
     public void setAssets(List<KuraAsset> assets) {
@@ -60,12 +57,9 @@ public class KuraAssets {
     /**
      * Parse a {@link JsonNode} that represent the {@link KuraAssets} object.
      *
-     * @param jsonKuraAssets
-     *            The {@link JsonNode} to parse
+     * @param jsonKuraAssets The {@link JsonNode} to parse
      * @return The parsed {@link KuraAssets} result.
-     *
      * @throws KapuaException
-     *
      * @since 1.0.0
      */
     public static KuraAssets readJsonNode(JsonNode jsonKuraAssets) throws KapuaException {
@@ -84,8 +78,7 @@ public class KuraAssets {
     /**
      * Serialize {@code  this} {@link KuraAssets} into json using the given {@link JsonGenerator}.
      *
-     * @param jsonGenerator
-     *            The {@link JsonGenerator} to put serialized {@link KuraAssets}.
+     * @param jsonGenerator The {@link JsonGenerator} to put serialized {@link KuraAssets}.
      * @throws IOException
      * @since 1.0.0
      */

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
@@ -22,11 +22,10 @@ import javax.xml.bind.annotation.XmlType;
  * Kura bundle definition.
  *
  * @since 1.0
- *
  */
 @XmlRootElement(name = "bundle")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "name", "version", "id", "state" })
+@XmlType(propOrder = {"name", "version", "id", "state"})
 public class KuraBundle {
 
     @XmlElement(name = "name")
@@ -60,7 +59,7 @@ public class KuraBundle {
     /**
      * Get bundle version
      *
-     * @return
+     * @return test
      */
     public String getVersion() {
         return version;
@@ -78,7 +77,7 @@ public class KuraBundle {
     /**
      * Get bundle identifier
      *
-     * @return
+     * @return test
      */
     public long getId() {
         return id;
@@ -96,7 +95,7 @@ public class KuraBundle {
     /**
      * Get bundle state
      *
-     * @return
+     * @return test
      */
     public String getState() {
         return state;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
@@ -21,7 +21,6 @@ import javax.xml.bind.annotation.XmlRootElement;
  * Kura bundles list definition.
  *
  * @since 1.0
- *
  */
 @XmlRootElement(name = "bundles")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -33,7 +32,7 @@ public class KuraBundles {
     /**
      * Get the bundles list
      *
-     * @return
+     * @return test
      */
     public KuraBundle[] getBundles() {
         return bundles;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
@@ -79,7 +79,7 @@ public class KuraDeviceComponentConfiguration {
      * Component Descriptor XML file; at runtime, the same value is also available
      * in the component.name and in the service.pid attributes of the Component Configuration.
      *
-     * @return
+     * @return test
      */
     public String getComponentId() {
         return componentId;
@@ -99,7 +99,7 @@ public class KuraDeviceComponentConfiguration {
      * The raw ObjectClassDefinition as parsed from the MetaType
      * Information XML resource associated to this Component.
      *
-     * @return
+     * @return test
      */
     public KapuaTocd getDefinition() {
         return definition;
@@ -118,7 +118,7 @@ public class KuraDeviceComponentConfiguration {
      * Get configuration properties.<br>
      * The Dictionary of properties currently used by this component.
      *
-     * @return
+     * @return test
      */
     public Map<String, Object> getProperties() {
         return properties;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
@@ -12,19 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.model.configuration;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A container for a list of OSGi component configurations.
  *
  * @since 1.0
- *
  */
 @XmlRootElement(name = "configurations")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -34,6 +32,7 @@ public class KuraDeviceConfiguration {
     private List<KuraDeviceComponentConfiguration> configurations;
 
     // Required by JAXB
+
     /**
      * Constructor
      */
@@ -54,7 +53,7 @@ public class KuraDeviceConfiguration {
     /**
      * Get the device component configuration list
      *
-     * @return
+     * @return test
      */
     public List<KuraDeviceComponentConfiguration> getConfigurations() {
         if (configurations == null) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraPassword.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraPassword.java
@@ -16,7 +16,6 @@ package org.eclipse.kapua.service.device.call.kura.model.configuration;
  * Kura password
  *
  * @since 1.0
- *
  */
 public class KuraPassword {
 
@@ -35,7 +34,7 @@ public class KuraPassword {
     /**
      * Get the password
      *
-     * @return
+     * @return test
      */
     public String getPassword() {
         return password;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapted.java
@@ -20,7 +20,6 @@ import javax.xml.bind.annotation.XmlElement;
  * A container for XmlConfigPropertyAdapted organized into an array.
  *
  * @since 1.0
- *
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class KuraXmlConfigPropertiesAdapted {
@@ -37,7 +36,7 @@ public class KuraXmlConfigPropertiesAdapted {
     /**
      * Get the adapted configuration properties array
      *
-     * @return
+     * @return test
      */
     public XmlConfigPropertyAdapted[] getProperties() {
         return properties;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
@@ -26,7 +26,6 @@ import javax.xml.bind.annotation.XmlEnumValue;
  * encrypted.
  *
  * @since 1.0
- *
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class XmlConfigPropertyAdapted {
@@ -90,8 +89,8 @@ public class XmlConfigPropertyAdapted {
      * @param values
      */
     public XmlConfigPropertyAdapted(String name,
-            ConfigPropertyType type,
-            String[] values) {
+                                    ConfigPropertyType type,
+                                    String[] values) {
         super();
 
         this.type = type;
@@ -102,7 +101,7 @@ public class XmlConfigPropertyAdapted {
     /**
      * Get the property name
      *
-     * @return
+     * @return test
      */
     public String getName() {
         return name;
@@ -120,7 +119,7 @@ public class XmlConfigPropertyAdapted {
     /**
      * Get the is array flag property
      *
-     * @return
+     * @return test
      */
     public boolean getArray() {
         return array;
@@ -138,7 +137,7 @@ public class XmlConfigPropertyAdapted {
     /**
      * Get the property type
      *
-     * @return
+     * @return test
      */
     public ConfigPropertyType getType() {
         return type;
@@ -156,7 +155,7 @@ public class XmlConfigPropertyAdapted {
     /**
      * Get the is encrypted flag property
      *
-     * @return
+     * @return test
      */
     public boolean isEncrypted() {
         return encrypted;
@@ -174,7 +173,7 @@ public class XmlConfigPropertyAdapted {
     /**
      * Get property values
      *
-     * @return
+     * @return test
      */
     public String[] getValues() {
         return values;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
@@ -22,11 +22,10 @@ import javax.xml.bind.annotation.XmlType;
  * Kura bundle information.
  *
  * @since 1.0
- *
  */
 @XmlRootElement(name = "bundleInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "name", "version" })
+@XmlType(propOrder = {"name", "version"})
 public class KuraBundleInfo {
 
     @XmlElement(name = "name")
@@ -38,7 +37,7 @@ public class KuraBundleInfo {
     /**
      * Get the bundle name
      *
-     * @return
+     * @return test
      */
     public String getName() {
         return name;
@@ -56,7 +55,7 @@ public class KuraBundleInfo {
     /**
      * Get the bundle version
      *
-     * @return
+     * @return test
      */
     public String getVersion() {
         return version;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
@@ -42,7 +42,7 @@ public class KuraDeploymentPackage {
     /**
      * Get the deployment package name
      *
-     * @return
+     * @return test
      */
     public String getName() {
         return name;
@@ -60,7 +60,7 @@ public class KuraDeploymentPackage {
     /**
      * Get the deployment package version
      *
-     * @return
+     * @return test
      */
     public String getVersion() {
         return version;
@@ -78,7 +78,7 @@ public class KuraDeploymentPackage {
     /**
      * Get the bundle information array
      *
-     * @return
+     * @return test
      */
     public KuraBundleInfo[] getBundleInfos() {
         if (bundleInfos == null) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
@@ -32,7 +32,7 @@ public class KuraDeploymentPackages {
     /**
      * Get the deployment package array
      *
-     * @return
+     * @return test
      */
     public KuraDeploymentPackage[] getDeploymentPackages() {
         if (deploymentPackages == null) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/KuraSnapshotIds.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/KuraSnapshotIds.java
@@ -12,15 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.model.snapshot;
 
-import java.util.List;
-
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
 
 /**
  * Utility class to serialize a set of snapshot ids.
  *
  * @since 1.0
- *
  */
 @XmlRootElement(name = "snapshot-ids")
 public class KuraSnapshotIds {
@@ -36,7 +34,7 @@ public class KuraSnapshotIds {
     /**
      * Get the snapshot identifiers list
      *
-     * @return
+     * @return test
      */
     public List<Long> getSnapshotIds() {
         return snapshotIds;

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSetting.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSetting.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
  * Class that offers access to device management settings
  *
  * @since 1.0
- *
  */
 public class DeviceManagementSetting extends AbstractKapuaSetting<DeviceManagementSettingKey> {
 
@@ -40,7 +39,7 @@ public class DeviceManagementSetting extends AbstractKapuaSetting<DeviceManageme
     /**
      * Get a singleton instance of {@link DeviceManagementSetting}.
      *
-     * @return
+     * @return test
      */
     public static DeviceManagementSetting getInstance() {
         return INSTANCE;

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
@@ -24,14 +24,14 @@ public interface DeviceBundleFactory extends KapuaObjectFactory {
     /**
      * Creates a new device bundle list
      *
-     * @return
+     * @return test
      */
     DeviceBundles newBundleListResult();
 
     /**
      * Create a new {@link DeviceBundle}
      *
-     * @return
+     * @return test
      */
     DeviceBundle newDeviceBundle();
 }

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
@@ -29,7 +29,7 @@ public interface DeviceBundleManagementService extends DeviceManagementService {
      * @param scopeId
      * @param deviceId
      * @param timeout  timeout waiting for the device response
-     * @return
+     * @return test
      * @throws KapuaException
      */
     DeviceBundles get(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
@@ -27,7 +27,7 @@ public class DeviceBundleXmlRegistry {
     /**
      * Creates a new device bundles list
      *
-     * @return
+     * @return test
      */
     public DeviceBundles newBundleListResult() {
         return factory.newBundleListResult();
@@ -36,7 +36,7 @@ public class DeviceBundleXmlRegistry {
     /**
      * Creates a new device bundle
      *
-     * @return
+     * @return test
      */
     public DeviceBundle newDeviceBundle() {
         return factory.newDeviceBundle();

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
@@ -42,7 +42,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get the device command
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "command")
     String getCommand();
@@ -57,7 +57,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get the device password
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "password")
     String getPassword();
@@ -72,7 +72,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get command arguments
      *
-     * @return
+     * @return test
      */
     @XmlElementWrapper(name = "arguments")
     @XmlElement(name = "argument")
@@ -88,7 +88,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get the command timeout
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "timeout")
     Integer getTimeout();
@@ -103,7 +103,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get the working directory
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "workingDir")
     String getWorkingDir();
@@ -118,7 +118,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get the command input body
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "body")
     byte[] getBody();
@@ -133,7 +133,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get the environment attributes
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "environment")
     String[] getEnvironment();
@@ -148,7 +148,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get the asynchronous run flag
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "runAsynch")
     boolean isRunAsynch();
@@ -163,7 +163,7 @@ public interface DeviceCommandInput extends DeviceCommand {
     /**
      * Get the device standard input
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "stdin")
     String getStdin();

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
@@ -38,7 +38,7 @@ public interface DeviceCommandOutput extends DeviceCommand {
     /**
      * Get the standard error
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "stderr")
     String getStderr();
@@ -53,7 +53,7 @@ public interface DeviceCommandOutput extends DeviceCommand {
     /**
      * Get the standard output
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "stdout")
     String getStdout();
@@ -68,7 +68,7 @@ public interface DeviceCommandOutput extends DeviceCommand {
     /**
      * Get the command execution exception message
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "exceptionMessage")
     String getExceptionMessage();
@@ -83,7 +83,7 @@ public interface DeviceCommandOutput extends DeviceCommand {
     /**
      * Get the command execution exception stack
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "exceptionStack")
     String getExceptionStack();
@@ -98,7 +98,7 @@ public interface DeviceCommandOutput extends DeviceCommand {
     /**
      * Get the command execution exit code
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "exitCode")
     Integer getExitCode();
@@ -113,7 +113,7 @@ public interface DeviceCommandOutput extends DeviceCommand {
     /**
      * Get the command execution timed out flag
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "hasTimedout")
     Boolean getHasTimedout();

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
@@ -95,7 +95,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
     /**
      * Get the command exit code
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public Integer getExitCode() {
@@ -115,7 +115,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
     /**
      * Get the command execution timed out flag
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public Boolean hasTimedout() {

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
@@ -36,7 +36,7 @@ public interface DeviceComponentConfiguration {
     /**
      * Get device configuration component identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "id")
     String getId();
@@ -51,7 +51,7 @@ public interface DeviceComponentConfiguration {
     /**
      * Get device configuration component name
      *
-     * @return
+     * @return test
      */
     @XmlAttribute(name = "name")
     String getName();
@@ -66,7 +66,7 @@ public interface DeviceComponentConfiguration {
     /**
      * Get device configuration component definition
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "definition")
     KapuaTocd getDefinition();
@@ -81,7 +81,7 @@ public interface DeviceComponentConfiguration {
     /**
      * Get device configuration component properties
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "properties")
     @XmlJavaTypeAdapter(DeviceXmlConfigPropertiesAdapter.class)

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
@@ -24,14 +24,14 @@ public interface DeviceConfigurationFactory extends KapuaObjectFactory {
     /**
      * Creates a new {@link DeviceComponentConfiguration} using the given component configuration identifier
      *
-     * @return
+     * @return test
      */
     DeviceComponentConfiguration newComponentConfigurationInstance(String componentConfigurationId);
 
     /**
      * Creates a new {@link DeviceConfiguration}
      *
-     * @return
+     * @return test
      */
     DeviceConfiguration newConfigurationInstance();
 }

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
@@ -31,7 +31,7 @@ public interface DeviceConfigurationManagementService extends DeviceManagementSe
      * @param configurationId
      * @param configurationComponentPid
      * @param timeout                   timeout waiting for the device response
-     * @return
+     * @return test
      * @throws KapuaException
      */
     DeviceConfiguration get(KapuaId scopeId, KapuaId deviceId,

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
@@ -30,7 +30,7 @@ public class DeviceConfigurationXmlRegistry {
     /**
      * Creates a new device configuration
      *
-     * @return
+     * @return test
      */
     public DeviceConfiguration newConfiguration() {
         return DEVICE_CONFIGURATION_FACTORY.newConfigurationInstance();
@@ -39,7 +39,7 @@ public class DeviceConfigurationXmlRegistry {
     /**
      * Creates a new device component configuration
      *
-     * @return
+     * @return test
      */
     public DeviceComponentConfiguration newComponentConfiguration() {
         return DEVICE_CONFIGURATION_FACTORY.newComponentConfigurationInstance(null);

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertiesAdapted.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertiesAdapted.java
@@ -36,7 +36,7 @@ public class DeviceXmlConfigPropertiesAdapted {
     /**
      * Get the adapted properties as array
      *
-     * @return
+     * @return test
      */
     public DeviceXmlConfigPropertyAdapted[] getProperties() {
         return properties;

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertyAdapted.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertyAdapted.java
@@ -31,16 +31,36 @@ public class DeviceXmlConfigPropertyAdapted {
 
     @XmlEnum
     public enum ConfigPropertyType {
-        @XmlEnumValue("String")stringType,
-        @XmlEnumValue("Long")longType,
-        @XmlEnumValue("Double")doubleType,
-        @XmlEnumValue("Float")floatType,
-        @XmlEnumValue("Integer")integerType,
-        @XmlEnumValue("Byte")byteType,
-        @XmlEnumValue("Char")charType,
-        @XmlEnumValue("Boolean")booleanType,
-        @XmlEnumValue("Short")shortType,
-        @XmlEnumValue("Password")passwordType
+
+        @XmlEnumValue("String")
+        stringType,
+
+        @XmlEnumValue("Long")
+        longType,
+
+        @XmlEnumValue("Double")
+        doubleType,
+
+        @XmlEnumValue("Float")
+        floatType,
+
+        @XmlEnumValue("Integer")
+        integerType,
+
+        @XmlEnumValue("Byte")
+        byteType,
+
+        @XmlEnumValue("Char")
+        charType,
+
+        @XmlEnumValue("Boolean")
+        booleanType,
+
+        @XmlEnumValue("Short")
+        shortType,
+
+        @XmlEnumValue("Password")
+        passwordType
     }
 
     /**

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
@@ -30,7 +30,7 @@ public class DeviceSnapshotXmlRegistry {
     /**
      * Creates a new device snapshots list
      *
-     * @return
+     * @return test
      */
     public DeviceSnapshots newDeviceSnapshots() {
         return DEVICE_SNAPSHOT_FACTORY.newDeviceSnapshots();
@@ -39,7 +39,7 @@ public class DeviceSnapshotXmlRegistry {
     /**
      * Creates a new device snapshot
      *
-     * @return
+     * @return test
      */
     public DeviceSnapshot newDeviceSnapshot() {
         return DEVICE_SNAPSHOT_FACTORY.newDeviceSnapshot();

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationDAO.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationDAO.java
@@ -37,7 +37,7 @@ public class JobDeviceManagementOperationDAO {
      *
      * @param em
      * @param jobDeviceManagementOperationCreator
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.1.0
      */
@@ -58,7 +58,7 @@ public class JobDeviceManagementOperationDAO {
      * @param em
      * @param scopeId
      * @param jobDeviceManagementOperationId
-     * @return
+     * @return test
      * @since 1.1.0
      */
     public static JobDeviceManagementOperation find(EntityManager em, KapuaId scopeId, KapuaId jobDeviceManagementOperationId) {
@@ -70,7 +70,7 @@ public class JobDeviceManagementOperationDAO {
      *
      * @param em
      * @param jobDeviceManagementOperationQuery
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.1.0
      */
@@ -84,7 +84,7 @@ public class JobDeviceManagementOperationDAO {
      *
      * @param em
      * @param jobDeviceManagementOperationQuery
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.1.0
      */

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageXmlRegistry.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageXmlRegistry.java
@@ -37,7 +37,7 @@ public class DevicePackageXmlRegistry {
     /**
      * Creates a new device package instance
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public DevicePackage newDevicePackage() {
@@ -47,7 +47,7 @@ public class DevicePackageXmlRegistry {
     /**
      * Creates a new device packages instance
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public DevicePackages newDevicePackages() {
@@ -57,7 +57,7 @@ public class DevicePackageXmlRegistry {
     /**
      * Creates a new device package bundle information instance
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public DevicePackageBundleInfo newDevicePackageBundleInfo() {
@@ -67,7 +67,7 @@ public class DevicePackageXmlRegistry {
     /**
      * Creates a new device package bundle informations instance
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public DevicePackageBundleInfos newDevicePackageBundleInfos() {
@@ -77,7 +77,7 @@ public class DevicePackageXmlRegistry {
     /**
      * Creates a new device package download request instance
      *
-     * @return
+     * @return test
      */
     public DevicePackageDownloadRequest newDevicePackageDownloadRequest() {
         return DEVICE_PACKAGE_FACTORY.newPackageDownloadRequest();
@@ -86,7 +86,7 @@ public class DevicePackageXmlRegistry {
     /**
      * Creates a new device package download request instance
      *
-     * @return
+     * @return test
      * @since 1.1.0
      */
     public AdvancedPackageDownloadOptions newAdvancedPackageDownloadOptions() {
@@ -116,7 +116,7 @@ public class DevicePackageXmlRegistry {
     /**
      * Creates a new device package uninstall request instance
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public DevicePackageUninstallRequest newDevicePackageUninstallRequest() {

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
@@ -36,7 +36,7 @@ public interface DevicePackageDownloadOperation {
     /**
      * Get the download package identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -52,7 +52,7 @@ public interface DevicePackageDownloadOperation {
     /**
      * Get the package size
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "size")
     Integer getSize();
@@ -67,7 +67,7 @@ public interface DevicePackageDownloadOperation {
     /**
      * Get the download progress
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "progress")
     Integer getProgress();
@@ -82,7 +82,7 @@ public interface DevicePackageDownloadOperation {
     /**
      * Get the download status
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "status")
     DevicePackageDownloadStatus getStatus();

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
@@ -36,7 +36,7 @@ public interface DevicePackageInstallOperation {
     /**
      * Get the package identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -52,7 +52,7 @@ public interface DevicePackageInstallOperation {
     /**
      * Get the package name
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "name")
     String getName();
@@ -67,7 +67,7 @@ public interface DevicePackageInstallOperation {
     /**
      * Get the package version
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "version")
     String getVersion();
@@ -82,7 +82,7 @@ public interface DevicePackageInstallOperation {
     /**
      * Get the package install status
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "status")
     DevicePackageInstallStatus getStatus();

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
@@ -22,7 +22,7 @@ public interface DevicePackageInstallRequest {
     /**
      * Get the package name
      *
-     * @return
+     * @return test
      */
     String getName();
 
@@ -36,7 +36,7 @@ public interface DevicePackageInstallRequest {
     /**
      * Get the package version
      *
-     * @return
+     * @return test
      */
     String getVersion();
 
@@ -50,7 +50,7 @@ public interface DevicePackageInstallRequest {
     /**
      * Get the device reboot flag
      *
-     * @return
+     * @return test
      */
     Boolean isReboot();
 
@@ -64,7 +64,7 @@ public interface DevicePackageInstallRequest {
     /**
      * Get the reboot delay
      *
-     * @return
+     * @return test
      */
     Integer getRebootDelay();
 

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
@@ -34,7 +34,7 @@ public interface DevicePackageUninstallOperation {
     /**
      * Get the package identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "id")
     KapuaId getId();
@@ -49,7 +49,7 @@ public interface DevicePackageUninstallOperation {
     /**
      * Get the package name
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "name")
     String getName();
@@ -64,7 +64,7 @@ public interface DevicePackageUninstallOperation {
     /**
      * Get the package version
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "version")
     String getVersion();
@@ -79,7 +79,7 @@ public interface DevicePackageUninstallOperation {
     /**
      * Get the package uninstall status
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "status")
     DevicePackageUninstallStatus getStatus();

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
@@ -31,7 +31,7 @@ import javax.xml.bind.annotation.XmlType;
         "name",
         "version",
         "reboot",
-        "rebootDelay" },
+        "rebootDelay"},
         factoryClass = DevicePackageXmlRegistry.class,
         factoryMethod = "newDevicePackageUninstallRequest")
 public interface DevicePackageUninstallRequest {
@@ -39,7 +39,7 @@ public interface DevicePackageUninstallRequest {
     /**
      * Get package name
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "name")
     String getName();
@@ -54,7 +54,7 @@ public interface DevicePackageUninstallRequest {
     /**
      * Get package version
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "version")
     String getVersion();
@@ -69,7 +69,7 @@ public interface DevicePackageUninstallRequest {
     /**
      * Get the device reboot flag
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "reboot")
     Boolean isReboot();
@@ -84,7 +84,7 @@ public interface DevicePackageUninstallRequest {
     /**
      * Get the reboot delay
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "rebootDelay")
     Integer getRebootDelay();

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
@@ -30,7 +30,7 @@ public class PackageRequestChannel extends KapuaRequestChannelImpl {
     /**
      * Get package resource
      *
-     * @return
+     * @return test
      */
     public PackageResource getPackageResource() {
         return packageResource;

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
@@ -247,7 +247,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the is a download package and install flag
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public Boolean isPackageDownloadInstall() {
@@ -291,7 +291,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the download block size
      *
-     * @return
+     * @return test
      * @since 1.1.0
      */
     public Integer getPackageDownloadBlockSize() {
@@ -398,7 +398,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the package install name
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getPackageInstallName() {
@@ -420,7 +420,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the package install version
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getPackageInstallVersion() {
@@ -446,7 +446,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the package uninstall name
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getPackageUninstallName() {
@@ -468,7 +468,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the package uninstall version
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public String getPackageUninstallVersion() {
@@ -494,7 +494,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the is a download request flag
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public boolean isDownloadRequest() {
@@ -504,7 +504,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the is an install request flag
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public boolean isInstallRequest() {
@@ -514,7 +514,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Get the is an uninstall request flag
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public boolean isUninstallRequest() {

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
@@ -55,7 +55,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
     /**
      * Get the package download operation identifier
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public KapuaId getPackageDownloadOperationId() {
@@ -77,7 +77,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
     /**
      * Get the package download operation status
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public DevicePackageDownloadStatus getPackageDownloadOperationStatus() {
@@ -99,7 +99,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
     /**
      * Set the package download size
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public Integer getPackageDownloadOperationSize() {
@@ -121,7 +121,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
     /**
      * Get the package download progress
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public Integer getPackageDownloadOperationProgress() {

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperation.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperation.java
@@ -45,7 +45,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     }
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "startedOn")
@@ -59,7 +59,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     void setStartedOn(Date startedOn);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "endedOn")
@@ -73,7 +73,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     void setEndedOn(Date endedOn);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "deviceId")
@@ -87,7 +87,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     void setDeviceId(KapuaId deviceId);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "operationId")
@@ -101,7 +101,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     void setOperationId(KapuaId operationId);
 
     /**
-     * @return
+     * @return test
      */
     @XmlElement(name = "appId")
     String getAppId();
@@ -113,7 +113,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     void setAppId(String appId);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "action")
@@ -126,7 +126,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     void setAction(KapuaMethod action);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "resource")
@@ -139,7 +139,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     void setResource(String resource);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "status")
@@ -153,7 +153,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
 
     /**
      * @param <P>
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElementWrapper(name = "operationProperties")
@@ -167,7 +167,7 @@ public interface DeviceManagementOperation extends KapuaUpdatableEntity {
     void setInputProperties(List<DeviceManagementOperationProperty> inputProperties);
 
     /**
-     * @return
+     * @return test
      * @since 1.2.0
      */
     String getLog();

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationDAO.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationDAO.java
@@ -37,7 +37,7 @@ public class DeviceManagementOperationDAO {
      *
      * @param em
      * @param deviceManagementOperationCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static DeviceManagementOperation create(EntityManager em, DeviceManagementOperationCreator deviceManagementOperationCreator)
@@ -64,7 +64,7 @@ public class DeviceManagementOperationDAO {
      *
      * @param em
      * @param deviceManagementOperation
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static DeviceManagementOperation update(EntityManager em, DeviceManagementOperation deviceManagementOperation)
@@ -99,7 +99,7 @@ public class DeviceManagementOperationDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static DeviceManagementOperationListResult query(EntityManager em, KapuaQuery query)
@@ -112,7 +112,7 @@ public class DeviceManagementOperationDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery query)

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationDAO.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationDAO.java
@@ -37,7 +37,7 @@ public class ManagementOperationNotificationDAO {
      *
      * @param em
      * @param managementOperationNotificationCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static ManagementOperationNotification create(EntityManager em, ManagementOperationNotificationCreator managementOperationNotificationCreator)
@@ -80,7 +80,7 @@ public class ManagementOperationNotificationDAO {
      *
      * @param em
      * @param stepDefinitionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static ManagementOperationNotificationListResult query(EntityManager em, KapuaQuery stepDefinitionQuery)
@@ -93,7 +93,7 @@ public class ManagementOperationNotificationDAO {
      *
      * @param em
      * @param stepDefinitionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery stepDefinitionQuery)

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
@@ -44,7 +44,7 @@ public interface DeviceRegistryService extends KapuaEntityService<Device, Device
      *
      * @param scopeId
      * @param clientId
-     * @return
+     * @return test
      * @throws KapuaException
      */
     Device findByClientId(KapuaId scopeId, String clientId) throws KapuaException;

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
@@ -30,7 +30,7 @@ public class DeviceXmlRegistry {
     /**
      * Creates a new {@link Device}
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public Device newDevice() {
@@ -40,7 +40,7 @@ public class DeviceXmlRegistry {
     /**
      * Creates a new device creator
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public DeviceCreator newDeviceCreator() {
@@ -50,7 +50,7 @@ public class DeviceXmlRegistry {
     /**
      * Creates a new device list result
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public DeviceListResult newDeviceListResult() {

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
         "reservedUserId",
         "protocol",
         "clientIp",
-        "serverIp" }, //
+        "serverIp"}, //
         factoryClass = DeviceConnectionXmlRegistry.class, //
         factoryMethod = "newDeviceConnection")
 public interface DeviceConnection extends KapuaUpdatableEntity {
@@ -55,7 +55,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     /**
      * Get the device connection status
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "status")
     DeviceConnectionStatus getStatus();
@@ -70,7 +70,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     /**
      * Get the client identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "clientId")
     String getClientId();
@@ -85,7 +85,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     /**
      * Get the user identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -116,7 +116,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     /**
      * Get the device connection user coupling mode.
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "userCouplingMode")
     ConnectionUserCouplingMode getUserCouplingMode();
@@ -131,7 +131,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     /**
      * Get the reserved user identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "reservedUserId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -147,7 +147,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     /**
      * Get the device protocol
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "protocol")
     String getProtocol();
@@ -162,7 +162,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     /**
      * Get the client ip
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "clientIp")
     String getClientIp();
@@ -177,7 +177,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     /**
      * Get the server ip
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "serverIp")
     String getServerIp();

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
@@ -28,7 +28,7 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
     /**
      * Get the device connection status
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "status")
     DeviceConnectionStatus getStatus();
@@ -43,7 +43,7 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
     /**
      * Get the client identifier
      *
-     * @return
+     * @return test
      */
     String getClientId();
 
@@ -57,7 +57,7 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
     /**
      * Get the user identifier
      *
-     * @return
+     * @return test
      */
     KapuaId getUserId();
 
@@ -71,7 +71,7 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
     /**
      * Get the device connection user coupling mode.
      *
-     * @return
+     * @return test
      */
     ConnectionUserCouplingMode getUserCouplingMode();
 
@@ -85,7 +85,7 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
     /**
      * Get the reserved user identifier
      *
-     * @return
+     * @return test
      */
     KapuaId getReservedUserId();
 
@@ -114,7 +114,7 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
     /**
      * Get the device protocol
      *
-     * @return
+     * @return test
      */
     String getProtocol();
 
@@ -128,7 +128,7 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
     /**
      * Get the client ip
      *
-     * @return
+     * @return test
      */
     String getClientIp();
 
@@ -142,7 +142,7 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
     /**
      * Get the server ip
      *
-     * @return
+     * @return test
      */
     String getServerIp();
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
@@ -33,7 +33,7 @@ public interface DeviceConnectionService extends KapuaEntityService<DeviceConnec
      *
      * @param scopeId
      * @param clientId
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
@@ -30,7 +30,7 @@ public class DeviceConnectionXmlRegistry {
     /**
      * Creates a new {@link DeviceConnection}
      *
-     * @return
+     * @return test
      */
     public DeviceConnection newDeviceConnection() {
         return DEVICE_CONNECTION_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class DeviceConnectionXmlRegistry {
     /**
      * Creates a new device list result
      *
-     * @return
+     * @return test
      */
     public DeviceConnectionListResult newDeviceConnectionListResult() {
         return DEVICE_CONNECTION_FACTORY.newListResult();

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
@@ -66,7 +66,7 @@ public interface DeviceConnectionOption extends KapuaUpdatableEntity {
     /**
      * Get the device connection user coupling mode.
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "userCouplingMode")
     ConnectionUserCouplingMode getUserCouplingMode();
@@ -81,7 +81,7 @@ public interface DeviceConnectionOption extends KapuaUpdatableEntity {
     /**
      * Get the reserved user identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "reservedUserId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionCreator.java
@@ -26,7 +26,7 @@ public interface DeviceConnectionOptionCreator extends KapuaUpdatableEntityCreat
     /**
      * Get the device connection user coupling mode.
      *
-     * @return
+     * @return test
      */
     ConnectionUserCouplingMode getUserCouplingMode();
 
@@ -40,7 +40,7 @@ public interface DeviceConnectionOptionCreator extends KapuaUpdatableEntityCreat
     /**
      * Get the reserved user identifier
      *
-     * @return
+     * @return test
      */
     KapuaId getReservedUserId();
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionXmlRegistry.java
@@ -30,7 +30,7 @@ public class DeviceConnectionOptionXmlRegistry {
     /**
      * Creates a new {@link DeviceConnectionOption}
      *
-     * @return
+     * @return test
      */
     public DeviceConnectionOption newDeviceConnectionOption() {
         return DEVICE_CONNECTION_OPTION_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class DeviceConnectionOptionXmlRegistry {
     /**
      * Creates a new device connection options list result
      *
-     * @return
+     * @return test
      */
     public DeviceConnectionOptionListResult newDeviceConnectionOptionListResult() {
         return DEVICE_CONNECTION_OPTION_FACTORY.newListResult();

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
@@ -77,7 +77,7 @@ public interface DeviceEvent extends KapuaEntity {
     /**
      * Get the sent on date
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "sentOn")
@@ -95,7 +95,7 @@ public interface DeviceEvent extends KapuaEntity {
     /**
      * Get the received on date
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "receivedOn")
@@ -113,7 +113,7 @@ public interface DeviceEvent extends KapuaEntity {
     /**
      * Get the device position
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "position")
@@ -130,7 +130,7 @@ public interface DeviceEvent extends KapuaEntity {
     /**
      * Get resource
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "resource")
@@ -146,7 +146,7 @@ public interface DeviceEvent extends KapuaEntity {
     /**
      * Get action
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "action")
@@ -163,7 +163,7 @@ public interface DeviceEvent extends KapuaEntity {
     /**
      * Get response code
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "responseCode")
@@ -180,7 +180,7 @@ public interface DeviceEvent extends KapuaEntity {
     /**
      * Get event message
      *
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "eventMessage")

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
@@ -30,7 +30,7 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
     /**
      * Get the device identifier
      *
-     * @return
+     * @return test
      */
     KapuaId getDeviceId();
 
@@ -44,7 +44,7 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
     /**
      * Get the sent on date
      *
-     * @return
+     * @return test
      */
     Date getSentOn();
 
@@ -58,7 +58,7 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
     /**
      * Get the received on date
      *
-     * @return
+     * @return test
      */
     Date getReceivedOn();
 
@@ -72,7 +72,7 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
     /**
      * Get device position
      *
-     * @return
+     * @return test
      */
     KapuaPosition getPosition();
 
@@ -86,7 +86,7 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
     /**
      * Get resource
      *
-     * @return
+     * @return test
      */
     String getResource();
 
@@ -100,7 +100,7 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
     /**
      * GHet action
      *
-     * @return
+     * @return test
      */
     KapuaMethod getAction();
 
@@ -114,7 +114,7 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
     /**
      * Get response code
      *
-     * @return
+     * @return test
      */
     KapuaResponseCode getResponseCode();
 
@@ -128,7 +128,7 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
     /**
      * Get event message
      *
-     * @return
+     * @return test
      */
     String getEventMessage();
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
@@ -30,7 +30,7 @@ public class DeviceEventXmlRegistry {
     /**
      * Creates a new device event
      *
-     * @return
+     * @return test
      */
     public DeviceEvent newDeviceEvent() {
         return DEVICE_EVENT_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class DeviceEventXmlRegistry {
     /**
      * Creates a new device event list result
      *
-     * @return
+     * @return test
      */
     public DeviceEventListResult newDeviceEventListResult() {
         return DEVICE_EVENT_FACTORY.newListResult();

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/KapuaDeviceRegistrySettings.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/KapuaDeviceRegistrySettings.java
@@ -30,7 +30,7 @@ public class KapuaDeviceRegistrySettings extends AbstractKapuaSetting<KapuaDevic
     /**
      * Return the device registry setting instance (singleton)
      *
-     * @return
+     * @return test
      */
     public static KapuaDeviceRegistrySettings getInstance() {
         return INSTANCE;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidation.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidation.java
@@ -65,7 +65,7 @@ public final class DeviceValidation {
      * Validates the device creates precondition
      *
      * @param deviceCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static DeviceCreator validateCreatePreconditions(DeviceCreator deviceCreator) throws KapuaException {
@@ -88,7 +88,7 @@ public final class DeviceValidation {
      * Validates the device updates precondition
      *
      * @param device
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static Device validateUpdatePreconditions(Device device) throws KapuaException {

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
@@ -34,7 +34,7 @@ public class DeviceConnectionDAO extends ServiceDAO {
      *
      * @param em
      * @param deviceConnectionCreator
-     * @return
+     * @return test
      */
     public static DeviceConnection create(EntityManager em, DeviceConnectionCreator deviceConnectionCreator) {
         DeviceConnection deviceConnection = new DeviceConnectionImpl(deviceConnectionCreator.getScopeId());
@@ -56,7 +56,7 @@ public class DeviceConnectionDAO extends ServiceDAO {
      *
      * @param em
      * @param deviceConnection
-     * @return
+     * @return test
      * @throws KapuaEntityNotFoundException If the {@link DeviceConnection} is not found.
      */
     public static DeviceConnection update(EntityManager em, DeviceConnection deviceConnection)
@@ -71,7 +71,7 @@ public class DeviceConnectionDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param deviceConnectionId
-     * @return
+     * @return test
      */
     public static DeviceConnection find(EntityManager em, KapuaId scopeId, KapuaId deviceConnectionId) {
         return ServiceDAO.find(em, DeviceConnectionImpl.class, scopeId, deviceConnectionId);
@@ -82,7 +82,7 @@ public class DeviceConnectionDAO extends ServiceDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static DeviceConnectionListResult query(EntityManager em, KapuaQuery query)
@@ -95,7 +95,7 @@ public class DeviceConnectionDAO extends ServiceDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery query)

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionDAO.java
@@ -33,7 +33,7 @@ public class DeviceConnectionOptionDAO extends ServiceDAO {
      *
      * @param em
      * @param deviceConnectionOptions
-     * @return
+     * @return test
      * @throws KapuaEntityNotFoundException If the {@link DeviceConnectionOption} is not found.
      */
     public static DeviceConnectionOption update(EntityManager em, DeviceConnectionOption deviceConnectionOptions)
@@ -48,7 +48,7 @@ public class DeviceConnectionOptionDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param deviceConnectionOptionsId
-     * @return
+     * @return test
      */
     public static DeviceConnectionOption find(EntityManager em, KapuaId scopeId, KapuaId deviceConnectionOptionsId) {
         return ServiceDAO.find(em, DeviceConnectionOptionImpl.class, scopeId, deviceConnectionOptionsId);
@@ -59,7 +59,7 @@ public class DeviceConnectionOptionDAO extends ServiceDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static DeviceConnectionOptionListResult query(EntityManager em, KapuaQuery query)
@@ -72,7 +72,7 @@ public class DeviceConnectionOptionDAO extends ServiceDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery query)

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDAO.java
@@ -34,7 +34,7 @@ public class DeviceEventDAO extends ServiceDAO {
      *
      * @param em
      * @param deviceEventCreator
-     * @return
+     * @return test
      */
     public static DeviceEvent create(EntityManager em, DeviceEventCreator deviceEventCreator) {
         DeviceEvent deviceEvent = new DeviceEventImpl(deviceEventCreator.getScopeId());
@@ -56,7 +56,7 @@ public class DeviceEventDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param deviceEventId
-     * @return
+     * @return test
      */
     public static DeviceEvent find(EntityManager em, KapuaId scopeId, KapuaId deviceEventId) {
         return ServiceDAO.find(em, DeviceEventImpl.class, scopeId, deviceEventId);
@@ -67,7 +67,7 @@ public class DeviceEventDAO extends ServiceDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static DeviceEventListResult query(EntityManager em, KapuaQuery query)
@@ -80,7 +80,7 @@ public class DeviceEventDAO extends ServiceDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery query)

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
@@ -38,7 +38,7 @@ public class DeviceDAO extends ServiceDAO {
      *
      * @param em
      * @param deviceCreator
-     * @return
+     * @return test
      */
     public static Device create(EntityManager em, DeviceCreator deviceCreator) {
         Device device = new DeviceImpl(deviceCreator.getScopeId());
@@ -81,7 +81,7 @@ public class DeviceDAO extends ServiceDAO {
      *
      * @param em
      * @param device
-     * @return
+     * @return test
      * @throws KapuaEntityNotFoundException If {@link Device} is not found.
      */
     public static Device update(EntityManager em, Device device) throws KapuaEntityNotFoundException {
@@ -95,7 +95,7 @@ public class DeviceDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param deviceId
-     * @return
+     * @return test
      */
     public static Device find(EntityManager em, KapuaId scopeId, KapuaId deviceId) {
         return ServiceDAO.find(em, DeviceImpl.class, scopeId, deviceId);
@@ -106,7 +106,7 @@ public class DeviceDAO extends ServiceDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static DeviceListResult query(EntityManager em, KapuaQuery query)
@@ -155,7 +155,7 @@ public class DeviceDAO extends ServiceDAO {
      *
      * @param em
      * @param query
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery query)

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoXmlRegistry.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoXmlRegistry.java
@@ -25,7 +25,7 @@ public class EndpointInfoXmlRegistry {
     /**
      * Creates a new {@link EndpointInfo} instance
      *
-     * @return
+     * @return test
      */
     public EndpointInfo newEntity() {
         return FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class EndpointInfoXmlRegistry {
     /**
      * Creates a new {@link EndpointInfoCreator} instance
      *
-     * @return
+     * @return test
      */
     public EndpointInfoCreator newCreator() {
         return FACTORY.newCreator(null);
@@ -43,7 +43,7 @@ public class EndpointInfoXmlRegistry {
     /**
      * Creates a new {@link EndpointInfoListResult}
      *
-     * @return
+     * @return test
      */
     public EndpointInfoListResult newListResult() {
         return FACTORY.newListResult();
@@ -52,7 +52,7 @@ public class EndpointInfoXmlRegistry {
     /**
      * Creates a new {@link EndpointInfoQuery}
      *
-     * @return
+     * @return test
      */
     public EndpointInfoQuery newQuery() {
         return FACTORY.newQuery(null);

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobXmlRegistry.java
@@ -30,7 +30,7 @@ public class JobXmlRegistry {
     /**
      * Creates a new job instance
      *
-     * @return
+     * @return test
      */
     public Job newJob() {
         return JOB_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class JobXmlRegistry {
     /**
      * Creates a new job creator instance
      *
-     * @return
+     * @return test
      */
     public JobCreator newJobCreator() {
         return JOB_FACTORY.newCreator(null);
@@ -48,7 +48,7 @@ public class JobXmlRegistry {
     /**
      * Creates a new job list result instance
      *
-     * @return
+     * @return test
      */
     public JobListResult newJobListResult() {
         return JOB_FACTORY.newListResult();

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -43,7 +43,7 @@ public interface JobExecution extends KapuaUpdatableEntity {
     }
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     KapuaId getJobId();
@@ -55,7 +55,7 @@ public interface JobExecution extends KapuaUpdatableEntity {
     void setJobId(KapuaId jobId);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     Date getStartedOn();
@@ -67,7 +67,7 @@ public interface JobExecution extends KapuaUpdatableEntity {
     void setStartedOn(Date startedOn);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     Date getEndedOn();
@@ -79,7 +79,7 @@ public interface JobExecution extends KapuaUpdatableEntity {
     void setEndedOn(Date endedOn);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     @XmlElement(name = "targetIds")
@@ -93,7 +93,7 @@ public interface JobExecution extends KapuaUpdatableEntity {
     void setTargetIds(Set<KapuaId> tagTargetIds);
 
     /**
-     * @return
+     * @return test
      * @since 1.1.0
      */
     String getLog();

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
@@ -36,7 +36,7 @@ import java.util.Set;
 public interface JobExecutionCreator extends KapuaUpdatableEntityCreator<JobExecution> {
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     KapuaId getJobId();
@@ -48,7 +48,7 @@ public interface JobExecutionCreator extends KapuaUpdatableEntityCreator<JobExec
     void setJobId(KapuaId jobId);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     Date getStartedOn();
@@ -60,7 +60,7 @@ public interface JobExecutionCreator extends KapuaUpdatableEntityCreator<JobExec
     void setStartedOn(Date startedOn);
 
     /**
-     * @return
+     * @return test
      * @since 1.1.0
      */
     @XmlElement(name = "targetIds")

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionXmlRegistry.java
@@ -30,7 +30,7 @@ public class JobExecutionXmlRegistry {
     /**
      * Creates a new job instance
      *
-     * @return
+     * @return test
      */
     public JobExecution newJobExecution() {
         return JOB_EXECUTION_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class JobExecutionXmlRegistry {
     /**
      * Creates a new job creator instance
      *
-     * @return
+     * @return test
      */
     public JobExecutionCreator newJobExecutionCreator() {
         return JOB_EXECUTION_FACTORY.newCreator(null);
@@ -48,7 +48,7 @@ public class JobExecutionXmlRegistry {
     /**
      * Creates a new job list result instance
      *
-     * @return
+     * @return test
      */
     public JobExecutionListResult newJobExecutionListResult() {
         return JOB_EXECUTION_FACTORY.newListResult();

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepXmlRegistry.java
@@ -31,7 +31,7 @@ public class JobStepXmlRegistry {
     /**
      * Creates a new job instance
      *
-     * @return
+     * @return test
      */
     public JobStep newJobStep() {
         return JOB_STEP_FACTORY.newEntity(null);
@@ -40,7 +40,7 @@ public class JobStepXmlRegistry {
     /**
      * Creates a new job creator instance
      *
-     * @return
+     * @return test
      */
     public JobStepCreator newJobStepCreator() {
         return JOB_STEP_FACTORY.newCreator(null);
@@ -49,7 +49,7 @@ public class JobStepXmlRegistry {
     /**
      * Creates a new job list result instance
      *
-     * @return
+     * @return test
      */
     public JobStepListResult newJobStepListResult() {
         return JOB_STEP_FACTORY.newListResult();

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionXmlRegistry.java
@@ -30,7 +30,7 @@ public class JobStepDefinitionXmlRegistry {
     /**
      * Creates a new job instance
      *
-     * @return
+     * @return test
      */
     public JobStepDefinition newJobStepDefinition() {
         return JOB_STEP_DEFINITION_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class JobStepDefinitionXmlRegistry {
     /**
      * Creates a new job creator instance
      *
-     * @return
+     * @return test
      */
     public JobStepDefinitionCreator newJobStepDefinitionCreator() {
         return JOB_STEP_DEFINITION_FACTORY.newCreator(null);
@@ -48,7 +48,7 @@ public class JobStepDefinitionXmlRegistry {
     /**
      * Creates a new job list result instance
      *
-     * @return
+     * @return test
      */
     public JobStepDefinitionListResult newJobStepDefinitionListResult() {
         return JOB_STEP_DEFINITION_FACTORY.newListResult();

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
@@ -30,7 +30,7 @@ import javax.xml.bind.annotation.XmlType;
 public interface JobStepProperty {
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getName();
@@ -42,7 +42,7 @@ public interface JobStepProperty {
     void setName(String name);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getPropertyType();
@@ -54,7 +54,7 @@ public interface JobStepProperty {
     void setPropertyType(String propertyType);
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getPropertyValue();
@@ -66,7 +66,7 @@ public interface JobStepProperty {
     void setPropertyValue(String propertyValue);
 
     /**
-     * @return
+     * @return test
      * @since 1.1.0
      */
     String getExampleValue();
@@ -110,7 +110,7 @@ public interface JobStepProperty {
     void setSecret(Boolean se);
 
     /**
-     * @return
+     * @return test
      * @since 1.5.0
      */
     Integer getMinLength();
@@ -122,7 +122,7 @@ public interface JobStepProperty {
     void setMinLength(Integer minLength);
 
     /**
-     * @return
+     * @return test
      * @since 1.5.0
      */
     Integer getMaxLength();
@@ -134,7 +134,7 @@ public interface JobStepProperty {
     void setMaxLength(Integer maxLength);
 
     /**
-     * @return
+     * @return test
      * @since 1.5.0
      */
     String getMinValue();
@@ -146,7 +146,7 @@ public interface JobStepProperty {
     void setMinValue(String minValue);
 
     /**
-     * @return
+     * @return test
      * @since 1.5.0
      */
     String getMaxValue();
@@ -158,7 +158,7 @@ public interface JobStepProperty {
     void setMaxValue(String maxValue);
 
     /**
-     * @return
+     * @return test
      * @since 1.5.0
      */
     String getValidationRegex();

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetXmlRegistry.java
@@ -30,7 +30,7 @@ public class JobTargetXmlRegistry {
     /**
      * Creates a new job instance
      *
-     * @return
+     * @return test
      */
     public JobTarget newJobTarget() {
         return JOB_TARGET_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class JobTargetXmlRegistry {
     /**
      * Creates a new job creator instance
      *
-     * @return
+     * @return test
      */
     public JobTargetCreator newJobTargetCreator() {
         return JOB_TARGET_FACTORY.newCreator(null);
@@ -48,7 +48,7 @@ public class JobTargetXmlRegistry {
     /**
      * Creates a new job list result instance
      *
-     * @return
+     * @return test
      */
     public JobTargetListResult newJobTargetListResult() {
         return JOB_TARGET_FACTORY.newListResult();

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionDAO.java
@@ -37,7 +37,7 @@ public class JobExecutionDAO {
      *
      * @param em
      * @param jobExecutionCreator
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */
@@ -58,7 +58,7 @@ public class JobExecutionDAO {
      *
      * @param em
      * @param jobExecution
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */
@@ -77,7 +77,7 @@ public class JobExecutionDAO {
      * @param em
      * @param scopeId
      * @param jobExecutionId
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public static JobExecution find(EntityManager em, KapuaId scopeId, KapuaId jobExecutionId) {
@@ -89,7 +89,7 @@ public class JobExecutionDAO {
      *
      * @param em
      * @param jobExecutionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */
@@ -103,7 +103,7 @@ public class JobExecutionDAO {
      *
      * @param em
      * @param jobExecutionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobDAO.java
@@ -37,7 +37,7 @@ public class JobDAO {
      *
      * @param em
      * @param jobCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static Job create(EntityManager em, JobCreator jobCreator)
@@ -57,7 +57,7 @@ public class JobDAO {
      *
      * @param em
      * @param job
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static Job update(EntityManager em, Job job)
@@ -75,7 +75,7 @@ public class JobDAO {
      * @param em
      * @param scopeId
      * @param jobId
-     * @return
+     * @return test
      */
     public static Job find(EntityManager em, KapuaId scopeId, KapuaId jobId) {
         return ServiceDAO.find(em, JobImpl.class, scopeId, jobId);
@@ -86,7 +86,7 @@ public class JobDAO {
      *
      * @param em
      * @param name
-     * @return
+     * @return test
      */
     public static Job findByName(EntityManager em, String name) {
         return ServiceDAO.findByName(em, JobImpl.class, name);
@@ -97,7 +97,7 @@ public class JobDAO {
      *
      * @param em
      * @param jobQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobListResult query(EntityManager em, KapuaQuery jobQuery)
@@ -110,7 +110,7 @@ public class JobDAO {
      *
      * @param em
      * @param jobQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery jobQuery)

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionDAO.java
@@ -37,7 +37,7 @@ public class JobStepDefinitionDAO {
      *
      * @param em
      * @param jobStepDefinitionCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobStepDefinition create(EntityManager em, JobStepDefinitionCreator jobStepDefinitionCreator)
@@ -62,7 +62,7 @@ public class JobStepDefinitionDAO {
      *
      * @param em
      * @param jobStepDefinition
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobStepDefinition update(EntityManager em, JobStepDefinition jobStepDefinition)
@@ -90,7 +90,7 @@ public class JobStepDefinitionDAO {
      *
      * @param em
      * @param stepDefinitionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobStepDefinitionListResult query(EntityManager em, KapuaQuery stepDefinitionQuery)
@@ -103,7 +103,7 @@ public class JobStepDefinitionDAO {
      *
      * @param em
      * @param stepDefinitionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery stepDefinitionQuery)

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepDAO.java
@@ -37,7 +37,7 @@ public class JobStepDAO {
      *
      * @param em
      * @param jobStepCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobStep create(EntityManager em, JobStepCreator jobStepCreator)
@@ -61,7 +61,7 @@ public class JobStepDAO {
      *
      * @param em
      * @param jobStep
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobStep update(EntityManager em, JobStep jobStep)
@@ -79,7 +79,7 @@ public class JobStepDAO {
      * @param em
      * @param scopeId
      * @param jobStepId
-     * @return
+     * @return test
      */
     public static JobStep find(EntityManager em, KapuaId scopeId, KapuaId jobStepId) {
         return ServiceDAO.find(em, JobStepImpl.class, scopeId, jobStepId);
@@ -90,7 +90,7 @@ public class JobStepDAO {
      *
      * @param em
      * @param name
-     * @return
+     * @return test
      */
     public static JobStep findByName(EntityManager em, String name) {
         return ServiceDAO.findByName(em, JobStepImpl.class, name);
@@ -101,7 +101,7 @@ public class JobStepDAO {
      *
      * @param em
      * @param jobStepQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobStepListResult query(EntityManager em, KapuaQuery jobStepQuery)
@@ -114,7 +114,7 @@ public class JobStepDAO {
      *
      * @param em
      * @param jobStepQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery jobStepQuery)

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetDAO.java
@@ -38,7 +38,7 @@ public class JobTargetDAO {
      *
      * @param em
      * @param jobTargetCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobTarget create(EntityManager em, JobTargetCreator jobTargetCreator)
@@ -60,7 +60,7 @@ public class JobTargetDAO {
      *
      * @param em
      * @param jobTarget
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobTarget update(EntityManager em, JobTarget jobTarget)
@@ -78,7 +78,7 @@ public class JobTargetDAO {
      * @param em
      * @param scopeId
      * @param jobTargetId
-     * @return
+     * @return test
      */
     public static JobTarget find(EntityManager em, KapuaId scopeId, KapuaId jobTargetId) {
         return ServiceDAO.find(em, JobTargetImpl.class, scopeId, jobTargetId);
@@ -89,7 +89,7 @@ public class JobTargetDAO {
      *
      * @param em
      * @param jobTargetQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static JobTargetListResult query(EntityManager em, KapuaQuery jobTargetQuery)
@@ -102,7 +102,7 @@ public class JobTargetDAO {
      *
      * @param em
      * @param jobTargetQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery jobTargetQuery)

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
@@ -24,13 +24,13 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "accessTokenCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "tokenId" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newAccessTokenCredentials")
+@XmlType(propOrder = {"tokenId"}, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newAccessTokenCredentials")
 public interface AccessTokenCredentials extends SessionCredentials {
 
     /**
      * Return the token id
      *
-     * @return
+     * @return test
      */
     String getTokenId();
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
@@ -25,13 +25,13 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "apiKeyCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "apiKey" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newApiKeyCredentials")
+@XmlType(propOrder = {"apiKey"}, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newApiKeyCredentials")
 public interface ApiKeyCredentials extends LoginCredentials {
 
     /**
      * return the api key
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "apiKey")
     String getApiKey();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationXmlRegistry.java
@@ -23,7 +23,7 @@ public class AuthenticationXmlRegistry {
     /**
      * Creates a new {@link UsernamePasswordCredentials} instance
      *
-     * @return
+     * @return test
      */
     public UsernamePasswordCredentials newUsernamePasswordCredentials() {
         return CREDENTIALS_FACTORY.newUsernamePasswordCredentials();
@@ -32,7 +32,7 @@ public class AuthenticationXmlRegistry {
     /**
      * Creates a new {@link ApiKeyCredentials} instance
      *
-     * @return
+     * @return test
      */
     public ApiKeyCredentials newApiKeyCredentials() {
         return CREDENTIALS_FACTORY.newApiKeyCredentials(null);
@@ -41,7 +41,7 @@ public class AuthenticationXmlRegistry {
     /**
      * Creates a new {@link JwtCredentials} instance
      *
-     * @return
+     * @return test
      */
     public JwtCredentials newJwtCredentials() {
         return CREDENTIALS_FACTORY.newJwtCredentials(null, null);
@@ -50,7 +50,7 @@ public class AuthenticationXmlRegistry {
     /**
      * Creates a new {@link AccessTokenCredentials} instance
      *
-     * @return
+     * @return test
      */
     public AccessTokenCredentials newAccessTokenCredentials() {
         return CREDENTIALS_FACTORY.newAccessTokenCredentials(null);
@@ -59,7 +59,7 @@ public class AuthenticationXmlRegistry {
     /**
      * Creates a new {@link RefreshTokenCredentials} instance
      *
-     * @return
+     * @return test
      */
     public RefreshTokenCredentials newRefreshTokenCredentials() {
         return CREDENTIALS_FACTORY.newRefreshTokenCredentials(null, null);

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
@@ -42,7 +42,7 @@ public interface CredentialsFactory extends KapuaObjectFactory {
      * Creates a new {@link ApiKeyCredentials} instance based on provided api key
      *
      * @param apiKey
-     * @return
+     * @return test
      */
     ApiKeyCredentials newApiKeyCredentials(String apiKey);
 
@@ -51,7 +51,7 @@ public interface CredentialsFactory extends KapuaObjectFactory {
      *
      * @param jwt
      * @param idToken the OpenID Connect idToken, used for the logout
-     * @return
+     * @return test
      */
     JwtCredentials newJwtCredentials(String jwt, String idToken);
 
@@ -59,7 +59,7 @@ public interface CredentialsFactory extends KapuaObjectFactory {
      * Creates a new {@link AccessTokenCredentials} instance based on provided tokenId
      *
      * @param tokenId
-     * @return
+     * @return test
      */
     AccessTokenCredentials newAccessTokenCredentials(String tokenId);
 
@@ -67,7 +67,7 @@ public interface CredentialsFactory extends KapuaObjectFactory {
      * Creates a new {@link RefreshTokenCredentials} instance based on provided tokenId and refresh token
      *
      * @param tokenId
-     * @return
+     * @return test
      */
     RefreshTokenCredentials newRefreshTokenCredentials(String tokenId, String refreshToken);
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
@@ -25,13 +25,13 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "jwtCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "accessToken", "idToken" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newJwtCredentials")
+@XmlType(propOrder = {"accessToken", "idToken"}, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newJwtCredentials")
 public interface JwtCredentials extends LoginCredentials {
 
     /**
      * Gets the OpenID Connect accessToken
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "accessToken")
     String getAccessToken();
@@ -46,7 +46,7 @@ public interface JwtCredentials extends LoginCredentials {
     /**
      * Gets the OpenID Connect idToken
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "idToken")
     String getIdToken();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/KapuaPrincipal.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/KapuaPrincipal.java
@@ -28,35 +28,35 @@ public interface KapuaPrincipal extends Principal, java.io.Serializable {
     /**
      * Return the token identifier
      *
-     * @return
+     * @return test
      */
     String getTokenId();
 
     /**
      * Return the user id
      *
-     * @return
+     * @return test
      */
     KapuaId getUserId();
 
     /**
      * Retur the account it
      *
-     * @return
+     * @return test
      */
     KapuaId getAccountId();
 
     /**
      * Return the remote client ip from which the user should be connected
      *
-     * @return
+     * @return test
      */
     String getClientIp();
 
     /**
      * Return the client identifiers from which the user should be connected
      *
-     * @return
+     * @return test
      */
     String getClientId();
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
@@ -25,13 +25,13 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "refreshTokenCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "tokenId", "refreshToken" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newRefreshTokenCredentials")
+@XmlType(propOrder = {"tokenId", "refreshToken"}, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newRefreshTokenCredentials")
 public interface RefreshTokenCredentials extends LoginCredentials {
 
     /**
      * return the token id
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "tokenId")
     String getTokenId();
@@ -46,7 +46,7 @@ public interface RefreshTokenCredentials extends LoginCredentials {
     /**
      * return the refresh token
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "refreshToken")
     String getRefreshToken();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
@@ -33,7 +33,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "credential")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "userId",
+@XmlType(propOrder = {"userId",
         "credentialType",
         "credentialKey",
         "status",
@@ -41,7 +41,7 @@ import java.util.Date;
         "loginFailures",
         "firstLoginFailure",
         "loginFailuresReset",
-        "lockoutReset" }, //
+        "lockoutReset"}, //
         factoryClass = CredentialXmlRegistry.class, //
         factoryMethod = "newCredential") //
 public interface Credential extends KapuaUpdatableEntity {
@@ -56,7 +56,7 @@ public interface Credential extends KapuaUpdatableEntity {
     /**
      * Return the user identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -70,7 +70,7 @@ public interface Credential extends KapuaUpdatableEntity {
     /**
      * Return the credential type
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "credentialType")
     CredentialType getCredentialType();
@@ -83,7 +83,7 @@ public interface Credential extends KapuaUpdatableEntity {
     /**
      * Return the credential key
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "credentialKey")
     String getCredentialKey();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
@@ -32,17 +32,17 @@ import java.util.Date;
  */
 @XmlRootElement(name = "credentialCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "userId",
+@XmlType(propOrder = {"userId",
         "credentialType",
         "credentialPlainKey",
         "credentialStatus",
-        "expirationDate" }, factoryClass = CredentialXmlRegistry.class, factoryMethod = "newCredentialCreator")
+        "expirationDate"}, factoryClass = CredentialXmlRegistry.class, factoryMethod = "newCredentialCreator")
 public interface CredentialCreator extends KapuaEntityCreator<Credential> {
 
     /**
      * Return the user identifier
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -59,7 +59,7 @@ public interface CredentialCreator extends KapuaEntityCreator<Credential> {
      * Return the credential type.<br>
      * The returned object will depend on the authentication algorithm.
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "credentialType")
     CredentialType getCredentialType();
@@ -74,7 +74,7 @@ public interface CredentialCreator extends KapuaEntityCreator<Credential> {
     /**
      * Return the plain credential (unencrypted value).
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "credentialKey")
     String getCredentialPlainKey();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
@@ -33,7 +33,7 @@ public interface CredentialService extends KapuaEntityService<Credential, Creden
      *
      * @param scopeId
      * @param userId
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0
      */
@@ -70,9 +70,10 @@ public interface CredentialService extends KapuaEntityService<Credential, Creden
 
     /**
      * Returns the minimum password length according to account setting and system default
-     * @param scopeId           The id of the Account to check the setting
-     * @return                  The minimum required password length
-     * @throws KapuaException   When something goes wrong
+     *
+     * @param scopeId The id of the Account to check the setting
+     * @return The minimum required password length
+     * @throws KapuaException When something goes wrong
      */
     int getMinimumPasswordLength(KapuaId scopeId) throws KapuaException;
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialXmlRegistry.java
@@ -25,7 +25,7 @@ public class CredentialXmlRegistry {
     /**
      * Creates a new credential instance
      *
-     * @return
+     * @return test
      */
     public Credential newCredential() {
         return CREDENTIAL_FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class CredentialXmlRegistry {
     /**
      * Creates a new credential list result instance
      *
-     * @return
+     * @return test
      */
     public CredentialListResult newCredentialListResult() {
         return CREDENTIAL_FACTORY.newListResult();
@@ -43,7 +43,7 @@ public class CredentialXmlRegistry {
     /**
      * Creates a new credential creator instance
      *
-     * @return
+     * @return test
      */
     public CredentialCreator newCredentialCreator() {
         return CREDENTIAL_FACTORY.newCreator(null, null, null, null, null, null);

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOption.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOption.java
@@ -63,7 +63,7 @@ public interface MfaOption extends KapuaUpdatableEntity {
     /**
      * Return the {@link MfaOption} key
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "mfaSecretKey")
     String getMfaSecretKey();
@@ -78,7 +78,7 @@ public interface MfaOption extends KapuaUpdatableEntity {
     /**
      * Return the trust key
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "trustKey")
     String getTrustKey();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionCreator.java
@@ -52,7 +52,7 @@ public interface MfaOptionCreator extends KapuaEntityCreator<MfaOption> {
     /**
      * Return the {@link MfaOption} key
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "mfaSecretKey")
     String getMfaSecretKey();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionXmlRegistry.java
@@ -25,7 +25,7 @@ public class MfaOptionXmlRegistry {
     /**
      * Creates a new {@link MfaOption} instance
      *
-     * @return
+     * @return test
      */
     public MfaOption newMfaOption() {
         return MFA_OPTION_FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class MfaOptionXmlRegistry {
     /**
      * Creates a new {@link MfaOption} list result instance
      *
-     * @return
+     * @return test
      */
     public MfaOptionListResult newMfaOptionListResult() {
         return MFA_OPTION_FACTORY.newListResult();
@@ -43,7 +43,7 @@ public class MfaOptionXmlRegistry {
     /**
      * Creates a new {@link MfaOption} creator instance
      *
-     * @return
+     * @return test
      */
     public MfaOptionCreator newMfaOptionCreator() {
         return MFA_OPTION_FACTORY.newCreator(null, null, null);

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCode.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCode.java
@@ -59,7 +59,7 @@ public interface ScratchCode extends KapuaUpdatableEntity {
     /**
      * Return the scratch code
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "scratchCode")
     String getCode();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeCreator.java
@@ -34,7 +34,7 @@ public interface ScratchCodeCreator extends KapuaEntityCreator<ScratchCode> {
     /**
      * Return the {@link KapuaId} of the corresponding {@link MfaOption}
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "mfaOptionId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -50,7 +50,7 @@ public interface ScratchCodeCreator extends KapuaEntityCreator<ScratchCode> {
     /**
      * Return the scratch code
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "scratchCode")
     String getCode();

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeService.java
@@ -29,7 +29,7 @@ public interface ScratchCodeService extends KapuaEntityService<ScratchCode, Scra
      * The scratch code provided within the scratchCodeCreator parameter is ignored.
      *
      * @param scratchCodeCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     ScratchCodeListResult createAllScratchCodes(ScratchCodeCreator scratchCodeCreator) throws KapuaException;
@@ -39,7 +39,7 @@ public interface ScratchCodeService extends KapuaEntityService<ScratchCode, Scra
      *
      * @param scopeId
      * @param mfaOptionId
-     * @return
+     * @return test
      * @throws KapuaException
      */
     ScratchCodeListResult findByMfaOptionId(KapuaId scopeId, KapuaId mfaOptionId) throws KapuaException;

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeXmlRegistry.java
@@ -25,7 +25,7 @@ public class ScratchCodeXmlRegistry {
     /**
      * Creates a new {@link ScratchCode} instance
      *
-     * @return
+     * @return test
      */
     public ScratchCode newScratchCode() {
         return SCRATCH_CODE_FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class ScratchCodeXmlRegistry {
     /**
      * Creates a new {@link ScratchCodeListResult} instance
      *
-     * @return
+     * @return test
      */
     public ScratchCodeListResult newScratchCodeListResult() {
         return SCRATCH_CODE_FACTORY.newListResult();
@@ -43,7 +43,7 @@ public class ScratchCodeXmlRegistry {
     /**
      * Creates a new {@link ScratchCodeCreator} instance
      *
-     * @return
+     * @return test
      */
     public ScratchCodeCreator newScratchCodeCreator() {
         return SCRATCH_CODE_FACTORY.newCreator(null, null, null);

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
@@ -30,7 +30,7 @@ public interface AccessTokenService extends KapuaEntityService<AccessToken, Acce
      *
      * @param scopeId
      * @param userId
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0
      */
@@ -40,7 +40,7 @@ public interface AccessTokenService extends KapuaEntityService<AccessToken, Acce
      * Find the access token by the given tokenId.
      *
      * @param tokenId
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0
      */

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoXmlRegistry.java
@@ -25,7 +25,7 @@ public class AccessInfoXmlRegistry {
     /**
      * Creates a new access info instance
      *
-     * @return
+     * @return test
      */
     public AccessInfo newAccessInfo() {
         return ACCESS_INFO_FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class AccessInfoXmlRegistry {
     /**
      * Creates a new access info creator instance
      *
-     * @return
+     * @return test
      */
     public AccessInfoCreator newAccessInfoCreator() {
         return ACCESS_INFO_FACTORY.newCreator(null);
@@ -43,7 +43,7 @@ public class AccessInfoXmlRegistry {
     /**
      * Creates a new {@link AccessInfoListResult} instance
      *
-     * @return
+     * @return test
      */
     public AccessInfoListResult newAccessInfoListResult() {
         return ACCESS_INFO_FACTORY.newListResult();

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionXmlRegistry.java
@@ -25,7 +25,7 @@ public class AccessPermissionXmlRegistry {
     /**
      * Creates a new {@link AccessPermission} instance
      *
-     * @return
+     * @return test
      */
     public AccessPermission newAccessPermission() {
         return ACCESS_PERMISSION_FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class AccessPermissionXmlRegistry {
     /**
      * Creates a new {@link AccessPermission} instance
      *
-     * @return
+     * @return test
      */
     public AccessPermissionCreator newCreator() {
         return ACCESS_PERMISSION_FACTORY.newCreator(null);
@@ -43,7 +43,7 @@ public class AccessPermissionXmlRegistry {
     /**
      * Creates a new {@link AccessPermission} instance
      *
-     * @return
+     * @return test
      */
     public AccessPermissionListResult newAccessPermissionListResult() {
         return ACCESS_PERMISSION_FACTORY.newListResult();

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleXmlRegistry.java
@@ -25,7 +25,7 @@ public class AccessRoleXmlRegistry {
     /**
      * Creates a new {@link AccessRole} instance
      *
-     * @return
+     * @return test
      */
     public AccessRole newAccessRole() {
         return ACCESS_ROLE_FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class AccessRoleXmlRegistry {
     /**
      * Creates a new {@link AccessRole} instance
      *
-     * @return
+     * @return test
      */
     public AccessRoleCreator newCreator() {
         return ACCESS_ROLE_FACTORY.newCreator(null);
@@ -43,7 +43,7 @@ public class AccessRoleXmlRegistry {
     /**
      * Creates a new {@link AccessRole} instance
      *
-     * @return
+     * @return test
      */
     public AccessRoleListResult newAccessRoleListResult() {
         return ACCESS_ROLE_FACTORY.newListResult();

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionXmlRegistry.java
@@ -25,7 +25,7 @@ public class RolePermissionXmlRegistry {
     /**
      * Creates a new {@link RolePermission} instance
      *
-     * @return
+     * @return test
      */
     public RolePermission newRolePermission() {
         return ROLE_PERMISSION_FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class RolePermissionXmlRegistry {
     /**
      * Creates a new {@link RolePermission} instance
      *
-     * @return
+     * @return test
      */
     public RolePermissionCreator newCreator() {
         return ROLE_PERMISSION_FACTORY.newCreator(null);
@@ -43,7 +43,7 @@ public class RolePermissionXmlRegistry {
     /**
      * Creates a new {@link RolePermissionListResult} instance
      *
-     * @return
+     * @return test
      */
     public RolePermissionListResult newRolePermissionListResult() {
         return ROLE_PERMISSION_FACTORY.newListResult();

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateUsage.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateUsage.java
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.XmlType;
 public interface CertificateUsage {
 
     /**
-     * @return
+     * @return test
      * @since 1.0.0
      */
     String getName();

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoService.java
@@ -33,7 +33,7 @@ public interface CertificateInfoService extends KapuaEntityService<CertificateIn
     /**
      * @param scopeId
      * @param usage
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.1.0
      */

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/setting/KapuaCertificateSetting.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/setting/KapuaCertificateSetting.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
  * Authentication setting implementation.
  *
  * @since 1.0
- *
  */
 public class KapuaCertificateSetting extends AbstractKapuaSetting<KapuaCertificateSettingKeys> {
 
@@ -36,7 +35,7 @@ public class KapuaCertificateSetting extends AbstractKapuaSetting<KapuaCertifica
     /**
      * Return the authentication setting instance (singleton)
      *
-     * @return
+     * @return test
      */
     public static KapuaCertificateSetting getInstance() {
         return INSTANCE;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionDAO.java
@@ -32,7 +32,7 @@ public class MfaOptionDAO extends ServiceDAO {
      *
      * @param em
      * @param mfaOptionCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static MfaOption create(EntityManager em, MfaOptionCreator mfaOptionCreator) throws KapuaException {
@@ -53,7 +53,7 @@ public class MfaOptionDAO extends ServiceDAO {
      *
      * @param em
      * @param mfaOption
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static MfaOption update(EntityManager em, MfaOption mfaOption)
@@ -71,7 +71,7 @@ public class MfaOptionDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param mfaOptionId
-     * @return
+     * @return test
      */
     public static MfaOption find(EntityManager em, KapuaId scopeId, KapuaId mfaOptionId) {
         return ServiceDAO.find(em, MfaOptionImpl.class, scopeId, mfaOptionId);
@@ -82,7 +82,7 @@ public class MfaOptionDAO extends ServiceDAO {
      *
      * @param em
      * @param mfaOptionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static MfaOptionListResult query(EntityManager em, KapuaQuery mfaOptionQuery) throws KapuaException {
@@ -94,7 +94,7 @@ public class MfaOptionDAO extends ServiceDAO {
      *
      * @param em
      * @param mfaOptionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery mfaOptionQuery) throws KapuaException {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeDAO.java
@@ -34,7 +34,7 @@ public class ScratchCodeDAO extends ServiceDAO {
      *
      * @param em
      * @param scratchCodeCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static ScratchCode create(EntityManager em, ScratchCodeCreator scratchCodeCreator) throws KapuaException {
@@ -56,7 +56,7 @@ public class ScratchCodeDAO extends ServiceDAO {
      *
      * @param em
      * @param code
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static ScratchCode update(EntityManager em, ScratchCode code) throws KapuaException {
@@ -70,7 +70,7 @@ public class ScratchCodeDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param scratchCodeId
-     * @return
+     * @return test
      */
     public static ScratchCode find(EntityManager em, KapuaId scopeId, KapuaId scratchCodeId) {
         return ServiceDAO.find(em, ScratchCodeImpl.class, scopeId, scratchCodeId);
@@ -81,7 +81,7 @@ public class ScratchCodeDAO extends ServiceDAO {
      *
      * @param em
      * @param scratchCodeQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static ScratchCodeListResult query(EntityManager em, KapuaQuery scratchCodeQuery) throws KapuaException {
@@ -93,7 +93,7 @@ public class ScratchCodeDAO extends ServiceDAO {
      *
      * @param em
      * @param scratchCodeQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery scratchCodeQuery) throws KapuaException {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialDAO.java
@@ -38,7 +38,7 @@ public class CredentialDAO extends ServiceDAO {
      *
      * @param em
      * @param credentialCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static Credential create(EntityManager em, CredentialCreator credentialCreator)
@@ -48,13 +48,13 @@ public class CredentialDAO extends ServiceDAO {
         // Crypto credential
         String cryptedCredential;
         switch (credentialCreator.getCredentialType()) {
-        case API_KEY:
-            cryptedCredential = cryptApiKey(credentialCreator.getCredentialPlainKey());
-            break;
-        case PASSWORD:
-        default:
-            cryptedCredential = cryptPassword(credentialCreator.getCredentialPlainKey());
-            break;
+            case API_KEY:
+                cryptedCredential = cryptApiKey(credentialCreator.getCredentialPlainKey());
+                break;
+            case PASSWORD:
+            default:
+                cryptedCredential = cryptPassword(credentialCreator.getCredentialPlainKey());
+                break;
         }
 
         //
@@ -76,7 +76,7 @@ public class CredentialDAO extends ServiceDAO {
      *
      * @param em
      * @param credential
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static Credential update(EntityManager em, Credential credential)
@@ -94,7 +94,7 @@ public class CredentialDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param credentialId
-     * @return
+     * @return test
      */
     public static Credential find(EntityManager em, KapuaId scopeId, KapuaId credentialId) {
         return ServiceDAO.find(em, CredentialImpl.class, scopeId, credentialId);
@@ -105,7 +105,7 @@ public class CredentialDAO extends ServiceDAO {
      *
      * @param em
      * @param credentialQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static CredentialListResult query(EntityManager em, KapuaQuery credentialQuery)
@@ -118,7 +118,7 @@ public class CredentialDAO extends ServiceDAO {
      *
      * @param em
      * @param credentialQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery credentialQuery)

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfo.java
@@ -25,7 +25,6 @@ import java.util.Map;
  * Kapua {@link AuthenticationInfo} implementation
  *
  * @since 1.0
- *
  */
 public class LoginAuthenticationInfo implements AuthenticationInfo {
 
@@ -46,10 +45,10 @@ public class LoginAuthenticationInfo implements AuthenticationInfo {
      * @param credentials
      */
     public LoginAuthenticationInfo(String realmName,
-            Account account,
-            User user,
-            Credential credentials,
-            Map<String, Object> credentialServiceConfig) {
+                                   Account account,
+                                   User user,
+                                   Credential credentials,
+                                   Map<String, Object> credentialServiceConfig) {
         this.realmName = realmName;
         this.account = account;
         this.user = user;
@@ -60,7 +59,7 @@ public class LoginAuthenticationInfo implements AuthenticationInfo {
     /**
      * Return the user
      *
-     * @return
+     * @return test
      */
     public User getUser() {
         return user;
@@ -69,7 +68,7 @@ public class LoginAuthenticationInfo implements AuthenticationInfo {
     /**
      * Return the account
      *
-     * @return
+     * @return test
      */
     public Account getAccount() {
         return account;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
@@ -23,7 +23,6 @@ import org.eclipse.kapua.service.user.User;
  * Kapua {@link AuthenticationInfo} implementation
  *
  * @since 1.0
- *
  */
 public class SessionAuthenticationInfo implements AuthenticationInfo {
 
@@ -43,9 +42,9 @@ public class SessionAuthenticationInfo implements AuthenticationInfo {
      * @param accessToken
      */
     public SessionAuthenticationInfo(String realmName,
-            Account account,
-            User user,
-            AccessToken accessToken) {
+                                     Account account,
+                                     User user,
+                                     AccessToken accessToken) {
         this.realmName = realmName;
         this.account = account;
         this.user = user;
@@ -55,7 +54,7 @@ public class SessionAuthenticationInfo implements AuthenticationInfo {
     /**
      * Return the user
      *
-     * @return
+     * @return test
      */
     public User getUser() {
         return user;
@@ -64,7 +63,7 @@ public class SessionAuthenticationInfo implements AuthenticationInfo {
     /**
      * Return the account
      *
-     * @return
+     * @return test
      */
     public Account getAccount() {
         return account;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSetting.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
  * Authentication setting implementation.
  *
  * @since 1.0
- *
  */
 public class KapuaAuthenticationSetting extends AbstractKapuaSetting<KapuaAuthenticationSettingKeys> {
 
@@ -36,7 +35,7 @@ public class KapuaAuthenticationSetting extends AbstractKapuaSetting<KapuaAuthen
     /**
      * Return the authentication setting instance (singleton)
      *
-     * @return
+     * @return test
      */
     public static KapuaAuthenticationSetting getInstance() {
         return INSTANCE;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSetting.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
  * Crypto setting implementation.
  *
  * @since 1.0
- *
  */
 public class KapuaCryptoSetting extends AbstractKapuaSetting<KapuaCryptoSettingKeys> {
 
@@ -36,7 +35,7 @@ public class KapuaCryptoSetting extends AbstractKapuaSetting<KapuaCryptoSettingK
     /**
      * Return the crypto setting instance (singleton)
      *
-     * @return
+     * @return test
      */
     public static KapuaCryptoSetting getInstance() {
         return INSTANCE;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenDAO.java
@@ -35,7 +35,7 @@ public class AccessTokenDAO extends ServiceDAO {
      *
      * @param em
      * @param accessTokenCreator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static AccessToken create(EntityManager em, AccessTokenCreator accessTokenCreator)
@@ -57,7 +57,7 @@ public class AccessTokenDAO extends ServiceDAO {
      *
      * @param em
      * @param accessToken
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static AccessToken update(EntityManager em, AccessToken accessToken)
@@ -75,7 +75,7 @@ public class AccessTokenDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param accessTokenId
-     * @return
+     * @return test
      */
     public static AccessToken find(EntityManager em, KapuaId scopeId, KapuaId accessTokenId) {
         return ServiceDAO.find(em, AccessTokenImpl.class, scopeId, accessTokenId);
@@ -86,7 +86,7 @@ public class AccessTokenDAO extends ServiceDAO {
      *
      * @param em
      * @param tokenId
-     * @return
+     * @return test
      */
     public static AccessToken findByTokenId(EntityManager em, String tokenId) {
         return ServiceDAO.findByField(em, AccessTokenImpl.class, AccessTokenAttributes.TOKEN_ID, tokenId);
@@ -97,7 +97,7 @@ public class AccessTokenDAO extends ServiceDAO {
      *
      * @param em
      * @param accessTokenQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static AccessTokenListResult query(EntityManager em, KapuaQuery accessTokenQuery)
@@ -110,7 +110,7 @@ public class AccessTokenDAO extends ServiceDAO {
      *
      * @param em
      * @param accessTokenQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery accessTokenQuery)

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDAO.java
@@ -34,7 +34,7 @@ public class AccessInfoDAO extends ServiceDAO {
      *
      * @param em
      * @param creator
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */
@@ -51,7 +51,7 @@ public class AccessInfoDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param accessInfoId
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public static AccessInfo find(EntityManager em, KapuaId scopeId, KapuaId accessInfoId) {
@@ -63,7 +63,7 @@ public class AccessInfoDAO extends ServiceDAO {
      *
      * @param em
      * @param accessInfoQuery
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */
@@ -77,7 +77,7 @@ public class AccessInfoDAO extends ServiceDAO {
      *
      * @param em
      * @param accessInfoQuery
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionDAO.java
@@ -26,7 +26,6 @@ import org.eclipse.kapua.service.authorization.access.AccessPermissionListResult
  * {@link AccessPermission} {@link ServiceDAO}
  *
  * @since 1.0
- *
  */
 public class AccessPermissionDAO extends ServiceDAO {
 
@@ -35,7 +34,7 @@ public class AccessPermissionDAO extends ServiceDAO {
      *
      * @param em
      * @param creator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static AccessPermission create(EntityManager em, AccessPermissionCreator creator)
@@ -54,7 +53,7 @@ public class AccessPermissionDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param accessPermissionId
-     * @return
+     * @return test
      */
     public static AccessPermission find(EntityManager em, KapuaId scopeId, KapuaId accessPermissionId) {
         return ServiceDAO.find(em, AccessPermissionImpl.class, scopeId, accessPermissionId);
@@ -65,7 +64,7 @@ public class AccessPermissionDAO extends ServiceDAO {
      *
      * @param em
      * @param accessInfoPermissionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static AccessPermissionListResult query(EntityManager em, KapuaQuery accessInfoPermissionQuery)
@@ -78,7 +77,7 @@ public class AccessPermissionDAO extends ServiceDAO {
      *
      * @param em
      * @param accessPermissionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery accessPermissionQuery)
@@ -93,8 +92,7 @@ public class AccessPermissionDAO extends ServiceDAO {
      * @param scopeId
      * @param accessPermissionId
      * @return the deleted {@link AccessPermission}
-     * @throws KapuaEntityNotFoundException
-     *             If {@link AccessPermission} is not found.
+     * @throws KapuaEntityNotFoundException If {@link AccessPermission} is not found.
      */
     public static AccessPermission delete(EntityManager em, KapuaId scopeId, KapuaId accessPermissionId) throws KapuaEntityNotFoundException {
         return ServiceDAO.delete(em, AccessPermissionImpl.class, scopeId, accessPermissionId);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleDAO.java
@@ -34,7 +34,7 @@ public class AccessRoleDAO extends ServiceDAO {
      *
      * @param em
      * @param creator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static AccessRole create(EntityManager em, AccessRoleCreator creator)
@@ -53,10 +53,10 @@ public class AccessRoleDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param accessRoleId
-     * @return
+     * @return test
      */
     public static AccessRole find(EntityManager em, KapuaId scopeId, KapuaId accessRoleId) {
-        return ServiceDAO.find(em , AccessRoleImpl.class, scopeId, accessRoleId);
+        return ServiceDAO.find(em, AccessRoleImpl.class, scopeId, accessRoleId);
     }
 
     /**
@@ -64,7 +64,7 @@ public class AccessRoleDAO extends ServiceDAO {
      *
      * @param em
      * @param accessInfoPermissionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static AccessRoleListResult query(EntityManager em, KapuaQuery accessInfoPermissionQuery)
@@ -77,7 +77,7 @@ public class AccessRoleDAO extends ServiceDAO {
      *
      * @param em
      * @param accessPermissionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery accessPermissionQuery)
@@ -92,8 +92,7 @@ public class AccessRoleDAO extends ServiceDAO {
      * @param scopeId
      * @param accessRoleId
      * @return the deleted {@link AccessRole}
-     * @throws KapuaEntityNotFoundException
-     *             If {@link AccessRole} is not found.
+     * @throws KapuaEntityNotFoundException If {@link AccessRole} is not found.
      */
     public static AccessRole delete(EntityManager em, KapuaId scopeId, KapuaId accessRoleId) throws KapuaEntityNotFoundException {
         return ServiceDAO.delete(em, AccessRoleImpl.class, scopeId, accessRoleId);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDAO.java
@@ -89,7 +89,7 @@ public class DomainDAO extends ServiceDAO {
      *
      * @param em          The {@link EntityManager} that holds the transaction.
      * @param domainQuery The {@link DomainQuery} used to filter results.
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
@@ -26,7 +26,6 @@ import org.eclipse.kapua.service.authorization.role.RoleListResult;
  * Role DAO
  *
  * @since 1.0
- *
  */
 public class RoleDAO extends ServiceDAO {
 
@@ -35,7 +34,7 @@ public class RoleDAO extends ServiceDAO {
      *
      * @param em
      * @param creator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static Role create(EntityManager em, RoleCreator creator)
@@ -53,7 +52,7 @@ public class RoleDAO extends ServiceDAO {
      *
      * @param em
      * @param role
-     * @return
+     * @return test
      * @throws KapuaEntityNotFoundException
      *             If {@link Role} is not found.
      */
@@ -68,7 +67,7 @@ public class RoleDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param roleId
-     * @return
+     * @return test
      */
     public static Role find(EntityManager em, KapuaId scopeId, KapuaId roleId) {
         return ServiceDAO.find(em, RoleImpl.class, scopeId, roleId);
@@ -79,7 +78,7 @@ public class RoleDAO extends ServiceDAO {
      *
      * @param em
      * @param roleQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static RoleListResult query(EntityManager em, KapuaQuery roleQuery)
@@ -92,7 +91,7 @@ public class RoleDAO extends ServiceDAO {
      *
      * @param em
      * @param roleQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery roleQuery)

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionDAO.java
@@ -26,7 +26,6 @@ import org.eclipse.kapua.service.authorization.role.RolePermissionListResult;
  * {@link RolePermission} DAO
  *
  * @since 1.0
- *
  */
 public class RolePermissionDAO extends ServiceDAO {
 
@@ -35,7 +34,7 @@ public class RolePermissionDAO extends ServiceDAO {
      *
      * @param em
      * @param creator
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static RolePermission create(EntityManager em, RolePermissionCreator creator)
@@ -54,7 +53,7 @@ public class RolePermissionDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param roleId
-     * @return
+     * @return test
      */
     public static RolePermission find(EntityManager em, KapuaId scopeId, KapuaId roleId) {
         return ServiceDAO.find(em, RolePermissionImpl.class, scopeId, roleId);
@@ -65,7 +64,7 @@ public class RolePermissionDAO extends ServiceDAO {
      *
      * @param em
      * @param rolePermissionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static RolePermissionListResult query(EntityManager em, KapuaQuery rolePermissionQuery)
@@ -78,7 +77,7 @@ public class RolePermissionDAO extends ServiceDAO {
      *
      * @param em
      * @param rolePermissionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery rolePermissionQuery)
@@ -93,8 +92,7 @@ public class RolePermissionDAO extends ServiceDAO {
      * @param scopeId
      * @param rolePermissionId
      * @return the deleted {@link RolePermission}
-     * @throws KapuaEntityNotFoundException
-     *             If {@link RolePermission} is not found.
+     * @throws KapuaEntityNotFoundException If {@link RolePermission} is not found.
      */
     public static RolePermission delete(EntityManager em, KapuaId scopeId, KapuaId rolePermissionId) throws KapuaEntityNotFoundException {
         return ServiceDAO.delete(em, RolePermissionImpl.class, scopeId, rolePermissionId);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSetting.java
@@ -33,7 +33,7 @@ public class KapuaAuthorizationSetting extends AbstractKapuaSetting<KapuaAuthori
     /**
      * Return the authorization setting instance (singleton)
      *
-     * @return
+     * @return test
      */
     public static KapuaAuthorizationSetting getInstance() {
         return INSTANCE;

--- a/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamService.java
+++ b/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamService.java
@@ -26,7 +26,7 @@ public interface StreamService extends KapuaService {
     /**
      * @param message
      * @param timeout
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagXmlRegistry.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagXmlRegistry.java
@@ -25,7 +25,7 @@ public class TagXmlRegistry {
     /**
      * Creates a new tag instance
      *
-     * @return
+     * @return test
      */
     public Tag newTag() {
         return TAG_FACTORY.newEntity(null);
@@ -34,7 +34,7 @@ public class TagXmlRegistry {
     /**
      * Creates a new tag creator instance
      *
-     * @return
+     * @return test
      */
     public TagCreator newTagCreator() {
         return TAG_FACTORY.newCreator(null, null);
@@ -43,7 +43,7 @@ public class TagXmlRegistry {
     /**
      * Creates a new tag creator instance
      *
-     * @return
+     * @return test
      */
     public TagListResult newTagListResult() {
         return TAG_FACTORY.newListResult();

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
@@ -36,7 +36,7 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
     /**
      * Return the display name (may be a friendly username to show in the UI)
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "displayName")
     String getDisplayName();
@@ -51,7 +51,7 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
     /**
      * Get the email
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "email")
     String getEmail();
@@ -66,7 +66,7 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
     /**
      * Get the phone number
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "phoneNumber")
     String getPhoneNumber();
@@ -81,7 +81,7 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
     /**
      * Get the user type
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "userType")
     UserType getUserType();
@@ -96,7 +96,7 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
     /**
      * Get the external ID
      *
-     * @return
+     * @return test
      */
     @XmlElement(name = "externalId")
     String getExternalId();

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
@@ -51,7 +51,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      * and permissions, loaded.
      *
      * @param user to be update
-     * @return
+     * @return test
      * @throws KapuaException
      */
     @Override
@@ -72,7 +72,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      * <b>The API does not perform any access control check and it is meant for internal use.</b>
      *
      * @param userId
-     * @return
+     * @return test
      * @throws KapuaException
      */
     @Override
@@ -81,7 +81,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
     /**
      * Returns the User with the specified username; returns null if the user is not found.
      *
-     * @return
+     * @return test
      * @throws KapuaException
      */
     @Override

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserXmlRegistry.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserXmlRegistry.java
@@ -30,7 +30,7 @@ public class UserXmlRegistry {
     /**
      * Creates a new user instance
      *
-     * @return
+     * @return test
      */
     public User newUser() {
         return USER_FACTORY.newEntity(null);
@@ -39,7 +39,7 @@ public class UserXmlRegistry {
     /**
      * Creates a new user creator instance
      *
-     * @return
+     * @return test
      */
     public UserCreator newUserCreator() {
         return USER_FACTORY.newCreator(null, null);
@@ -48,7 +48,7 @@ public class UserXmlRegistry {
     /**
      * Creates new user list result
      *
-     * @return
+     * @return test
      */
     public UserListResult newUserListResult() {
         return USER_FACTORY.newListResult();

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
@@ -36,7 +36,7 @@ public class UserDAO extends ServiceDAO {
      *
      * @param em
      * @param userCreator
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public static User create(EntityManager em, UserCreator userCreator) {
@@ -61,7 +61,7 @@ public class UserDAO extends ServiceDAO {
      *
      * @param em
      * @param user
-     * @return
+     * @return test
      * @throws KapuaException
      * @since 1.0.0
      */
@@ -77,7 +77,7 @@ public class UserDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param userId
-     * @return
+     * @return test
      * @since 1.0.0
      */
     public static User find(EntityManager em, KapuaId scopeId, KapuaId userId) {
@@ -89,7 +89,7 @@ public class UserDAO extends ServiceDAO {
      *
      * @param em
      * @param name
-     * @return
+     * @return test
      */
     public static User findByName(EntityManager em, String name) {
         return ServiceDAO.findByName(em, UserImpl.class, name);
@@ -102,7 +102,7 @@ public class UserDAO extends ServiceDAO {
      * @param externalId id the external ID so search for
      * @return the user record, may be {@code null}
      */
-    public static User findByExternalId(final EntityManager em, final String externalId) {
+    public static User findByExternalId(EntityManager em, String externalId) {
         return ServiceDAO.findByField(em, UserImpl.class, UserAttributes.EXTERNAL_ID, externalId);
     }
 
@@ -124,7 +124,7 @@ public class UserDAO extends ServiceDAO {
      *
      * @param em
      * @param userPermissionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static UserListResult query(EntityManager em, KapuaQuery userPermissionQuery)
@@ -137,7 +137,7 @@ public class UserDAO extends ServiceDAO {
      *
      * @param em
      * @param userPermissionQuery
-     * @return
+     * @return test
      * @throws KapuaException
      */
     public static long count(EntityManager em, KapuaQuery userPermissionQuery)


### PR DESCRIPTION
Bumped following dependencies 

- checkstyle from 7.6.1 to 9.3
- maven-checkstyle-plugin from 2.17 to 3.2.1

solving following CVEs:

- CVE-2019-9658 
- CVE-2019-10782 

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version of the dependencies and fixed newly detected checkstyle errors.

**Screenshots**
_None_

**Any side note on the changes made**
New checkstyle validated Javadoc `@return` and it must have a value.