### PR TITLE
Make credential unlock endpoint more consistent with the codebase

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Credentials.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Credentials.java
@@ -217,12 +217,34 @@ public class Credentials extends AbstractKapuaResource {
      * @return HTTP 200 if operation has completed successfully.
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
+     * @deprecated Since 2.0.0. Please make use of {@link #unlock(ScopeId, EntityId)}
      */
     @POST
     @Path("{credentialId}/unlock")
+    @Deprecated
     public Response unlockCredential(
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("credentialId") EntityId credentialId) throws KapuaException {
+        credentialService.unlock(scopeId, credentialId);
+
+        return returnNoContent();
+    }
+
+
+    /**
+     * Unlocks a {@link Credential} that has been locked due to a lockout policy.
+     *
+     * @param scopeId      The {@link ScopeId} of {@link Credential} to unlock.
+     * @param credentialId The id of the Credential to be unlocked.
+     * @return HTTP 200 if operation has completed successfully.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 2.0.0
+     */
+    @POST
+    @Path("{credentialId}/_unlock")
+    public Response unlock(
+        @PathParam("scopeId") ScopeId scopeId,
+        @PathParam("credentialId") EntityId credentialId) throws KapuaException {
         credentialService.unlock(scopeId, credentialId);
 
         return returnNoContent();

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId-unlock.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId-unlock.yaml
@@ -17,6 +17,32 @@ paths:
       tags:
         - Credential
       summary: Unlock a Credential
+      deprecated: true
+      operationId: credentialUnlockDeprecated
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: './credential.yaml#/components/parameters/credentialId'
+      responses:
+        204:
+          description: The Credential has been unlocked
+          content:
+            application/json:
+              schema:
+                $ref: './credential.yaml#/components/schemas/credential'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
+
+  /{scopeId}/credentials/{credentialId}/_unlock:
+    post:
+      tags:
+        - Credential
+      summary: Unlock a Credential
       operationId: credentialUnlock
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -107,6 +107,8 @@ paths:
     $ref: './credential/credential-scopeId-_query.yaml#/paths/~1{scopeId}~1credentials~1_query'
   /{scopeId}/credentials/{credentialId}/unlock:
     $ref: './credential/credential-scopeId-credentialId-unlock.yaml#/paths/~1{scopeId}~1credentials~1{credentialId}~1unlock'
+  /{scopeId}/credentials/{credentialId}/_unlock:
+    $ref: './credential/credential-scopeId-credentialId-unlock.yaml#/paths/~1{scopeId}~1credentials~1{credentialId}~1_unlock'
   ### Data Channel ###
   /{scopeId}/data/channels:
     $ref: './dataChannel/dataChannel-scopeId.yaml#/paths/~1{scopeId}~1data~1channels'


### PR DESCRIPTION
Brief description of the PR.
This PR renames the endpoint `POST /{scopeId}/credentials/{credentialId}/unlock` to `POST /{scopeId}/credentials/{credentialId}/_unlock` (adding the leading `_` character).

**Related Issue**
This PR fixes #3754.

**Description of the solution adopted**
The old endpoint is deprecated and a new endpoint is created.