### PR TITLE
Inserted missing checks on nested entities

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessPermissions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessPermissions.java
@@ -223,6 +223,13 @@ public class AccessPermissions extends AbstractKapuaResource {
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("accessInfoId") EntityId accessInfoId,
             @PathParam("accessPermissionId") EntityId accessPermissionId) throws KapuaException {
+
+        try {
+            find(scopeId,accessInfoId,accessPermissionId);
+        } catch (KapuaEntityNotFoundException e) {
+            throw e;
+        }
+
         accessPermissionService.delete(scopeId, accessPermissionId);
 
         return returnNoContent();


### PR DESCRIPTION
This PR inserts some missing checks of existence on nested entities. 
For example, in the provided commit, the delete function of AccessPermissions endpoints has been revisited in order to check if the provided accessPermission exists inside the provided accessInfo. This kind of control is in place for the find function but not for the delete one (the one modified here), so I wanted to fill the gap.

Other endpoints have this same problem and with this first commit I simply wanted to demonstrate the kind of modifications I would like to do.