### PR TITLE
Add reset user password button to the console

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
@@ -39,6 +39,7 @@ import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authentication.client.messages.ConsoleCredentialMessages;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredential;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialQuery;
+import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialType;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.permission.CredentialSessionPermission;
 import org.eclipse.kapua.app.console.module.authentication.shared.service.GwtCredentialService;
 import org.eclipse.kapua.app.console.module.authentication.shared.service.GwtCredentialServiceAsync;
@@ -237,6 +238,10 @@ public class CredentialGrid extends EntityGrid<GwtCredential> {
                 getSelectionModel().getSelectedItem() != null &&
                         getSelectionModel().getSelectedItem().getLockoutReset() != null &&
                         currentSession.hasPermission(CredentialSessionPermission.write()));
+        getToolbar().getResetPasswordButton().setEnabled(
+            getSelectionModel().getSelectedItem() != null &&
+                getSelectionModel().getSelectedItem().getCredentialTypeEnum().equals(GwtCredentialType.PASSWORD) &&
+                currentSession.hasPermission(CredentialSessionPermission.write()));
     }
 
     @Override

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialResetDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialResetDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,38 +12,43 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authentication.client.tabs.credentials;
 
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.widget.Label;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DateUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
-import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.ConfirmPasswordUpdateFieldValidator;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.PasswordUpdateFieldValidator;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredential;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialType;
 
 import java.util.Date;
 
-public class CredentialEditDialog extends CredentialAddDialog {
-
+public class CredentialResetDialog extends CredentialAddDialog {
     private final GwtCredential selectedCredential;
 
     private final Label lockedUntil = new Label();
 
-    public CredentialEditDialog(GwtSession currentSession, GwtCredential selectedCredential, String selectedUserId, String selectedUserName) {
+
+    public CredentialResetDialog(GwtSession currentSession, String selectedUserId, String selectedUserName, GwtCredential selectedCredential) {
         super(currentSession, selectedUserId, selectedUserName);
         this.selectedCredential = selectedCredential;
     }
 
+
     @Override
     public void submit() {
-        // TODO read enabled and expire date
         selectedCredential.setCredentialKey(password.getValue());
         selectedCredential.setExpirationDate(expirationDate.getValue());
         selectedCredential.setCredentialStatus(credentialStatus.getValue().getValue().toString());
         selectedCredential.setOptlock(optlock.getValue().intValue());
-        GWT_CREDENTIAL_SERVICE.update(xsrfToken, selectedCredential, new AsyncCallback<GwtCredential>() {
+        GWT_CREDENTIAL_SERVICE.resetPassword(xsrfToken, selectedCredential.getScopeId(), selectedCredential.getId(), password.getValue(), new AsyncCallback<Void>() {
 
             @Override
             public void onFailure(Throwable caught) {
@@ -60,25 +65,22 @@ public class CredentialEditDialog extends CredentialAddDialog {
             }
 
             @Override
-            public void onSuccess(GwtCredential result) {
+            public void onSuccess(Void result) {
                 exitStatus = true;
-
-                if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.API_KEY) {
-                    exitMessage = MSGS.dialogEditConfirmationAPI();
-                } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
-                    exitMessage = MSGS.dialogEditConfirmationPassword();
-                }
+                exitMessage = MSGS.dialogEditConfirmationPassword();
 
                 hide();
             }
         });
     }
 
+
     @Override
     public void createBody() {
         super.createBody();
         loadCredential();
     }
+
 
     private void loadCredential() {
         credentialType.setSimpleValue(selectedCredential.getCredentialTypeEnum());
@@ -90,27 +92,54 @@ public class CredentialEditDialog extends CredentialAddDialog {
             credentialStatus.setToolTip(MSGS.dialogAddStatusApiKeyTooltip());
         } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
             passwordTooltip.show();
-            DialogUtils.resizeDialog(CredentialEditDialog.this, 400, 355);
+            DialogUtils.resizeDialog(CredentialResetDialog.this, 400, 355);
             expirationDate.setToolTip(MSGS.dialogAddFieldExpirationDatePasswordTooltip());
             credentialStatus.setToolTip(MSGS.dialogAddStatusPasswordTooltip());
         }
     }
 
+
     @Override
     protected void onRender(Element parent, int pos) {
         super.onRender(parent, pos);
-        password.setVisible(false);
-        confirmPassword.setVisible(false);
-        passwordTooltip.setVisible(false);
+        DialogUtils.resizeDialog(this, 400, 250);
+        password.setVisible(true);
+        confirmPassword.setVisible(true);
+        passwordTooltip.setVisible(true);
         credentialFormPanel.remove(credentialType);
-        credentialTypeLabel.setVisible(true);
-        credentialTypeLabel.setValue(selectedCredential.getCredentialType());
+        credentialTypeLabel.setVisible(false);
+        expirationDate.setVisible(false);
+        credentialStatus.setVisible(false);
+        password.setFieldLabel(MSGS.dialogEditFieldNewPassword());
+        password.setAllowBlank(true);
+        password.addListener(Events.Change, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                confirmPassword.setAllowBlank(password.getValue() == null || password.getValue().equals(""));
+            }
+        });
+        confirmPassword.setFieldLabel(MSGS.dialogEditFieldConfirmNewPassword());
+        confirmPassword.setAllowBlank(true);
         if (selectedCredential.getLockoutReset() != null && selectedCredential.getLockoutReset().after(new Date())) {
             lockedUntil.setText(MSGS.dialogEditLockedUntil(DateUtils.formatDateTime(selectedCredential.getLockoutReset())));
             credentialFormPanel.add(lockedUntil);
         }
-        DialogUtils.resizeDialog(this, 400, 230);
+        GWT_CREDENTIAL_SERVICE.getMinPasswordLength(selectedCredential.getScopeId(), new AsyncCallback<Integer>() {
+
+            @Override
+            public void onFailure(Throwable caught) {
+                FailureHandler.handle(caught);
+            }
+
+            @Override
+            public void onSuccess(Integer result) {
+                confirmPassword.setValidator(new ConfirmPasswordUpdateFieldValidator(confirmPassword, password, result));
+                password.setValidator(new PasswordUpdateFieldValidator(password, result));
+            }
+        });
     }
+
 
     @Override
     public void validateUserCredential() {
@@ -120,33 +149,24 @@ public class CredentialEditDialog extends CredentialAddDialog {
             ConsoleInfo.display(CMSGS.popupError(), password.getErrorMessage());
         } else if (password.getValue() != null && !password.getValue().equals(confirmPassword.getValue())) {
             ConsoleInfo.display(CMSGS.popupError(), confirmPassword.getErrorMessage());
-        } else if (!expirationDate.isValid()) {
-            ConsoleInfo.display(CMSGS.popupError(), KapuaSafeHtmlUtils.htmlUnescape(expirationDate.getErrorMessage()));
         }
     }
+
 
     @Override
     protected void preSubmit() {
         super.preSubmit();
     }
 
+
     @Override
     public String getHeaderMessage() {
-        if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.API_KEY) {
-            return MSGS.dialogEditApiKeyHeader(selectedCredential.getUsername());
-        } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
-            return MSGS.dialogEditPasswordHeader(selectedCredential.getUsername());
-        }
-        return MSGS.dialogEditHeader(selectedCredential.getUsername());
+        return MSGS.dialogResetPasswordHeader(selectedCredential.getUsername());
     }
+
 
     @Override
     public String getInfoMessage() {
-        if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.API_KEY) {
-            return MSGS.dialogEditApiKeyInfo();
-        } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
-            return MSGS.dialogEditPasswordInfo();
-        }
-        return MSGS.dialogEditInfo();
+        return MSGS.dialogResetPassword();
     }
 }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
@@ -33,6 +33,7 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
     private String selectedUserName;
 
     private final KapuaButton unlockButton;
+    private final KapuaButton resetPasswordButton;
 
     private static final ConsoleCredentialMessages MSGS = GWT.create(ConsoleCredentialMessages.class);
 
@@ -48,6 +49,16 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
                 }
             }
         });
+        resetPasswordButton = new KapuaButton(MSGS.resetPasswordButton(), new KapuaIcon(IconSet.UNDO), new SelectionListener<ButtonEvent>() {
+
+            @Override
+            public void componentSelected(ButtonEvent buttonEvent) {
+                GwtCredential selectedCredential = gridSelectionModel.getSelectedItem();
+                if (selectedUserId != null && selectedCredential != null) {
+                    showResetPasswordDialog(selectedCredential);
+                }
+            }
+        });
     }
 
     @Override
@@ -55,6 +66,8 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
         super.onRender(target, index);
         add(new SeparatorToolItem());
         add(getUnlockButton());
+        add(new SeparatorToolItem());
+        add(getResetPasswordButton());
 
         updateButtonsEnabled();
         getEditEntityButton().disable();
@@ -64,6 +77,7 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
         if (getFilterButton() != null) {
             getFilterButton().hide();
         }
+        resetPasswordButton.disable();
         setBorders(true);
     }
 
@@ -115,10 +129,22 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
         return unlockButton;
     }
 
+
+    public KapuaButton getResetPasswordButton() {
+        return resetPasswordButton;
+    }
+
+
     private void showUnlockDialog(GwtCredential selectedCredential) {
         CredentialUnlockDialog dialog = new CredentialUnlockDialog(selectedCredential);
         dialog.addListener(Events.Hide, getHideDialogListener());
         dialog.show();
     }
 
+
+    private void showResetPasswordDialog(GwtCredential selectedCredential) {
+        CredentialResetDialog dialog = new CredentialResetDialog(currentSession, selectedUserId, selectedUserName, selectedCredential);
+        dialog.addListener(Events.Hide, getHideDialogListener());
+        dialog.show();
+    }
 }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
@@ -49,6 +49,7 @@ import org.eclipse.kapua.service.authentication.exception.PasswordLengthExceptio
 import org.eclipse.kapua.service.authentication.shiro.utils.AuthenticationUtils;
 import org.eclipse.kapua.service.authentication.shiro.utils.CryptAlgorithm;
 import org.eclipse.kapua.service.authentication.user.PasswordChangeRequest;
+import org.eclipse.kapua.service.authentication.user.PasswordResetRequest;
 import org.eclipse.kapua.service.authentication.user.UserCredentialsFactory;
 import org.eclipse.kapua.service.authentication.user.UserCredentialsService;
 import org.eclipse.kapua.service.user.User;
@@ -124,7 +125,7 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
             }
 
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
 
         return new BasePagingLoadResult<GwtCredential>(gwtCredentials, loadConfig.getOffset(), totalLength);
@@ -140,7 +141,7 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
 
             CREDENTIAL_SERVICE.delete(scopeId, credentialId);
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
     }
 
@@ -166,7 +167,7 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
             gwtCredential.setCredentialKey(credential.getCredentialKey());
 
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
 
         //
@@ -204,7 +205,7 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
             gwtCredentialUpdated = KapuaGwtAuthenticationModelConverter.convertCredential(credentialUpdated, user);
 
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
 
         //
@@ -244,14 +245,14 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
             );
 
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
     }
 
 
     @Override
     public void changePassword(GwtXSRFToken gwtXsrfToken, String oldPassword, final String newPassword, String mfaCode, String stringUserId, String stringScopeId) throws GwtKapuaException {
-        String username = null;
+        String username;
         try {
             final KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(stringScopeId);
             final KapuaId userId = GwtKapuaCommonsModelConverter.convertKapuaId(stringUserId);
@@ -280,9 +281,27 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
             USER_CREDENTIALS_SERVICE.changePasswordRequest(passwordChangeRequest);
 
         } catch (Exception e) {
-            KapuaExceptionHandler.handle(e);
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
     }
+
+
+    @Override
+    public void resetPassword(GwtXSRFToken gwtXsrfToken, String stringScopeId, String gwtCredentialId, final String newPassword) throws GwtKapuaException {
+        checkXSRFToken(gwtXsrfToken);
+
+        try {
+            final KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(stringScopeId);
+            final KapuaId credentialId = GwtKapuaCommonsModelConverter.convertKapuaId(gwtCredentialId);
+
+            PasswordResetRequest passwordResetRequest = USER_CREDENTIALS_FACTORY.newPasswordResetRequest();
+            passwordResetRequest.setNewPassword(newPassword);
+            USER_CREDENTIALS_SERVICE.resetPassword(scopeId, credentialId, passwordResetRequest);
+        } catch (KapuaException e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
+        }
+    }
+
 
     @Override
     public void unlock(GwtXSRFToken xsrfToken, String stringScopeId, String gwtCredentialId) throws GwtKapuaException {
@@ -297,7 +316,7 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
 
             CREDENTIAL_SERVICE.unlock(scopeId, credentialId);
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
     }
 

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/service/GwtCredentialService.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/service/GwtCredentialService.java
@@ -12,16 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authentication.shared.service;
 
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredential;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialCreator;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialQuery;
-
-import com.extjs.gxt.ui.client.data.PagingLoadConfig;
-import com.extjs.gxt.ui.client.data.PagingLoadResult;
-import com.google.gwt.user.client.rpc.RemoteService;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
 @RemoteServiceRelativePath("credential")
 public interface GwtCredentialService extends RemoteService {
@@ -33,7 +32,7 @@ public interface GwtCredentialService extends RemoteService {
      * @return
      * @throws GwtKapuaException
      */
-    public PagingLoadResult<GwtCredential> query(PagingLoadConfig loadConfig, GwtCredentialQuery gwtCredentialQuery)
+    PagingLoadResult<GwtCredential> query(PagingLoadConfig loadConfig, GwtCredentialQuery gwtCredentialQuery)
             throws GwtKapuaException;
 
     /**
@@ -42,19 +41,21 @@ public interface GwtCredentialService extends RemoteService {
      * @param gwtCredentialId
      * @throws GwtKapuaException
      */
-    public void delete(GwtXSRFToken xsfrToken, String stringScopeId, String gwtCredentialId)
+    void delete(GwtXSRFToken xsfrToken, String stringScopeId, String gwtCredentialId)
             throws GwtKapuaException;
 
-    public GwtCredential create(GwtXSRFToken gwtXsrfToken, GwtCredentialCreator gwtRoleCreator)
+    GwtCredential create(GwtXSRFToken gwtXsrfToken, GwtCredentialCreator gwtRoleCreator)
             throws GwtKapuaException;
 
-    public GwtCredential update(GwtXSRFToken gwtXsrfToken, GwtCredential gwtCredential)
+    GwtCredential update(GwtXSRFToken gwtXsrfToken, GwtCredential gwtCredential)
             throws GwtKapuaException;
 
-    public void changePassword(GwtXSRFToken gwtXsrfToken, String oldPassword, String newPassword, String mfaCode, String stringUserId, String stringScopeId)
+    void changePassword(GwtXSRFToken gwtXsrfToken, String oldPassword, String newPassword, String mfaCode, String stringUserId, String stringScopeId)
             throws GwtKapuaException;
 
-    public void unlock(GwtXSRFToken xsfrToken, String stringScopeId, String gwtCredentialId)
+    void resetPassword(GwtXSRFToken gwtXsrfToken, String stringScopeId, String gwtCredentialId, String newPassword) throws GwtKapuaException;
+
+    void unlock(GwtXSRFToken xsfrToken, String stringScopeId, String gwtCredentialId)
             throws GwtKapuaException;
 
     Integer getMinPasswordLength(String scopeId)

--- a/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
+++ b/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
@@ -76,6 +76,8 @@ dialogEditError=Credentials edit failed: {0}
 dialogEditFieldNewPassword=New Password
 dialogEditFieldConfirmNewPassword=Confirm New Password
 dialogEditLockedUntil=These credentials are locked until {0}
+dialogResetPassword=Reset the password for the selected user.
+dialogResetPasswordHeader=Reset Password: {0}
 
 #
 # Delete dialog
@@ -95,6 +97,11 @@ dialogUnlockHeader=Unlock Credential: {0}
 dialogUnlockInfo=Are you sure you want to unlock selected credential?
 dialogUnlockConfirmation=Credentials successfully unlocked.
 dialogUnlockError=Credentials unlock failed: {0}
+
+#
+# Reset password dialog
+resetPasswordButton=Reset
+dialogPasswordResetHeader=Reset password: {0}
 
 #
 # Credential Filter


### PR DESCRIPTION
**Brief description of the PR.**
This PR fixes #3733, i.e. add the possibility of resetting the password of a user via console.

**Related Issue**
#3733.

**Description of the solution adopted**
It was created a new button, called "Reset" used to reset the user password. This button, when pressed, display a dialog that require the new password of the user.

**Screenshots**
<img width="408" alt="Screenshot 2023-03-08 at 09 49 53" src="https://user-images.githubusercontent.com/66636702/223731499-ad99e9ee-5a61-485f-b6ab-ff840f39c0ae.png">
<img width="408" alt="Screenshot 2023-03-08 at 09 50 01" src="https://user-images.githubusercontent.com/66636702/223731509-1a988a6d-ae25-497d-ba81-4a37bd856efa.png">
<img width="385" alt="Screenshot 2023-03-08 at 09 50 14" src="https://user-images.githubusercontent.com/66636702/223731510-50b98606-1387-4461-bffd-8146ca842da9.png">
<img width="1081" alt="Screenshot 2023-03-08 at 15 27 38" src="https://user-images.githubusercontent.com/66636702/223739588-7337671d-87da-499b-b831-da0f99897fc1.png">
<img width="1081" alt="Screenshot 2023-03-08 at 15 27 42" src="https://user-images.githubusercontent.com/66636702/223739592-fd41be31-ba01-45da-8308-1ecdfe6d122a.png">


**Any side note on the changes made**
The "Edit credential" dialog was modified in order to remove the password and confirm password fields.
