### PR TITLE
Create endpoint to retrieve current system `version` and `build version`

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
@@ -105,7 +105,7 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
 
                     String fileFullPath = String.join("", "file://", configResourceDirName, configFileName);
 
-                    // Ignore files that arent named '*.properties'
+                    // Ignore files that aren't named '*.properties'
                     if (fileFullPath.endsWith(".properties")) {
                         loadConfigResource(compositeConfig, fileFullPath);
                     } else {

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -16,7 +16,7 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=${project.version}
-commons.build.version=
+commons.build.version=${buildNumber}
 commons.build.number=
 
 #

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
         <maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
 
+        <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
         <checkstyle.version>7.6.1</checkstyle.version>
         <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
         <docker-maven-plugin.version>0.40.2</docker-maven-plugin.version>
@@ -479,6 +480,22 @@
                         <excludes>**/target/**/*, **/.settings/**/*, maven/**/*, .maven/**/*, .idea/**/*, **/node/**/*</excludes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>${buildnumber-maven-plugin.version}</version>
+                    <configuration>
+                        <timestampFormat>{0,date,yyyyMMdd}</timestampFormat>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -555,6 +572,11 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>${exec-maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>${buildnumber-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -1125,6 +1147,26 @@
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-user-test-steps</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-system-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-system-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-system-test</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-system-test-steps</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/rest-api/resources/pom.xml
+++ b/rest-api/resources/pom.xml
@@ -91,5 +91,9 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-job-engine-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-system-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/SystemInformation.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/SystemInformation.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.systeminfo.SystemInfo;
+import org.eclipse.kapua.service.systeminfo.SystemInfoService;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/sys-info")
+public class SystemInformation extends AbstractKapuaResource {
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final SystemInfoService systemInfoService = locator.getService(SystemInfoService.class);
+
+
+    /**
+     * Gets the system info.
+     *
+     * @since 2.0.0
+     */
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public SystemInfo getSystemInfo() {
+        return systemInfoService.getSystemInfo();
+    }
+
+}

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -393,6 +393,9 @@ paths:
     $ref: './serviceConfiguration/serviceConfiguration-scopeId.yaml#/paths/~1{scopeId}~1serviceConfigurations'
   /{scopeId}/serviceConfigurations/{componentId}:
     $ref: './serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml#/paths/~1{scopeId}~1serviceConfigurations~1{componentId}'
+  ### System Info ###
+  /sys-info:
+    $ref: './systemInfo/systemInfo.yaml#/paths/~1sys-info'
   ### Stream ###
   /{scopeId}/streams/messages:
     $ref: './stream/stream-scopeId.yaml#/paths/~1{scopeId}~1streams~1messages'
@@ -901,6 +904,9 @@ components:
       $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/option'
     serviceAttributeDefinition:
       $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/attributeDefinition'
+    ### System Info Entities ###
+    systemInfo:
+      $ref: './systemInfo/systemInfo.yaml#/components/schemas/systemInfo'
     ### Tag Entities ###
     tag:
       $ref: './tag/tag.yaml#/components/schemas/tag'

--- a/rest-api/resources/src/main/resources/openapi/systemInfo/systemInfo.yaml
+++ b/rest-api/resources/src/main/resources/openapi/systemInfo/systemInfo.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.2
+
+info:
+  title: Eclipse Kapua REST API - Version
+  version: '1.0'
+  contact:
+    name: Eclipse Kapua Dev Team
+    url: https://eclipse.org/kapua
+    email: kapua-dev@eclipse.org
+  license:
+    name: Eclipse Public License 2.0
+    url: https://www.eclipse.org/legal/epl-2.0
+
+paths:
+  /sys-info:
+    get:
+      tags:
+        - "System Info"
+      summary: Get the system info
+      responses:
+        200:
+          description: System info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/systemInfo'
+
+components:
+  schemas:
+    systemInfo:
+      type: object
+      description: System info
+      properties:
+        version:
+          type: string
+          description: Version of the system
+        build:
+          type: string
+          description: Build version of the system
+      example:
+        version: 5.10.0
+        build: 0217c5988517bb3cfeef783d43438a8b8faaa1d8

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -134,6 +134,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-system-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-tag-internal</artifactId>
         </dependency>
         <dependency>

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -305,6 +305,8 @@ import org.eclipse.kapua.service.storable.model.query.SortField;
 import org.eclipse.kapua.service.storable.model.query.SortFieldXmlAdapter;
 import org.eclipse.kapua.service.storable.model.query.XmlAdaptedSortField;
 import org.eclipse.kapua.service.storable.model.query.XmlAdaptedSortFields;
+import org.eclipse.kapua.service.systeminfo.SystemInfo;
+import org.eclipse.kapua.service.systeminfo.SystemInfoXmlRegistry;
 import org.eclipse.kapua.service.tag.Tag;
 import org.eclipse.kapua.service.tag.TagCreator;
 import org.eclipse.kapua.service.tag.TagListResult;
@@ -672,6 +674,10 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     AccessRoleCreator.class,
                     AccessRoleQuery.class,
                     AccessRoleXmlRegistry.class,
+
+                    // System Info
+                    SystemInfo.class,
+                    SystemInfoXmlRegistry.class,
 
                     // Tag
                     Tag.class,

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -114,6 +114,11 @@ kapuaAuthcAccessToken = org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthentica
 /v1/*/tags.xml                  = kapuaAuthcAccessToken
 /v1/*/tags/**                   = kapuaAuthcAccessToken
 
+# System Info
+/v1/*/systemInfo.json           = kapuaAuthcAccessToken
+/v1/*/systemInfo.xml            = kapuaAuthcAccessToken
+/v1/*/systemInfo/**             = kapuaAuthcAccessToken
+
 # User
 /v1/*/users.json                = kapuaAuthcAccessToken
 /v1/*/users.xml                 = kapuaAuthcAccessToken

--- a/service/system/api/about.html
+++ b/service/system/api/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/service/system/api/pom.xml
+++ b/service/system/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -14,33 +14,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.eclipse.kapua</groupId>
-        <artifactId>kapua</artifactId>
+        <artifactId>kapua-system</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>kapua-service</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>kapua-system-api</artifactId>
 
-    <modules>
-        <module>api</module>
-
-        <module>commons</module>
-
-        <module>account</module>
-        <module>datastore</module>
-        <module>device</module>
-        <module>endpoint</module>
-        <module>job</module>
-        <module>scheduler</module>
-        <module>security</module>
-        <module>system</module>
-        <module>stream</module>
-        <module>tag</module>
-        <module>user</module>
-
-    </modules>
-
+    <dependencies>
+        <!-- Extended service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfo.java
+++ b/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfo.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * {@link SystemInfo} {@link org.eclipse.kapua.model.KapuaEntity} definition
+ * <p>
+ * {@link SystemInfo}s represent the system info.
+ *
+ * @since 2.0.0
+ */
+@XmlRootElement(name = "systemInfo")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = SystemInfoXmlRegistry.class, factoryMethod = "newSystemInfo")
+public interface SystemInfo {
+    @XmlElement(name = "version")
+    String getVersion();
+
+    void setVersion(String version);
+
+    @XmlElement(name = "buildVersion")
+    String getBuildVersion();
+
+
+    void setBuildVersion(String buildVersion);
+}

--- a/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfoFactory.java
+++ b/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfoFactory.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo;
+
+import org.eclipse.kapua.model.KapuaObjectFactory;
+
+public interface SystemInfoFactory extends KapuaObjectFactory {
+    SystemInfo newSystemInfo();
+}

--- a/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfoService.java
+++ b/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfoService.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo;
+
+import org.eclipse.kapua.service.KapuaService;
+
+/**
+ * System Info service definition
+ *
+ * @since 2.0.0
+ */
+public interface SystemInfoService extends KapuaService {
+    SystemInfo getSystemInfo();
+}

--- a/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfoXmlRegistry.java
+++ b/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfoXmlRegistry.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.KapuaService;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class SystemInfoXmlRegistry implements KapuaService {
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final SystemInfoFactory SYSTEM_INFO_FACTORY = LOCATOR.getFactory(SystemInfoFactory.class);
+
+
+    /**
+     * Creates a new SystemInfo instance.
+     *
+     * @return new SystemInfo instance.
+     */
+    public SystemInfo newSystemInfo() {
+        return SYSTEM_INFO_FACTORY.newSystemInfo();
+    }
+}

--- a/service/system/internal/about.html
+++ b/service/system/internal/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/service/system/internal/pom.xml
+++ b/service/system/internal/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua-system</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-system-internal</artifactId>
+    <name>${project.artifactId}</name>
+
+    <dependencies>
+        <!-- Implemented service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-system-api</artifactId>
+        </dependency>
+
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-locator-guice</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoFactoryImpl.java
+++ b/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoFactoryImpl.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo.internal;
+
+import org.eclipse.kapua.service.systeminfo.SystemInfo;
+import org.eclipse.kapua.service.systeminfo.SystemInfoFactory;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class SystemInfoFactoryImpl implements SystemInfoFactory {
+    @Override
+    public SystemInfo newSystemInfo() {
+        return new SystemInfoImpl();
+    }
+}

--- a/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoImpl.java
+++ b/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoImpl.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo.internal;
+
+import org.eclipse.kapua.service.systeminfo.SystemInfo;
+
+public class SystemInfoImpl implements SystemInfo {
+    private String version;
+    private String buildNumber;
+
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+
+    @Override
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+
+    @Override
+    public String getBuildVersion() {
+        return buildNumber;
+    }
+
+
+    @Override
+    public void setBuildVersion(String buildVersion) {
+        this.buildNumber = buildVersion;
+    }
+}

--- a/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoModule.java
+++ b/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.systeminfo.SystemInfoFactory;
+import org.eclipse.kapua.service.systeminfo.SystemInfoService;
+
+public class SystemInfoModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(SystemInfoService.class).to(SystemInfoServiceImpl.class);
+        bind(SystemInfoFactory.class).to(SystemInfoFactoryImpl.class);
+    }
+}

--- a/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoServiceImpl.java
+++ b/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoServiceImpl.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo.internal;
+
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.systeminfo.SystemInfo;
+import org.eclipse.kapua.service.systeminfo.SystemInfoFactory;
+import org.eclipse.kapua.service.systeminfo.SystemInfoService;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class SystemInfoServiceImpl implements SystemInfoService {
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+
+
+    @Override
+    public SystemInfo getSystemInfo() {
+        SystemSetting systemSetting = SystemSetting.getInstance();
+        String version = systemSetting.getString(SystemSettingKey.VERSION);
+        String buildVersion = systemSetting.getString(SystemSettingKey.BUILD_VERSION);
+
+        SystemInfoFactory systemInfoFactory = locator.getFactory(SystemInfoFactory.class);
+        SystemInfo systemInfo = systemInfoFactory.newSystemInfo();
+        systemInfo.setVersion(version);
+        systemInfo.setBuildVersion(buildVersion);
+
+        return systemInfo;
+    }
+}

--- a/service/system/pom.xml
+++ b/service/system/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -17,30 +17,19 @@
 
     <parent>
         <groupId>org.eclipse.kapua</groupId>
-        <artifactId>kapua</artifactId>
+        <artifactId>kapua-service</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-
-    <artifactId>kapua-service</artifactId>
     <packaging>pom</packaging>
+
+    <artifactId>kapua-system</artifactId>
+    <name>${project.artifactId}</name>
 
     <modules>
         <module>api</module>
-
-        <module>commons</module>
-
-        <module>account</module>
-        <module>datastore</module>
-        <module>device</module>
-        <module>endpoint</module>
-        <module>job</module>
-        <module>scheduler</module>
-        <module>security</module>
-        <module>system</module>
-        <module>stream</module>
-        <module>tag</module>
-        <module>user</module>
-
+        <module>internal</module>
+        <module>test</module>
+        <module>test-steps</module>
     </modules>
 
 </project>

--- a/service/system/test-steps/about.html
+++ b/service/system/test-steps/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/service/system/test-steps/pom.xml
+++ b/service/system/test-steps/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua-system</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-system-test-steps</artifactId>
+    <name>${project.artifactId}</name>
+
+    <dependencies>
+        <!-- Required service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-authentication-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-authorization-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-system-api</artifactId>
+        </dependency>
+
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-test-steps</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/service/system/test-steps/src/main/java/org/eclipse/kapua/service/systeminfo/steps/SystemInfoSteps.java
+++ b/service/system/test-steps/src/main/java/org/eclipse/kapua/service/systeminfo/steps/SystemInfoSteps.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo.steps;
+
+import io.cucumber.java.After;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.qa.common.StepData;
+import org.eclipse.kapua.qa.common.TestBase;
+import org.eclipse.kapua.service.systeminfo.SystemInfo;
+import org.eclipse.kapua.service.systeminfo.SystemInfoFactory;
+import org.eclipse.kapua.service.systeminfo.SystemInfoService;
+import org.junit.Assert;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class SystemInfoSteps extends TestBase {
+    private SystemInfoService systemInfoService;
+    private SystemInfoFactory systemInfoFactory;
+
+
+    @Inject
+    public SystemInfoSteps(StepData stepData) {
+        super(stepData);
+    }
+
+
+    @After(value = "@setup")
+    public void setServices() {
+        KapuaLocator locator = KapuaLocator.getInstance();
+        systemInfoService = locator.getService(SystemInfoService.class);
+        systemInfoFactory = locator.getFactory(SystemInfoFactory.class);
+    }
+
+
+    @Given("I retrieve the system info")
+    public void configureSystemInfo() {
+        SystemInfo systemInfo = systemInfoService.getSystemInfo();
+        stepData.put("systemVersion", systemInfo.getVersion());
+        stepData.put("systemBuildVersion", systemInfo.getBuildVersion());
+    }
+
+
+    @Then("The version of the system is {string} and the build version of the system is {string}")
+    public void theVersionOfTheSystemIsAndTheBuildVersionOfTheSystemIs(String expectedVersion, String expectedBuildVersion) {
+        Assert.assertEquals(stepData.get("systemVersion"), expectedVersion);
+        Assert.assertEquals(stepData.get("systemBuildVersion"), expectedBuildVersion);
+    }
+}

--- a/service/system/test/about.html
+++ b/service/system/test/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/service/system/test/pom.xml
+++ b/service/system/test/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua-system</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-system-test</artifactId>
+
+    <dependencies>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-system-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-system-test-steps</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/service/system/test/src/test/java/org/eclipse/kapua/service/systeminfo/test/RunSystemInfoUnitTest.java
+++ b/service/system/test/src/test/java/org/eclipse/kapua/service/systeminfo/test/RunSystemInfoUnitTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.systeminfo.test;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = { "classpath:features/SystemInfoServiceUnitTests.feature"
+    },
+    glue = {"org.eclipse.kapua.service.device.registry.steps",
+        "org.eclipse.kapua.service.systeminfo.test",
+        "org.eclipse.kapua.service.systeminfo.steps",
+        "org.eclipse.kapua.qa.common"
+    },
+    plugin = { "pretty",
+        "html:target/cucumber/SystemInfoService",
+        "json:target/SystemInfoService_cucumber.json" },
+    monochrome = true)
+public class RunSystemInfoUnitTest {
+}

--- a/service/system/test/src/test/java/org/eclipse/kapua/service/systeminfo/test/SystemInfoLocatorConfiguration.java
+++ b/service/system/test/src/test/java/org/eclipse/kapua/service/systeminfo/test/SystemInfoLocatorConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.service.tag.test;
+package org.eclipse.kapua.service.systeminfo.test;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -21,8 +21,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
 import org.eclipse.kapua.commons.model.query.QueryFactoryImpl;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.message.KapuaMessageFactory;
-import org.eclipse.kapua.message.internal.KapuaMessageFactoryImpl;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.model.query.QueryFactory;
 import org.eclipse.kapua.qa.common.MockedLocator;
@@ -33,29 +31,15 @@ import org.eclipse.kapua.service.account.internal.AccountServiceImpl;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
-import org.eclipse.kapua.service.device.registry.DeviceFactory;
-import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
-import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionFactoryImpl;
-import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionServiceImpl;
-import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
-import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
-import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventFactoryImpl;
-import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventServiceImpl;
-import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFactory;
-import org.eclipse.kapua.service.device.registry.internal.DeviceFactoryImpl;
-import org.eclipse.kapua.service.device.registry.internal.DeviceRegistryServiceImpl;
-import org.eclipse.kapua.service.tag.TagFactory;
-import org.eclipse.kapua.service.tag.TagService;
-import org.eclipse.kapua.service.tag.internal.TagEntityManagerFactory;
-import org.eclipse.kapua.service.tag.internal.TagFactoryImpl;
-import org.eclipse.kapua.service.tag.internal.TagServiceImpl;
+import org.eclipse.kapua.service.systeminfo.SystemInfoFactory;
+import org.eclipse.kapua.service.systeminfo.SystemInfoService;
+import org.eclipse.kapua.service.systeminfo.internal.SystemInfoFactoryImpl;
+import org.eclipse.kapua.service.systeminfo.internal.SystemInfoServiceImpl;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 @Singleton
-public class TagLocatorConfiguration {
+public class SystemInfoLocatorConfiguration {
 
     /**
      * Setup DI with Google Guice DI.
@@ -91,25 +75,10 @@ public class TagLocatorConfiguration {
                 bind(AccountService.class).toInstance(Mockito.spy(new AccountServiceImpl()));
                 bind(AccountFactory.class).toInstance(Mockito.spy(new AccountFactoryImpl()));
 
-                // Inject actual Tag service related services
-                TagEntityManagerFactory tagEntityManagerFactory = TagEntityManagerFactory.getInstance();
-                bind(TagEntityManagerFactory.class).toInstance(tagEntityManagerFactory);
-                bind(TagService.class).toInstance(new TagServiceImpl());
-                bind(TagFactory.class).toInstance(new TagFactoryImpl());
+                // Inject actual System Info service related services
+                bind(SystemInfoService.class).toInstance(new SystemInfoServiceImpl());
+                bind(SystemInfoFactory.class).toInstance(new SystemInfoFactoryImpl());
 
-                // Inject actual Device service related services
-                DeviceEntityManagerFactory deviceEntityManagerFactory = DeviceEntityManagerFactory.getInstance();
-                bind(DeviceEntityManagerFactory.class).toInstance(deviceEntityManagerFactory);
-
-                bind(DeviceRegistryService.class).toInstance(new DeviceRegistryServiceImpl());
-                bind(DeviceFactory.class).toInstance(new DeviceFactoryImpl());
-
-                bind(DeviceConnectionService.class).toInstance(new DeviceConnectionServiceImpl());
-                bind(DeviceConnectionFactory.class).toInstance(new DeviceConnectionFactoryImpl());
-
-                bind(DeviceEventService.class).toInstance(new DeviceEventServiceImpl());
-                bind(DeviceEventFactory.class).toInstance(new DeviceEventFactoryImpl());
-                bind(KapuaMessageFactory.class).toInstance(new KapuaMessageFactoryImpl());
             }
         };
 

--- a/service/system/test/src/test/resources/features/SystemInfoServiceUnitTests.feature
+++ b/service/system/test/src/test/resources/features/SystemInfoServiceUnitTests.feature
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech
+###############################################################################
+@env_none
+
+Feature: System Info
+  This feature file contains unit tests for System Info.
+
+  @setup
+  @KapuaProperties("locator.class.impl=org.eclipse.kapua.qa.common.MockedLocator")
+  Scenario: Initialize test environment
+    Given Init Jaxb Context
+    And Init Security Context
+
+
+  Scenario: Retrieve the system info
+    When I retrieve the system info
+    Then The version of the system is "kapuaVersion42" and the build version of the system is "kapuaBuildVersion42"

--- a/service/system/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/system/test/src/test/resources/kapua-environment-setting.properties
@@ -1,0 +1,65 @@
+###############################################################################
+# Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+commons.sys.provision.account.name=kapua-provision
+commons.sys.admin.account=kapua-sys
+commons.sys.admin.userName=kapua-sys
+
+commons.version=kapuaVersion42
+commons.build.version=kapuaBuildVersion42
+commons.build.number=
+
+#
+# SQL database settings
+#
+commons.db.name=kapuadb
+commons.db.username=kapua
+commons.db.password=kapua
+
+commons.db.jdbcConnectionUrlResolver=H2
+commons.db.jdbc.driver=org.h2.Driver
+commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
+commons.db.connection.host=
+commons.db.connection.port=
+commons.db.connection.useSsl=
+commons.db.connection.trust.store.url=
+commons.db.connection.trust.store.pwd=
+
+commons.db.schema=kapuadb
+commons.db.useTimezone=true
+commons.db.useLegacyDatetimeCode=false
+commons.db.serverTimezone=UTC
+commons.db.characterEncoding=UTF-8
+
+commons.db.pool.size.initial=5
+commons.db.pool.size.min=2
+commons.db.pool.size.max=30
+commons.db.pool.borrow.timeout=15000
+
+#
+# Broker settings
+#
+broker.scheme=tcp
+broker.host=localhost
+broker.connector.internal.port=1893
+
+character.encoding=UTF-8
+
+#
+# Entity settings
+#
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
+commons.entity.insert.max.retry=3
+
+commons.control_message.classifier=$EDC

--- a/service/system/test/src/test/resources/locator.xml
+++ b/service/system/test/src/test/resources/locator.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<locator-config>
+    <provided>
+    </provided>
+
+    <packages>
+        <package>org.eclipse.kapua.commons</package>
+        <package>org.eclipse.kapua.service.generator.id.sequence</package>
+    </packages>
+</locator-config>

--- a/service/system/test/src/test/resources/logback.xml
+++ b/service/system/test/src/test/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023, 2022 Red Hat Inc and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Red Hat - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="liquibase" level="WARN" />
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/service/system/test/src/test/resources/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/system/test/src/test/resources/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,0 +1,13 @@
+#################################################################################
+#  Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+#
+#  This program and the accompanying materials are made
+#  available under the terms of the Eclipse Public License 2.0
+#  which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#       Eurotech - initial API and implementation
+#################################################################################
+org.eclipse.kapua.test.authentication.CredentialsFactoryMock

--- a/service/system/test/src/test/resources/shiro.ini
+++ b/service/system/test/src/test/resources/shiro.ini
@@ -1,0 +1,72 @@
+# =======================
+# Shiro INI configuration
+# =======================
+
+[main]
+# Objects and their properties are defined here,
+# Such as the securityManager, Realms and anything
+# else needed to build the SecurityManager
+
+#authenticator
+authenticator = org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticator
+securityManager.authenticator = $authenticator
+
+#
+# Auth filters
+# kapuaAuthcAccessToken = org.eclipse.kapua.app.api.auth.KapuaTokenAuthenticationFilter
+
+#cacheManager = org.eclipse.kapua.broker.core.experimental.CacheManager
+#securityManager.cacheManager = $cacheManager
+
+##########
+# Realms #
+##########
+# Login
+kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
+
+# Session
+kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
+
+########################
+#Authorization section #
+########################
+# Authorization
+kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
+#removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
+securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
+
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
+#realms must be set again otherwise the authorizer will not have any.
+#The security manager (AuthorizingSecurityManager) is built in this way:
+#    AuthorizingSecurityManager()         //constructor
+#    setRealms(realms)                    //set realms (if any)
+#    afterRealmsSet()                     //set realms to authenticator (if any)
+#    setAuthorizer(Authorizer authorizer) //if any configured
+#    setAuthenticator()                   //if any custom authenticator is set
+#In this way the new authenticator must have the realms already configured once is set to the security manager.
+#Otherwise the security manager doesn't set it's own security manager to the authenticator
+authorizer.realms = $kapuaAuthorizingRealm
+securityManager.authorizer = $authorizer
+
+# SessionListeners only works with in the native SessionMode
+# This is not the mode we use when running in Tomcat.
+#securityManager.sessionMode = native
+securityManager.sessionManager.globalSessionTimeout = -1
+securityManager.sessionManager.sessionValidationSchedulerEnabled = false
+
+securityManager.subjectDAO.sessionStorageEvaluator.sessionStorageEnabled = false
+
+[users]
+# The 'users' section is for simple deployments
+# when you only need a small number of statically-defined
+# set of User accounts.
+
+[roles]
+# The 'roles' section is for simple deployments
+# when you only need a small number of statically-defined
+# roles.
+
+[urls]
+# The 'urls' section is used for url-based security
+# in web applications.  We'll discuss this section in the
+# Web documentation


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3716, i.e. creates an endpoint used to retrieve information about the current system.
For now, the info are: `version` and `build version`, but in the future it can be used to retrieve even other info.