### PR TITLE
Added NPE checking on JobEngineClient response error handling

### DIFF
--- a/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineServiceClient.java
+++ b/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineServiceClient.java
@@ -275,10 +275,19 @@ public class JobEngineServiceClient implements JobEngineService {
     private KapuaException buildJobEngineExceptionFromResponse(String responseText) {
         try {
             if (StringUtils.isBlank(responseText)) {
-                throw new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, "Job Engine returned an error but no message was given");
+                throw new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, "JobEngine returned an error but no message was given");
             }
 
             ExceptionInfo exceptionInfo = XmlUtil.unmarshalJson(responseText, ExceptionInfo.class);
+
+            if (exceptionInfo == null) {
+                throw new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, "Job Engine returned an not-empty response but it was not deserializable as an ExceptionInfo. Content returned: " + responseText);
+            }
+
+            if (exceptionInfo.getKapuaErrorCode() == null) {
+                throw new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, "Job Engine returned an ExceptionInfo without a KapuaErrorCode. Content returned: " + responseText);
+            }
+
             switch (exceptionInfo.getKapuaErrorCode()) {
                 case "ENTITY_NOT_FOUND":
                     EntityNotFoundExceptionInfo entityNotFoundExceptionInfo = XmlUtil.unmarshalJson(responseText, EntityNotFoundExceptionInfo.class);


### PR DESCRIPTION
This PR adds handling of possible NPE while checking content of the JobEngine web application response in case of error.

**Related Issue**
_None_

**Description of the solution adopted**
Added NPEs check and thrown proper exception

**Screenshots**
_None_

**Any side note on the changes made**
_None_