### PR TITLE
Bumped Jetty from 9.4.44.v20210927 to 9.4.50.v20221201 - CVE-2022-2047 CVE-2022-2048

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
         <mockito.version>1.10.19</mockito.version>
         <netty.version>4.1.87.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
+        <ow2-asm.version>9.4</ow2-asm.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>
         <opencsv.version>3.7</opencsv.version>
         <paho.version>1.2.1</paho.version>
@@ -1666,6 +1667,28 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${ow2-asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-analysis</artifactId>
+                <version>${ow2-asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+                <version>${ow2-asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+                <version>${ow2-asm.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.owasp.encoder</groupId>
                 <artifactId>encoder</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <jersey.version>2.27</jersey.version>
         <jersey-hk2.version>2.30</jersey-hk2.version>
         <jersey-repackaged.version>2.26-b03</jersey-repackaged.version>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.50.v20221201</jetty.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.10</jose4j.version>
@@ -2282,12 +2282,12 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util-ajax</artifactId>
+                <artifactId>jetty-util</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
+                <artifactId>jetty-util-ajax</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR bumps the version of Jetty dependencies from 9.4.44.v20210927 to 9.4.50.v20221201, solving following CVEs:

- CVE-2022-2047 
- CVE-2022-2048

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version of Jetty.

**Screenshots**
_None_

**Any side note on the changes made**
Added ow2 asm dependencies to `dependencyManagement` section