### PR TITLE
Correct retrieval of specific endpoints 

### DIFF
--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -191,7 +191,7 @@ public class EndpointInfoServiceImpl
         EndpointInfo endpointInfoToFind = entityManagerSession.doAction(em -> EndpointInfoDAO.find(em, KapuaId.ANY, endpointInfoId)); // search the endpoint in any scope
 
         if (endpointInfoToFind == null) {
-            throw new KapuaEntityNotFoundException(EndpointInfo.TYPE, scopeId);
+            throw new KapuaEntityNotFoundException(EndpointInfo.TYPE, endpointInfoId);
         }
 
         if (endpointInfoToFind.getScopeId().equals(scopeId)) { //found in the specified scope, search finish here
@@ -204,7 +204,7 @@ public class EndpointInfoServiceImpl
         EndpointInfoListResult nearestUsableEndpoints = query(query, type);
 
         if (nearestUsableEndpoints.isEmpty() || ! nearestUsableEndpoints.getFirstItem().getScopeId().equals(endpointInfoToFind.getScopeId())) { //the second condition is equivalent to verify if the searched endpoint is in this list
-            throw new KapuaEntityNotFoundException(EndpointInfo.TYPE, scopeId);
+            throw new KapuaEntityNotFoundException(EndpointInfo.TYPE, endpointInfoId);
         } else {
             return endpointInfoToFind;
         }


### PR DESCRIPTION
Brief description of the PR.
Modifications to the "find" function inside the endpoint service to correctly retrieve specific endpoints.

**Description of the solution adopted**
The query function of the service has been re-used in order to retrieve the available endpoints in the scope (aka, the nearest defined proceeding upwards in the hierarchy).  This doesn't mean a performance penalty with respect to a specific traversal to retrieve the same data because actually the steps performed are the same.
