### PR TITLE
Add new information in `system info` endpoint response

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -31,7 +31,7 @@ public enum SystemSettingKey implements SettingKey {
      */
     SYS_ADMIN_ACCOUNT("commons.sys.admin.account"),
     /**
-     * System administration user name
+     * System administration username
      */
     SYS_ADMIN_USERNAME("commons.sys.admin.userName"),
 
@@ -42,7 +42,15 @@ public enum SystemSettingKey implements SettingKey {
     /**
      * Build version
      */
-    BUILD_VERSION("commons.build.version"),
+    BUILD_REVISION("commons.build.revision"),
+    /**
+     * Build timestamp
+     */
+    BUILD_TIMESTAMP("commons.build.timestamp"),
+    /**
+     * Build branch
+     */
+    BUILD_BRANCH("commons.build.branch"),
     /**
      * Build number
      */

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -16,8 +16,10 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=${project.version}
-commons.build.version=${buildNumber}
-commons.build.number=
+commons.build.revision=${buildNumber}
+commons.build.timestamp=${maven.build.timestamp}
+commons.build.branch=${scmBranch}
+commons.build.number=${env.BUILD_NUMBER}
 
 #
 # SQL database settings

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/system/SystemSettingKeyTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/system/SystemSettingKeyTest.java
@@ -13,13 +13,12 @@
 package org.eclipse.kapua.commons.setting.system;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
-
-import java.util.Map;
-import java.util.EnumMap;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.util.EnumMap;
+import java.util.Map;
 
 
 @Category(JUnitTests.class)
@@ -34,7 +33,9 @@ public class SystemSettingKeyTest {
         systemSettings.put(SystemSettingKey.SYS_ADMIN_ACCOUNT, "commons.sys.admin.account");
         systemSettings.put(SystemSettingKey.SYS_ADMIN_USERNAME, "commons.sys.admin.userName");
         systemSettings.put(SystemSettingKey.VERSION, "commons.version");
-        systemSettings.put(SystemSettingKey.BUILD_VERSION, "commons.build.version");
+        systemSettings.put(SystemSettingKey.BUILD_REVISION, "commons.build.revision");
+        systemSettings.put(SystemSettingKey.BUILD_TIMESTAMP, "commons.build.timestamp");
+        systemSettings.put(SystemSettingKey.BUILD_BRANCH, "commons.build.branch");
         systemSettings.put(SystemSettingKey.BUILD_NUMBER, "commons.build.number");
         systemSettings.put(SystemSettingKey.CHAR_ENCODING, "character.encoding");
         systemSettings.put(SystemSettingKey.DB_JDBC_CONNECTION_URL_RESOLVER, "commons.db.jdbcConnectionUrlResolver");

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
@@ -45,9 +45,9 @@ import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.AuthenticationService;
 import org.eclipse.kapua.service.authentication.CredentialsFactory;
 import org.eclipse.kapua.service.authentication.JwtCredentials;
-import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationErrorCodes;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService;
+import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationErrorCodes;
 import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationException;
 import org.eclipse.kapua.service.authentication.registration.RegistrationService;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
@@ -293,7 +293,7 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
         SystemSetting commonsConfig = SystemSetting.getInstance();
 
         gwtSession.setVersion(commonsConfig.getString(SystemSettingKey.VERSION));
-        gwtSession.setBuildVersion(commonsConfig.getString(SystemSettingKey.BUILD_VERSION));
+        gwtSession.setBuildVersion(commonsConfig.getString(SystemSettingKey.BUILD_REVISION));
         gwtSession.setBuildNumber(commonsConfig.getString(SystemSettingKey.BUILD_NUMBER));
         gwtSession.setSsoEnabled(ConsoleSsoLocator.getLocator(this).getService().isEnabled());
         gwtSession.setDatastoreDisabled(DatastoreSettings.getInstance().getBoolean(DatastoreSettingsKey.DISABLE_DATASTORE, false));

--- a/pom.xml
+++ b/pom.xml
@@ -484,9 +484,6 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
                     <version>${buildnumber-maven-plugin.version}</version>
-                    <configuration>
-                        <timestampFormat>{0,date,yyyyMMdd}</timestampFormat>
-                    </configuration>
                     <executions>
                         <execution>
                             <phase>validate</phase>

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 commons.settings.hotswap=true

--- a/rest-api/resources/src/main/resources/openapi/systemInfo/systemInfo.yaml
+++ b/rest-api/resources/src/main/resources/openapi/systemInfo/systemInfo.yaml
@@ -34,9 +34,21 @@ components:
         version:
           type: string
           description: Version of the system
-        build:
+        revision:
           type: string
-          description: Build version of the system
+          description: Last commit hash of the system
+        buildDate:
+          type: string
+          description: Build date of the system
+        buildNumber:
+          type: string
+          description: Build number of the system
+        buildBranch:
+          type: string
+          description: Build branch of the system
       example:
-        version: 5.10.0
-        build: 0217c5988517bb3cfeef783d43438a8b8faaa1d8
+        buildBranch: release/2.0.0,
+        buildNumber: 142
+        buildDate: 2023-03-02T08:50:59Z UTC
+        revision: e53c7b7d4208204a0791ec296fa3d4dbe2344585
+        version": 2.0.0

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #

--- a/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #

--- a/service/security/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/test/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #

--- a/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfo.java
+++ b/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfo.java
@@ -34,9 +34,23 @@ public interface SystemInfo {
 
     void setVersion(String version);
 
-    @XmlElement(name = "buildVersion")
-    String getBuildVersion();
+    @XmlElement(name = "revision")
+    String getRevision();
 
+    void setRevision(String revision);
 
-    void setBuildVersion(String buildVersion);
+    @XmlElement(name = "buildDate")
+    String getBuildTimestamp();
+
+    void setBuildTimestamp(String buildDate);
+
+    @XmlElement(name = "buildBranch")
+    String getBuildBranch();
+
+    void setBuildBranch(String buildBranch);
+
+    @XmlElement(name = "buildNumber")
+    String getBuildNumber();
+
+    void setBuildNumber(String buildNumber);
 }

--- a/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoImpl.java
+++ b/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoImpl.java
@@ -17,6 +17,9 @@ import org.eclipse.kapua.service.systeminfo.SystemInfo;
 public class SystemInfoImpl implements SystemInfo {
     private String version;
     private String buildNumber;
+    private String buildDate;
+    private String buildBranch;
+    private String buildRevision;
 
 
     @Override
@@ -32,13 +35,49 @@ public class SystemInfoImpl implements SystemInfo {
 
 
     @Override
-    public String getBuildVersion() {
+    public String getRevision() {
+        return buildRevision;
+    }
+
+
+    @Override
+    public void setRevision(String revision) {
+        this.buildRevision = revision;
+    }
+
+
+    @Override
+    public String getBuildTimestamp() {
+        return buildDate;
+    }
+
+
+    @Override
+    public void setBuildTimestamp(String buildDate) {
+        this.buildDate = buildDate;
+    }
+
+
+    @Override
+    public String getBuildNumber() {
         return buildNumber;
     }
 
 
     @Override
-    public void setBuildVersion(String buildVersion) {
-        this.buildNumber = buildVersion;
+    public void setBuildNumber(String buildNumber) {
+        this.buildNumber = buildNumber;
+    }
+
+
+    @Override
+    public String getBuildBranch() {
+        return buildBranch;
+    }
+
+
+    @Override
+    public void setBuildBranch(String buildBranch) {
+        this.buildBranch = buildBranch;
     }
 }

--- a/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoServiceImpl.java
+++ b/service/system/internal/src/main/java/org/eclipse/kapua/service/systeminfo/internal/SystemInfoServiceImpl.java
@@ -30,13 +30,18 @@ public class SystemInfoServiceImpl implements SystemInfoService {
     public SystemInfo getSystemInfo() {
         SystemSetting systemSetting = SystemSetting.getInstance();
         String version = systemSetting.getString(SystemSettingKey.VERSION);
-        String buildVersion = systemSetting.getString(SystemSettingKey.BUILD_VERSION);
+        String revision = systemSetting.getString(SystemSettingKey.BUILD_REVISION);
+        String branch = systemSetting.getString(SystemSettingKey.BUILD_BRANCH);
+        String timestamp = systemSetting.getString(SystemSettingKey.BUILD_TIMESTAMP);
+        String buildNumber = systemSetting.getString(SystemSettingKey.BUILD_NUMBER);
 
         SystemInfoFactory systemInfoFactory = locator.getFactory(SystemInfoFactory.class);
         SystemInfo systemInfo = systemInfoFactory.newSystemInfo();
         systemInfo.setVersion(version);
-        systemInfo.setBuildVersion(buildVersion);
-
+        systemInfo.setRevision(revision);
+        systemInfo.setBuildBranch(branch);
+        systemInfo.setBuildTimestamp(timestamp + " UTC");
+        systemInfo.setBuildNumber(buildNumber);
         return systemInfo;
     }
 }

--- a/service/system/test-steps/src/main/java/org/eclipse/kapua/service/systeminfo/steps/SystemInfoSteps.java
+++ b/service/system/test-steps/src/main/java/org/eclipse/kapua/service/systeminfo/steps/SystemInfoSteps.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.qa.common.StepData;
 import org.eclipse.kapua.qa.common.TestBase;
 import org.eclipse.kapua.service.systeminfo.SystemInfo;
-import org.eclipse.kapua.service.systeminfo.SystemInfoFactory;
 import org.eclipse.kapua.service.systeminfo.SystemInfoService;
 import org.junit.Assert;
 
@@ -29,7 +28,6 @@ import javax.inject.Singleton;
 @Singleton
 public class SystemInfoSteps extends TestBase {
     private SystemInfoService systemInfoService;
-    private SystemInfoFactory systemInfoFactory;
 
 
     @Inject
@@ -42,7 +40,6 @@ public class SystemInfoSteps extends TestBase {
     public void setServices() {
         KapuaLocator locator = KapuaLocator.getInstance();
         systemInfoService = locator.getService(SystemInfoService.class);
-        systemInfoFactory = locator.getFactory(SystemInfoFactory.class);
     }
 
 
@@ -50,13 +47,39 @@ public class SystemInfoSteps extends TestBase {
     public void configureSystemInfo() {
         SystemInfo systemInfo = systemInfoService.getSystemInfo();
         stepData.put("systemVersion", systemInfo.getVersion());
-        stepData.put("systemBuildVersion", systemInfo.getBuildVersion());
+        stepData.put("buildNumber", systemInfo.getBuildNumber());
+        stepData.put("buildRevision", systemInfo.getRevision());
+        stepData.put("buildTimestamp", systemInfo.getBuildTimestamp());
+        stepData.put("buildBranch", systemInfo.getBuildBranch());
     }
 
 
-    @Then("The version of the system is {string} and the build version of the system is {string}")
-    public void theVersionOfTheSystemIsAndTheBuildVersionOfTheSystemIs(String expectedVersion, String expectedBuildVersion) {
+    @Then("The version of the system is {string}")
+    public void theVersionOfTheSystemIs(String expectedVersion) {
         Assert.assertEquals(stepData.get("systemVersion"), expectedVersion);
-        Assert.assertEquals(stepData.get("systemBuildVersion"), expectedBuildVersion);
+    }
+
+
+    @Then("The build number of the system is {string}")
+    public void theBuildNumberOfTheSystemIs(String expectedBuildNumber) {
+        Assert.assertEquals(stepData.get("buildNumber"), expectedBuildNumber);
+    }
+
+
+    @Then("The build revision of the system is {string}")
+    public void theRevisionOfTheSystemIs(String expectedBuildRevision) {
+        Assert.assertEquals(stepData.get("buildRevision"), expectedBuildRevision);
+    }
+
+
+    @Then("The build timestamp of the system is {string}")
+    public void theTimestampOfTheSystemIs(String expectedBuildTimestamp) {
+        Assert.assertEquals(stepData.get("buildTimestamp"), expectedBuildTimestamp);
+    }
+
+
+    @Then("The build branch of the system is {string}")
+    public void theBranchOfTheSystemIs(String expectedBuildBranch) {
+        Assert.assertEquals(stepData.get("buildBranch"), expectedBuildBranch);
     }
 }

--- a/service/system/test/src/test/resources/features/SystemInfoServiceUnitTests.feature
+++ b/service/system/test/src/test/resources/features/SystemInfoServiceUnitTests.feature
@@ -22,6 +22,10 @@ Feature: System Info
     And Init Security Context
 
 
-  Scenario: Retrieve the system info
+  Scenario: Retrieve the system info, then check if everything match with provided properties.
     When I retrieve the system info
-    Then The version of the system is "kapuaVersion42" and the build version of the system is "kapuaBuildVersion42"
+    Then The version of the system is "kapuaVersion42"
+    And The build number of the system is "kapuaBuildNumber42"
+    And The build revision of the system is "42a24b"
+    And The build timestamp of the system is "1677748276 UTC"
+    And The build branch of the system is "test-branch"

--- a/service/system/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/system/test/src/test/resources/kapua-environment-setting.properties
@@ -16,8 +16,10 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=kapuaVersion42
-commons.build.version=kapuaBuildVersion42
-commons.build.number=
+commons.build.revision=42a24b
+commons.build.timestamp=1677748276
+commons.build.branch=test-branch
+commons.build.number=kapuaBuildNumber42
 
 #
 # SQL database settings

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -16,7 +16,9 @@ commons.sys.admin.account=kapua-sys
 commons.sys.admin.userName=kapua-sys
 
 commons.version=
-commons.build.version=
+commons.build.revision=
+commons.build.timestamp=
+commons.build.branch=
 commons.build.number=
 
 #


### PR DESCRIPTION
**Brief description of the PR.**
This PR fixes #3728, i.e. adds new information inside the response of the `system info` endpoint.
Before this PR the response was something like this:
```
{
   "version": "2.0.0",
   "build": "0217c5988517bb3cfeef783d43438a8b8faaa1d8"
}
```
While after the PR the response is something like this:
```
{
    "buildBranch": "develop",
    "buildNumber": "142",
    "buildDate": "2023-03-02T08:50:59Z UTC",
    "revision": "e53c7b7d4208204a0791ec296fa3d4dbe2344585",
    "version": "2.0.0-SNAPSHOT"
}
``` 

**Related Issue**
#3728.