### PR TITLE
Bump and aligned Jersey version to 2.38

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -217,7 +217,6 @@
                 <include>org.glassfish.hk2:hk2-api</include>
                 <include>org.glassfish.hk2:hk2-locator</include>
                 <include>org.glassfish.hk2:hk2-utils</include>
-                <include>org.glassfish.jersey.bundles.repackaged:jersey-guava</include>
                 <include>org.glassfish.jersey.core:jersey-client</include>
                 <include>org.glassfish.jersey.core:jersey-common</include>
                 <include>org.glassfish.jersey.ext:jersey-entity-filtering</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -172,15 +172,11 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-            <artifactId>jersey-guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
         </dependency>
-        <!-- dependencies added otherwise the unix assembly doesn't know the arctifact to add -->
 
+        <!-- dependencies added otherwise the unix assembly doesn't know the arctifact to add -->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-transport-api</artifactId>

--- a/job-engine/app/web/pom.xml
+++ b/job-engine/app/web/pom.xml
@@ -34,15 +34,10 @@
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
-        <!-- fixes java.lang.ClassNotFoundException: javax.ws.rs.client.RxInvokerProvider -->
         <dependency>
             <groupId>org.glassfish.jersey.bundles</groupId>
             <artifactId>jaxrs-ri</artifactId>
             <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-            <artifactId>jersey-guava</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,7 @@
         <jaxb-core.version>2.3.0.1</jaxb-core.version>
         <jaxb-impl.version>2.3.6</jaxb-impl.version>
         <jbatch.version>1.0.2</jbatch.version>
-        <jersey.version>2.27</jersey.version>
-        <jersey-hk2.version>2.30</jersey-hk2.version>
-        <jersey-repackaged.version>2.26-b03</jersey-repackaged.version>
+        <jersey.version>2.38</jersey.version>
         <jetty.version>9.4.50.v20221201</jetty.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
@@ -2040,46 +2038,7 @@
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${javax-servlet-api.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-moxy</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.ext</groupId>
-                <artifactId>jersey-entity-filtering</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-server</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-client</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-common</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.containers</groupId>
-                <artifactId>jersey-container-servlet-core</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-json-jackson</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.inject</groupId>
-                <artifactId>jersey-hk2</artifactId>
-                <version>${jersey-hk2.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>hk2-api</artifactId>
@@ -2094,16 +2053,6 @@
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>hk2-locator</artifactId>
                 <version>${hk2-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.bundles</groupId>
-                <artifactId>jaxrs-ri</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-                <artifactId>jersey-guava</artifactId>
-                <version>${jersey-repackaged.version}</version>
             </dependency>
 
             <!-- -->
@@ -2368,6 +2317,84 @@
                 <groupId>org.eclipse.jetty.websocket</groupId>
                 <artifactId>websocket-servlet</artifactId>
                 <version>${jetty.version}</version>
+            </dependency>
+
+            <!-- -->
+            <!-- Jersey -->
+            <dependency>
+                <groupId>org.glassfish.jersey.bundles</groupId>
+                <artifactId>jaxrs-ri</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.bundles</groupId>
+                <artifactId>repackaged</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.connectors</groupId>
+                <artifactId>jersey-apache-connector</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.containers</groupId>
+                <artifactId>jersey-container-servlet-core</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.containers</groupId>
+                <artifactId>jersey-container-servlet</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-client</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-common</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-server</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.ext</groupId>
+                <artifactId>jersey-entity-filtering</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-jaxb</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-binding</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-jackson</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-moxy</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-sse</artifactId>
+                <version>${jersey.version}</version>
             </dependency>
 
             <!-- -->

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -29,16 +29,10 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
         </dependency>
-        <!-- fixes java.lang.ClassNotFoundException: javax.ws.rs.client.RxInvokerProvider -->
         <dependency>
             <groupId>org.glassfish.jersey.bundles</groupId>
             <artifactId>jaxrs-ri</artifactId>
             <version>${jersey.version}</version>
-        </dependency>
-        <!-- fixes java.lang.NoClassDefFoundError: jersey.repackaged.com.google.common.util.concurrent.MoreExecutors -->
-        <dependency>
-            <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-            <artifactId>jersey-guava</artifactId>
         </dependency>
 
         <!-- Required service interfaces -->

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -38,10 +38,6 @@
             <groupId>org.glassfish.jersey.bundles</groupId>
             <artifactId>jaxrs-ri</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-            <artifactId>jersey-guava</artifactId>
-        </dependency>
 
         <!-- Internal dependencies -->
         <dependency>


### PR DESCRIPTION
Bumped and aligned the version of Jersey dependencies to 2.38 since we have multiple 2.x version across different Jersey components

**Related Issue**
_None_

**Description of the solution adopted**
Just aligned version of components

**Screenshots**
_None_

**Any side note on the changes made**
_None_