### PR TITLE
Fix - missing dependency propagation from 2 modules

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -133,7 +133,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -158,7 +157,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/extras/liquibase-unlocker/pom.xml
+++ b/extras/liquibase-unlocker/pom.xml
@@ -38,28 +38,16 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-        </dependency>
 
         <!-- -->
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
This PR solves some missing dependencies propagation from Kapua-commons module and the liquibase-unlocker-tool module. 

First: in commons, the SystemSetting class performs internally some logs, therefore has a dependency on some logging artifacts. If, for example, an external module creates an instance of SystemSetting, such log is performed and so these logging artifacts are required. To me, this external module should state only a dependency on kapua-commons in his pom file, not on those logging artifacts. The problem is that, in the pom file of kapua commons, those logging artifacts are inserted as dependent artifacts with the TEST SCOPE, as such are not propagated to modules that depend on kapua-commons...I solved this deleting the test scope (so by default now there is compile scope). In this way modules that depend on commons (like, liquibase-unlocker-tool module) doesn't need to insert in their pom file dependencies already specified in the commons pom file and that are necessary to use "things" defined in commons.

Secondly, the liquibase-unlocker-tool module was creating the dependency-reduced-pom, as a result of the configuration of its maven shade plugin, but this was having the effect of removing from the artifact pom file all its dependencies. This was having an effect similar to what explained previously: modules that had a dependency on this module (like, the liquibase-unlocker-tool ported on another platform) were not importing transitive dependencies and as such had to rewrite all of them on their pom file. Removing the creation of this dep. reduced pom file solved this issue.

**Any side note on the changes made**
I hope that removing the test scope from the kapua-commons dependencies will not have side offects on module that depends on it. Aka problems with the fact that now these logging artifacts are propagated to other modules
