### PR TITLE
Set timeout field tooltip time in milliseconds for Job Step

### DIFF
--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -135,7 +135,7 @@ dialogAddStepDefinitionCombo=Step definition
 dialogAddStepDefinitionComboTooltip=Select a job step definition.
 dialogAddStepDefinitionComboEmpty=Select A Step Definition
 dialogAddStepNameTooltip=Enter a unique Job step name.
-dialogAddStepTimeoutTooltip=Enter a timeout in seconds. This is timeout between pressing the Start button and actual job execution.
+dialogAddStepTimeoutTooltip=Enter a timeout in milliseconds. This is timeout between pressing the Start button and actual job execution.
 dialogAddStepDescriptionTooltip=Enter a job step description for detailed information about the step.
 
 dialogAddStepNameEmpty=Job step name


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3738, i.e. change the timeout field tooltip of the job step in milliseconds instead of seconds. 

**Screenshots**
Before the fix:
![image](https://user-images.githubusercontent.com/66636702/224665468-38828425-66ae-4b08-82d2-74f6508d1972.png)

After the fix:
<img width="605" alt="Screenshot 2023-03-13 at 09 55 03" src="https://user-images.githubusercontent.com/66636702/224665341-d4580cf2-aebd-46e1-b7a2-99f0662e9888.png">


