### PR TITLE
Add the possibility for an authenticated user to read and change his own profile information

### DIFF
--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
@@ -49,6 +49,7 @@ import org.eclipse.kapua.qa.common.cucumber.CucRolePermission;
 import org.eclipse.kapua.qa.common.cucumber.CucTopic;
 import org.eclipse.kapua.qa.common.cucumber.CucTriggerProperty;
 import org.eclipse.kapua.qa.common.cucumber.CucUser;
+import org.eclipse.kapua.qa.common.cucumber.CucUserProfile;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreElasticsearchClientSettings;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreElasticsearchClientSettingsKey;
 import org.eclipse.kapua.transport.message.jms.JmsTopic;
@@ -316,6 +317,14 @@ public class BasicSteps extends TestBase {
                 Util.parseBigInteger(entry.get("scopeId")),
                 entry.get("password"),
                 entry.get("expirationDate"));
+    }
+
+
+    @DataTableType
+    public CucUserProfile cucUserProfile(Map<String, String> entry) {
+        return new CucUserProfile(entry.get("displayName"),
+                                  entry.get("phoneNumber"),
+                                  entry.get("email"));
     }
 
     @ParameterType(".*")

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucUserProfile.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucUserProfile.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.qa.common.cucumber;
+
+public class CucUserProfile {
+    private String displayName;
+    private String phoneNumber;
+    private String email;
+
+
+    public CucUserProfile(String displayName, String phoneNumber, String email) {
+        this.displayName = displayName;
+        this.phoneNumber = phoneNumber;
+        this.email = email;
+    }
+
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+
+    public String getEmail() {
+        return email;
+    }
+
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserProfileUnitTests.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserProfileUnitTests.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.service.user;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = { "classpath:features/user/UserProfileUnitTests.feature"
+    },
+    glue = {"org.eclipse.kapua.service.security.test",
+        "org.eclipse.kapua.service.authorization.steps",
+        "org.eclipse.kapua.service.authentication.steps",
+        "org.eclipse.kapua.service.user.steps",
+        "org.eclipse.kapua.service.account.steps",
+        "org.eclipse.kapua.qa.common"
+    },
+    plugin = {"pretty",
+        "html:target/cucumber/UserProfile",
+        "json:target/UserProfile_cucumber.json"
+    },
+    monochrome = true)
+public class RunUserProfileUnitTests {
+}

--- a/qa/integration/src/test/resources/features/user/UserProfileUnitTests.feature
+++ b/qa/integration/src/test/resources/features/user/UserProfileUnitTests.feature
@@ -1,0 +1,62 @@
+###############################################################################
+# Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech
+###############################################################################
+@security
+@env_none
+
+Feature: User Credential
+  This feature file contains Unit tests for User Profile.
+
+  @setup
+  Scenario: Initialize test environment
+    Given Init Jaxb Context
+    And Init Security Context
+
+  Scenario: Change User Profile correctly
+  Create a user, login with it, change the user profile and then check if the operation is performed correctly.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I change the profile to the following
+      | displayName | phoneNumber | email       |
+      | Foo         | 424242      | foo@bar.com |
+    When I search for user with name "kapua-sys"
+    Then I find user
+      | kapua-sys | Foo | foo@bar.com | 424242 | ENABLED |
+    And I logout
+
+  Scenario: Change User Profile correctly to all blank values
+  Create a user, login with it, change the user profile with all fields blank, and then check if the operation is performed correctly.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I change the profile to the following
+      | displayName | phoneNumber | email |
+      |             |             |       |
+    When I search for user with name "kapua-sys"
+    Then I find user
+      | kapua-sys |  |  |  | ENABLED |
+    And I logout
+
+  Scenario: Change User Profile incorrectly
+  Create a user, login with it, change the user profile incorrectly, and then check if the exception is occurred.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument userProfile.email: foo.com."
+    When I change the profile to the following
+      | displayName | phoneNumber | email   |
+      | Foo         | 424242      | foo.com |
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Read User Profile correctly
+  Create a user, login with it, and then read its user profile.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I read the following user profile
+      | displayName    | phoneNumber     | email                 |
+      | Kapua Sysadmin | +1 555 123 4567 | kapua-sys@eclipse.org |
+    And I logout

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserProfiles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserProfiles.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.app.api.core.model.ScopeId;
+import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.user.profile.UserProfile;
+import org.eclipse.kapua.service.user.profile.UserProfileService;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("{scopeId}/user/profile")
+public class UserProfiles extends AbstractKapuaResource {
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final UserProfileService userProfileService = locator.getService(UserProfileService.class);
+
+
+    @PUT
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public Response changeUserProfile(@PathParam("scopeId") ScopeId scopeId, UserProfile userProfile) throws KapuaException {
+        userProfileService.changeUserProfile(userProfile);
+        return returnOk();
+    }
+
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public UserProfile getUserProfile(@PathParam("scopeId") ScopeId scopeId) throws KapuaException {
+        return userProfileService.getUserProfile();
+    }
+}
+

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -426,6 +426,9 @@ paths:
     $ref: './userCredentials/userCredentials-scopeId.yaml#/paths/~1{scopeId}~1user~1credentials~1password'
   /{scopeId}/user/credentials/{credentialId}/_reset:
     $ref: './userCredentials/userCredentials-scopeId-credentialId-_reset.yaml#/paths/~1{scopeId}~1user~1credentials~1{credentialId}~1_reset'
+  ### User Profile ###
+  /{scopeId}/user/profile/:
+    $ref: './userProfile/userProfile-scopeId.yaml#/paths/~1{scopeId}~1user~1profile~1'
 
 components:
   parameters:
@@ -939,6 +942,9 @@ components:
       $ref: './userCredentials/userCredentials.yaml#/components/schemas/passwordChangeRequest'
     passwordResetRequest:
       $ref: './userCredentials/userCredentials.yaml#/components/schemas/passwordResetRequest'
+    ### User Profile Entities ###
+    userProfile:
+      $ref: './userProfile/userProfile.yaml#/components/schemas/userProfile'
   requestBodies:
     kapuaQuery:
       description: An object to specify Query options

--- a/rest-api/resources/src/main/resources/openapi/userProfile/userProfile-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userProfile/userProfile-scopeId.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.2
+
+info:
+  title: Everyware Cloud REST API - User Profile
+  version: '1.0'
+  contact:
+    name: Eurotech
+    url: https://www.eurotech.com
+
+paths:
+
+  /{scopeId}/user/profile/:
+    get:
+      tags:
+        - User Profile
+      summary: Get the User Profile
+      operationId: userProfileGet
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+      responses:
+        200:
+          description: The desired user profile
+          content:
+            application/json:
+              schema:
+                $ref: './userProfile.yaml#/components/schemas/userProfile'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
+    put:
+      tags:
+        - User Profile
+      summary: Change the User Profile
+      operationId: userProfileUpdate
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../openapi.yaml#/components/schemas/userProfile'
+      responses:
+        200:
+          description: The user profile has been updated
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
+      description: Change logged user profile

--- a/rest-api/resources/src/main/resources/openapi/userProfile/userProfile.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userProfile/userProfile.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.2
+
+info:
+  title: Everyware Cloud REST API - User Profile
+  version: '1.0'
+  contact:
+    name: Eurotech
+    url: https://www.eurotech.com
+
+paths: {}
+
+components:
+  schemas:
+    userProfile:
+      allOf:
+        - description: The user profile
+          type: object
+          properties:
+            displayName:
+              type: string
+            phoneNumber:
+              type: string
+            email:
+              type: string
+          example:
+            displayName: "Foo42"
+            phoneNumber: "424202424"
+            email: "foo@bar.com"

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -318,6 +318,8 @@ import org.eclipse.kapua.service.user.UserCreator;
 import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserQuery;
 import org.eclipse.kapua.service.user.UserXmlRegistry;
+import org.eclipse.kapua.service.user.profile.UserProfile;
+import org.eclipse.kapua.service.user.profile.UserProfileXmlRegistry;
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 
@@ -698,6 +700,10 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     PasswordChangeRequest.class,
                     PasswordResetRequest.class,
                     UserCredentialsXmlRegistry.class,
+
+                    // User Profile
+                    UserProfile.class,
+                    UserProfileXmlRegistry.class,
 
                     // KapuaEvent
                     ServiceEvent.class,

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -128,3 +128,8 @@ kapuaAuthcAccessToken = org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthentica
 /v1/*/user/credentials.json     = kapuaAuthcAccessToken
 /v1/*/user/credentials.xml      = kapuaAuthcAccessToken
 /v1/*/user/credentials/**       = kapuaAuthcAccessToken
+
+# User Profile
+/v1/*/user/profile.json         = kapuaAuthcAccessToken
+/v1/*/user/profile.xml          = kapuaAuthcAccessToken
+/v1/*/user/profile/**           = kapuaAuthcAccessToken

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/user/shiro/UserCredentialsModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/user/shiro/UserCredentialsModule.java
@@ -22,7 +22,7 @@ import org.eclipse.kapua.service.authentication.user.UserCredentialsService;
  *
  * @since 2.0.0
  */
-public class UserCredentialsModule extends AbstractKapuaModule implements Module {
+public class UserCredentialsModule extends AbstractKapuaModule {
     @Override
     protected void configureModule() {
         bind(UserCredentialsService.class).to(UserCredentialsServiceImpl.class);

--- a/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfoXmlRegistry.java
+++ b/service/system/api/src/main/java/org/eclipse/kapua/service/systeminfo/SystemInfoXmlRegistry.java
@@ -13,12 +13,11 @@
 package org.eclipse.kapua.service.systeminfo;
 
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.service.KapuaService;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
-public class SystemInfoXmlRegistry implements KapuaService {
+public class SystemInfoXmlRegistry {
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
     private static final SystemInfoFactory SYSTEM_INFO_FACTORY = LOCATOR.getFactory(SystemInfoFactory.class);
 

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/profile/UserProfile.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/profile/UserProfile.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.profile;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = UserProfileXmlRegistry.class, factoryMethod = "newUserProfile")
+public interface UserProfile {
+    String TYPE = "userProfile";
+
+    @XmlElement(name = "displayName")
+    String getDisplayName();
+
+    void setDisplayName(String displayName);
+
+    @XmlElement(name = "phoneNumber")
+    String getPhoneNumber();
+
+    void setPhoneNumber(String phoneNumber);
+
+    @XmlElement(name = "email")
+    String getEmail();
+
+    void setEmail(String email);
+}

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/profile/UserProfileFactory.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/profile/UserProfileFactory.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.profile;
+
+import org.eclipse.kapua.model.KapuaObjectFactory;
+
+public interface UserProfileFactory extends KapuaObjectFactory {
+    UserProfile newUserProfile();
+}

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/profile/UserProfileService.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/profile/UserProfileService.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.profile;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.KapuaService;
+
+public interface UserProfileService extends KapuaService {
+
+    void changeUserProfile(UserProfile userProfile) throws KapuaException;
+
+    UserProfile getUserProfile() throws KapuaException;
+}

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/profile/UserProfileXmlRegistry.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/profile/UserProfileXmlRegistry.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.profile;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class UserProfileXmlRegistry {
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final UserProfileFactory userProfileFactory = locator.getFactory(UserProfileFactory.class);
+
+
+    public UserProfile newUserProfile() {
+        return userProfileFactory.newUserProfile();
+    }
+}

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/profile/UserProfileFactoryImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/profile/UserProfileFactoryImpl.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.internal.profile;
+
+import org.eclipse.kapua.service.user.profile.UserProfile;
+import org.eclipse.kapua.service.user.profile.UserProfileFactory;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class UserProfileFactoryImpl implements UserProfileFactory {
+    @Override
+    public UserProfile newUserProfile() {
+        return new UserProfileImpl();
+    }
+}

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/profile/UserProfileImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/profile/UserProfileImpl.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.internal.profile;
+
+import org.eclipse.kapua.service.user.profile.UserProfile;
+
+public class UserProfileImpl implements UserProfile {
+    private String displayName;
+    private String phoneNumber;
+    private String email;
+
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+
+    @Override
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+
+    @Override
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+
+    @Override
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+
+    @Override
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/profile/UserProfileModule.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/profile/UserProfileModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.internal.profile;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.user.profile.UserProfileFactory;
+import org.eclipse.kapua.service.user.profile.UserProfileService;
+
+public class UserProfileModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(UserProfileService.class).to(UserProfileServiceImpl.class);
+        bind(UserProfileFactory.class).to(UserProfileFactoryImpl.class);
+    }
+}

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/profile/UserProfileServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/profile/UserProfileServiceImpl.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.internal.profile;
+
+import com.google.common.base.Strings;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.commons.util.CommonsValidationRegex;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserService;
+import org.eclipse.kapua.service.user.profile.UserProfile;
+import org.eclipse.kapua.service.user.profile.UserProfileFactory;
+import org.eclipse.kapua.service.user.profile.UserProfileService;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class UserProfileServiceImpl implements UserProfileService {
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final UserService userService = locator.getService(UserService.class);
+    private final UserProfileFactory userProfileFactory = locator.getFactory(UserProfileFactory.class);
+
+
+    @Override
+    public void changeUserProfile(UserProfile userProfile) throws KapuaException {
+        if (!Strings.isNullOrEmpty(userProfile.getEmail())) {
+            ArgumentValidator.match(userProfile.getEmail(), CommonsValidationRegex.EMAIL_REGEXP, "userProfile.email");
+        }
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            User user = userService.find(KapuaSecurityUtils.getSession().getScopeId(), KapuaSecurityUtils.getSession().getUserId());
+            if (user == null) {
+                throw new KapuaEntityNotFoundException(User.TYPE, KapuaSecurityUtils.getSession().getUserId());
+            }
+            user.setEmail(userProfile.getEmail());
+            user.setDisplayName(userProfile.getDisplayName());
+            user.setPhoneNumber(userProfile.getPhoneNumber());
+
+            userService.update(user);
+        });
+    }
+
+
+    @Override
+    public UserProfile getUserProfile() throws KapuaException {
+        return KapuaSecurityUtils.doPrivileged(() -> {
+            User user = userService.find(KapuaSecurityUtils.getSession().getScopeId(), KapuaSecurityUtils.getSession().getUserId());
+            if (user == null) {
+                throw new KapuaEntityNotFoundException(User.TYPE, KapuaSecurityUtils.getSession().getUserId());
+            }
+
+            UserProfile userProfile = userProfileFactory.newUserProfile();
+            userProfile.setDisplayName(user.getDisplayName());
+            userProfile.setEmail(user.getEmail());
+            userProfile.setPhoneNumber(user.getPhoneNumber());
+            return userProfile;
+        });
+    }
+}

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserProfileServiceTest.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserProfileServiceTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.steps;
+
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import io.cucumber.java.en.Then;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.qa.common.StepData;
+import org.eclipse.kapua.qa.common.TestBase;
+import org.eclipse.kapua.qa.common.cucumber.CucUserProfile;
+import org.eclipse.kapua.service.user.profile.UserProfile;
+import org.eclipse.kapua.service.user.profile.UserProfileFactory;
+import org.eclipse.kapua.service.user.profile.UserProfileService;
+import org.junit.Assert;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class UserProfileServiceTest extends TestBase {
+    private UserProfileService userProfileService;
+    private UserProfileFactory userProfileFactory;
+
+
+    @Inject
+    public UserProfileServiceTest(StepData stepData) {
+        super(stepData);
+    }
+
+
+    @After(value = "@setup")
+    public void setServices() {
+        KapuaLocator locator = KapuaLocator.getInstance();
+        userProfileService = locator.getService(UserProfileService.class);
+        userProfileFactory = locator.getFactory(UserProfileFactory.class);
+    }
+
+
+    @Before
+    public void beforeScenario(Scenario scenario) {
+        updateScenario(scenario);
+    }
+
+
+    @Then("I change the profile to the following")
+    public void iChangeTheUserProfileToTheFollowing(CucUserProfile cucUserProfile) throws Exception {
+        UserProfile userProfile = userProfileFactory.newUserProfile();
+        userProfile.setDisplayName(cucUserProfile.getDisplayName());
+        userProfile.setEmail(cucUserProfile.getEmail());
+        userProfile.setPhoneNumber(cucUserProfile.getPhoneNumber());
+        try {
+            userProfileService.changeUserProfile(userProfile);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+
+    @Then("I read the following user profile")
+    public void iReadTheFollowingUserProfile(CucUserProfile expectedUserProfile) throws KapuaException {
+        UserProfile actualUserProfile = userProfileService.getUserProfile();
+        Assert.assertEquals(expectedUserProfile.getDisplayName(), actualUserProfile.getDisplayName());
+        Assert.assertEquals(expectedUserProfile.getEmail(), actualUserProfile.getEmail());
+        Assert.assertEquals(expectedUserProfile.getPhoneNumber(), actualUserProfile.getPhoneNumber());
+    }
+}


### PR DESCRIPTION
**Brief description of the PR.**
This PR adds the possibility for an authenticated user to read and change his own profile information, which consists of:
* Display name
* Email address
* Phone number

This feature does not require the user to have `user:read` and/or `user:write` permissions.

**Related Issue**
This PR fixes #3744.

**Description of the solution adopted**
A new service, `UserProfileService`, is created with the related entities. This service belongs to the `user` module.

**Any side note on the changes made**
In the first PR commit there is some code cleanup of redundant interfaces `implements`.
