### PR TITLE
Wrong example for endpoint PUT Rest API method

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
@@ -60,6 +60,7 @@ paths:
               usages:
                 - name: MESSAGE_BROKER
                 - name: PROVISION
+              endpointType: resource
         required: true
       responses:
         200:


### PR DESCRIPTION
This pr inserts a missing parameter in the example for the PUT method of endpoint's rest APis.
With the previous example, if someone tried to update an endpoint substituting parameters in the example a 500 internal server error ewas thrown and this could lead to confusion for some clients.