### PR TITLE
Fix missing `jersey-hk2` dependency in `kapua-console-web` module

### DIFF
--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -235,6 +235,12 @@
             <artifactId>kapua-service-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>2.30</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -238,7 +238,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <version>2.30</version>
         </dependency>
 
     </dependencies>

--- a/job-engine/app/web/pom.xml
+++ b/job-engine/app/web/pom.xml
@@ -194,7 +194,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <version>2.30</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <jaxb-impl.version>2.3.6</jaxb-impl.version>
         <jbatch.version>1.0.2</jbatch.version>
         <jersey.version>2.27</jersey.version>
+        <jersey-hk2.version>2.30</jersey-hk2.version>
         <jersey-repackaged.version>2.26-b03</jersey-repackaged.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <joda.version>2.9.4</joda.version>
@@ -2012,14 +2013,14 @@
 
             <!-- REST API -->
             <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-moxy</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${javax-servlet-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-moxy</artifactId>
+                <version>${jersey.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
@@ -2050,6 +2051,11 @@
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-json-jackson</artifactId>
                 <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
+                <version>${jersey-hk2.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.hk2</groupId>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -179,7 +179,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <version>2.30</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR adds `jersey-hk2` dependency to `kapua-console-web` module which was not added in PR https://github.com/eclipse/kapua/pull/3683.

**Related Issue**
This PR fixes changes made in https://github.com/eclipse/kapua/pull/3683

**Description of the solution adopted**
Added missing dependency

**Screenshots**
_None_

**Any side note on the changes made**
_None_