### PR TITLE
Fix - deletion of mandatory property for "displayName" device parameter

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -156,9 +156,8 @@ public class DeviceAddDialog extends EntityAddEditDialog {
 
         // Display name
         displayNameField = new KapuaTextField<String>();
-        displayNameField.setAllowBlank(false);
         displayNameField.setName("displayName");
-        displayNameField.setFieldLabel("* " + DEVICE_MSGS.deviceFormDisplayName());
+        displayNameField.setFieldLabel(DEVICE_MSGS.deviceFormDisplayName());
         displayNameField.setToolTip(DEVICE_MSGS.deviceFormDisplayNameTooltip());
         displayNameField.setWidth(225);
         displayNameField.setMaxLength(255);

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -225,14 +225,9 @@
             <groupId>com.allen-sauer.gwt.log</groupId>
             <artifactId>gwt-log</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-commons</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-service-api</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Deletes mandatory property for the property. Also, fixed a little typo on one duplicated dependency, which was causing warning on building