### PR TITLE
Rename `changePasswordRequest` to `changePassword` in UserCredentialService

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
@@ -278,7 +278,7 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
             PasswordChangeRequest passwordChangeRequest = USER_CREDENTIALS_FACTORY.newPasswordChangeRequest();
             passwordChangeRequest.setCurrentPassword(oldPassword);
             passwordChangeRequest.setNewPassword(newPassword);
-            USER_CREDENTIALS_SERVICE.changePasswordRequest(passwordChangeRequest);
+            USER_CREDENTIALS_SERVICE.changePassword(passwordChangeRequest);
 
         } catch (Exception e) {
             throw KapuaExceptionHandler.buildExceptionFromError(e);

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserCredential.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserCredential.java
@@ -48,7 +48,7 @@ public class UserCredential {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public Credential newPassword(@PathParam("scopeId") ScopeId scopeId, PasswordChangeRequest passwordChangeRequest) throws KapuaException {
-        return userCredentialsService.changePasswordRequest(passwordChangeRequest);
+        return userCredentialsService.changePassword(passwordChangeRequest);
     }
 
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/user/UserCredentialsService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/user/UserCredentialsService.java
@@ -31,7 +31,7 @@ public interface UserCredentialsService extends KapuaService {
      * @return The updated credential
      * @throws KapuaException
      */
-    Credential changePasswordRequest(PasswordChangeRequest passwordChangeRequest) throws KapuaException;
+    Credential changePassword(PasswordChangeRequest passwordChangeRequest) throws KapuaException;
 
 
     /**

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/user/shiro/UserCredentialsServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/user/shiro/UserCredentialsServiceImpl.java
@@ -59,7 +59,7 @@ public class UserCredentialsServiceImpl implements UserCredentialsService {
 
 
     @Override
-    public Credential changePasswordRequest(PasswordChangeRequest passwordChangeRequest) throws KapuaException {
+    public Credential changePassword(PasswordChangeRequest passwordChangeRequest) throws KapuaException {
         ArgumentValidator.notNull(passwordChangeRequest.getNewPassword(), "passwordChangeRequest.newPassword");
         ArgumentValidator.notNull(passwordChangeRequest.getCurrentPassword(), "passwordChangeRequest.currentPassword");
 

--- a/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authentication/steps/AuthenticationServiceSteps.java
+++ b/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authentication/steps/AuthenticationServiceSteps.java
@@ -211,7 +211,7 @@ public class AuthenticationServiceSteps extends TestBase {
         passwordChangeRequest.setNewPassword(newPassword);
 
         try {
-            userCredentialsService.changePasswordRequest(passwordChangeRequest);
+            userCredentialsService.changePassword(passwordChangeRequest);
         } catch (Exception ex) {
             verifyException(ex);
         }


### PR DESCRIPTION
Brief description of the PR.
This PR renames the method `UserCredentialService#changePasswordRequest` to `UserCredentialService#changePassword` in order to be more consistent with the usual method naming.

**Related Issue**
This PR fixes #3748.