### PR TITLE
Fixed JobTarget showing when Device is not found

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsGrid.java
@@ -20,7 +20,6 @@ import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
@@ -114,7 +113,17 @@ public class JobTabTargetsGrid extends EntityGrid<GwtJobTarget> {
     protected List<ColumnConfig> getColumns() {
         List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
 
-        ColumnConfig columnConfig = new ColumnConfig("clientId", MSGS.gridJobTargetColumnHeaderJobClientId(), 200);
+        ColumnConfig columnConfig = new ColumnConfig("id", "Id", 100);
+        columnConfig.setSortable(false);
+        columnConfig.setHidden(true);
+        columnConfigs.add(columnConfig);
+
+        columnConfig = new ColumnConfig("jobTargetId", "Job Target Id", 100);
+        columnConfig.setSortable(false);
+        columnConfig.setHidden(true);
+        columnConfigs.add(columnConfig);
+
+        columnConfig = new ColumnConfig("clientId", MSGS.gridJobTargetColumnHeaderJobClientId(), 200);
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobTargetServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobTargetServiceImpl.java
@@ -53,7 +53,7 @@ public class GwtJobTargetServiceImpl extends KapuaRemoteServiceServlet implement
 
     private static final long serialVersionUID = -4365251346832037608L;
 
-    private static final String NOT_AVAILABLE = "Not available";
+    private static final String NOT_AVAILABLE = "Device not found";
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
@@ -78,7 +78,6 @@ public class GwtJobTargetServiceImpl extends KapuaRemoteServiceServlet implement
             totalLength = jobTargetList.getTotalCount().intValue();
 
             List<KapuaId> deviceIds = new ArrayList<KapuaId>();
-            // Convert to GWT entity
             for (JobTarget jt : jobTargetList.getItems()) {
                 deviceIds.add(jt.getJobTargetId());
             }
@@ -87,25 +86,24 @@ public class GwtJobTargetServiceImpl extends KapuaRemoteServiceServlet implement
             query.setPredicate(query.attributePredicate(DeviceAttributes.ENTITY_ID, deviceIds));
             DeviceListResult deviceListResult = DEVICE_REGISTRY_SERVICE.query(query);
 
-            Map<KapuaId, Device> deviceMap = new HashMap<KapuaId, Device>();
+            Map<KapuaId, Device> devicesByIdMap = new HashMap<KapuaId, Device>();
             for (Device device : deviceListResult.getItems()) {
-                deviceMap.put(device.getId(), device);
+                devicesByIdMap.put(device.getId(), device);
             }
 
-            for (JobTarget jt : jobTargetList.getItems()) {
-                GwtJobTarget gwtJobTarget = KapuaGwtJobModelConverter.convertJobTarget(jt);
-                Device device = DEVICE_REGISTRY_SERVICE.find(KapuaEid.parseCompactId(gwtJobTarget.getScopeId()), KapuaEid.parseCompactId(gwtJobTarget.getJobTargetId()));
-                if (device != null) {
-                    insertClientId(gwtJobTarget, deviceMap.get(jt.getJobTargetId()));
-                    gwtJobTargetList.add(gwtJobTarget);
-                }
+            for (JobTarget jobTarget : jobTargetList.getItems()) {
+                GwtJobTarget gwtJobTarget = KapuaGwtJobModelConverter.convertJobTarget(jobTarget);
+
+                Device device = devicesByIdMap.get(jobTarget.getJobTargetId());
+                insertClientId(gwtJobTarget, device);
+
+                gwtJobTargetList.add(gwtJobTarget);
             }
 
+            return new BasePagingLoadResult<GwtJobTarget>(gwtJobTargetList, loadConfig != null ? loadConfig.getOffset() : 0, totalLength);
         } catch (Exception e) {
-            KapuaExceptionHandler.handle(e);
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
-
-        return new BasePagingLoadResult<GwtJobTarget>(gwtJobTargetList, loadConfig != null ? loadConfig.getOffset() : 0, totalLength);
     }
 
     @Override
@@ -197,17 +195,10 @@ public class GwtJobTargetServiceImpl extends KapuaRemoteServiceServlet implement
      * @param device       existing device
      * @throws KapuaException
      */
-    private void insertClientId(GwtJobTarget gwtJobTarget, Device device) throws KapuaException {
-        String clientId = null;
-        String displayName = null;
+    private void insertClientId(GwtJobTarget gwtJobTarget, Device device) {
         if (device != null) {
-            clientId = device.getClientId();
-            displayName = device.getDisplayName();
-        }
-
-        if (clientId != null) {
-            gwtJobTarget.setClientId(clientId);
-            gwtJobTarget.setDisplayName(displayName);
+            gwtJobTarget.setClientId(device.getClientId());
+            gwtJobTarget.setDisplayName(device.getDisplayName());
         } else {
             gwtJobTarget.setClientId(NOT_AVAILABLE);
         }


### PR DESCRIPTION
This PR fixes missing JobTarget in the Job target Tab if the correspondent Device is deleted. 
Not adding the JobTarget to the list of shown items causes the list to be empty but the count reporting 1 element. 
See screenshot below.

![Screenshot 2023-03-23 at 16 00 47](https://user-images.githubusercontent.com/3942036/227510265-2f6fa047-0d48-4730-8554-9fca9f372dd6.png)


**Related Issue**
_None_

**Description of the solution adopted**
Removed skipping showing target and added a message which shows that the Device was not found.

**Screenshots**
_None_

**Any side note on the changes made**
Added `id` and `jobTargetId` as hidden column in the gird.