### PR TITLE
Remove `credentialKey` from `Credential` object responses when not needed

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId.yaml
@@ -28,6 +28,41 @@ paths:
             application/json:
               schema:
                 $ref: './credential.yaml#/components/schemas/credential'
+              examples:
+                Password:
+                  value:
+                    id: LgJHjS2jvdE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    optlock: 0
+                    userId: AQ
+                    credentialType: PASSWORD
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
+                API Key:
+                  value:
+                    id: LgJHjS2jvdE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    optlock: 0
+                    userId: AQ
+                    credentialType: PASSWORD
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -58,6 +93,22 @@ paths:
             application/json:
               schema:
                 $ref: './credential.yaml#/components/schemas/credential'
+              example:
+                id: LgJHjS2jvdE
+                scopeId: AQ
+                createdOn: "2023-03-09T13:58:30.385Z"
+                createdBy: AQ
+                modifiedOn: "2023-03-09T13:58:30.385Z"
+                modifiedBy: AQ
+                optlock: 0
+                userId: AQ
+                credentialType: PASSWORD
+                status: ENABLED
+                expirationDate: "2023-04-09T13:58:30.385Z"
+                loginFailures: 0
+                firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                lockoutReset: "2023-03-09T14:58:30.385Z"
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId.yaml
@@ -35,6 +35,41 @@ paths:
             application/json:
               schema:
                 $ref: './credential.yaml#/components/schemas/credentialListResult'
+              example:
+                type: credentialListResult
+                limitExceeded: false
+                size: 2
+                items:
+                  - id: LgJHjS2jvdE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    optlock: 0
+                    userId: AQ
+                    credentialType: PASSWORD
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
+                  - id: LgREjS2jadE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    optlock: 0
+                    userId: AQ
+                    credentialType: API_KEY
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -60,7 +95,7 @@ paths:
                 value:
                     userId: "AQ"
                     credentialType: PASSWORD
-                    credentialKey: "new-password-123!"
+                    credentialKey: "New-password-123!"
                     credentialStatus: ENABLED
                     expirationDate: "2019-12-31T00:00:00.000Z"
               apikey:
@@ -78,6 +113,42 @@ paths:
             application/json:
               schema:
                 $ref: './credential.yaml#/components/schemas/credential'
+              examples:
+                Password:
+                  value:
+                    id: LgJHjS2jvdE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    optlock: 0
+                    userId: AQ
+                    credentialType: PASSWORD
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
+                API Key:
+                  value:
+                    id: LgJHjS2jvdE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    credentialKey: $2a$12$BjLeC/gqcnEyk.XNo2qorul.a/v4HDuOUlfmojdSZXRSFTjymPdVm
+                    optlock: 0
+                    userId: AQ
+                    credentialType: PASSWORD
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/credential/credential.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential.yaml
@@ -40,6 +40,7 @@ components:
                 - JWT
             credentialKey:
               type: string
+              readOnly: true
             status:
               type: string
               enum:

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
@@ -85,4 +85,16 @@ public interface CredentialService extends KapuaEntityService<Credential, Creden
      * @throws KapuaException   When something goes wrong
      */
     void validatePassword(KapuaId scopeId, String plainPassword) throws KapuaException;
+
+
+    /**
+     * Return the {@link Credential} within the provided scopeId with the provided credentialId.
+     * The returned object contains the field credentialKey filled with the actual value.
+     *
+     * @param scopeId         The scope ID in which to perform the find
+     * @param credentialId    The ID of the credential to find
+     * @return                The searched Credential
+     * @throws KapuaException When something goes wrong
+     */
+    Credential findWithKey(KapuaId scopeId, KapuaId credentialId) throws KapuaException;
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -185,7 +185,7 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
                     break;
                 case PASSWORD:
                 default:
-                    credential.setCredentialKey(fullKey);
+                    credential.setCredentialKey(null);
             }
         } catch (Exception pe) {
             em.rollback();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
@@ -87,7 +87,14 @@ public class ApiKeyAuthenticatingRealm extends KapuaAuthenticatingRealm {
         // Find credential
         Credential credential = null;
         try {
-            credential = KapuaSecurityUtils.doPrivileged(() -> credentialService.findByApiKey(tokenApiKey));
+            credential = KapuaSecurityUtils.doPrivileged(() -> {
+                Credential apiCredential = credentialService.findByApiKey(tokenApiKey);
+                if (apiCredential == null) {
+                    return null;
+                } else {
+                    return credentialService.findWithKey(apiCredential.getScopeId(), apiCredential.getId());
+                }
+            });
         } catch (AuthenticationException ae) {
             throw ae;
         } catch (KapuaIllegalArgumentException ae) {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
@@ -115,7 +115,12 @@ public class UserPassAuthenticatingRealm extends KapuaAuthenticatingRealm {
 
                 List<Credential> passwordCredentialList = userCredentialList.getItems(c -> CredentialType.PASSWORD.equals(c.getCredentialType()));
 
-                return passwordCredentialList.isEmpty() ? null : passwordCredentialList.get(0);
+                if (passwordCredentialList.isEmpty()) {
+                    return null;
+                } else {
+                    Credential passwordCredential = passwordCredentialList.get(0);
+                    return credentialService.findWithKey(passwordCredential.getScopeId(), passwordCredential.getId());
+                }
             });
         } catch (AuthenticationException ae) {
             throw ae;


### PR DESCRIPTION
**Brief description of the PR.**
This PR fixes #3735, i.e. remove the `credentialKey` field form the `Credential` object when it's not needed. Thus, the field is not reported in the REST API responses.

**Related Issue**
#3735.

**Description of the solution adopted**
Set the field to `null` in the service level, and add a new method `findWithKey` that return the `Credential` object with the correct `credentialKey` to use when needed.

**Additional notes**
Open API specification is improved in order to provided meaningful example of requests and responses.
