### PR TITLE
FIX - mods. to store service taking into account service disabled

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -39,6 +39,7 @@ import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
 import org.eclipse.kapua.broker.BrokerDomains;
+import org.eclipse.kapua.commons.configuration.metatype.EmptyTocd;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
@@ -441,7 +442,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
                     } catch (KapuaServiceDisabledException ex) {
                         continue;
                     }
-                    if (tocd != null) {
+                    if (tocd != null && !(tocd instanceof EmptyTocd)) {
                         GwtConfigComponent gwtConfig = new GwtConfigComponent();
                         gwtConfig.setId(tocd.getId());
                         gwtConfig.setName(tocd.getName());

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -82,7 +82,6 @@ public class DeviceConfigComponents extends LayoutContainer {
 
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private static final ConsoleDeviceMessages DEVICE_MSGS = GWT.create(ConsoleDeviceMessages.class);
-
     private final GwtDeviceServiceAsync gwtDeviceService = GWT.create(GwtDeviceService.class);
     private final GwtDeviceManagementServiceAsync gwtDeviceManagementService = GWT.create(GwtDeviceManagementService.class);
     private final GwtSecurityTokenServiceAsync gwtXSRFService = GWT.create(GwtSecurityTokenService.class);
@@ -159,6 +158,7 @@ public class DeviceConfigComponents extends LayoutContainer {
     public void setDevice(GwtDevice selectedDevice) {
         dirty = true;
         this.selectedDevice = selectedDevice;
+        refreshVisibilityStoreSettingButton();
         refresh();
     }
 
@@ -465,6 +465,24 @@ public class DeviceConfigComponents extends LayoutContainer {
 
             loader.load();
         }
+    }
+
+    private void refreshVisibilityStoreSettingButton() {
+        gwtDeviceManagementService.isStoreServiceEnabled(selectedDevice.getScopeId(), selectedDevice.getId(), new AsyncCallback<Boolean>() {
+            @Override
+            public void onFailure(Throwable t) {
+                FailureHandler.handle(t);
+            }
+
+            @Override
+            public void onSuccess(Boolean enabled) {
+                if (!enabled) {
+                    settings.hide();
+                } else {
+                    settings.show();
+                }
+            }
+        });
     }
 
     public void refreshConfigPanel(GwtConfigComponent configComponent) {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -476,11 +476,7 @@ public class DeviceConfigComponents extends LayoutContainer {
 
             @Override
             public void onSuccess(Boolean enabled) {
-                if (!enabled) {
-                    settings.hide();
-                } else {
-                    settings.show();
-                }
+                settings.setVisible(enabled);
             }
         });
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -44,7 +44,6 @@ import org.eclipse.kapua.app.console.module.device.shared.model.management.packa
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
 import org.eclipse.kapua.commons.configuration.metatype.Password;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTicon;
@@ -482,14 +481,11 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
             KapuaId deviceId = GwtKapuaCommonsModelConverter.convertKapuaId(deviceIdString);
             DeviceConfigurationStoreSettings deviceConfigurationStoreSettings = null;
             GwtDeviceConfigurationStoreSettings gwtDeviceConfigurationStoreSettings = null;
-            if (DEVICE_CONFIGURATION_STORE_SERVICE.isServiceEnabled(scopeId)) {
-                deviceConfigurationStoreSettings = DEVICE_CONFIGURATION_STORE_SERVICE.getApplicationSettings(scopeId, deviceId);
-                gwtDeviceConfigurationStoreSettings = new GwtDeviceConfigurationStoreSettings();
-                gwtDeviceConfigurationStoreSettings.setStoreEnablementPolicy(GwtDeviceConfigurationStoreSettings.GwtDeviceConfigurationStoreEnablementPolicy.valueOf(deviceConfigurationStoreSettings.getEnablementPolicy().name()));
-                return gwtDeviceConfigurationStoreSettings;
-            } else {
-                throw new KapuaServiceDisabledException(DEVICE_CONFIGURATION_STORE_SERVICE.getClass().getName());
-            }
+
+            deviceConfigurationStoreSettings = DEVICE_CONFIGURATION_STORE_SERVICE.getApplicationSettings(scopeId, deviceId);
+            gwtDeviceConfigurationStoreSettings = new GwtDeviceConfigurationStoreSettings();
+            gwtDeviceConfigurationStoreSettings.setStoreEnablementPolicy(GwtDeviceConfigurationStoreSettings.GwtDeviceConfigurationStoreEnablementPolicy.valueOf(deviceConfigurationStoreSettings.getEnablementPolicy().name()));
+            return gwtDeviceConfigurationStoreSettings;
         } catch (Throwable t) {
             throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
@@ -509,11 +505,7 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
                 deviceConfigurationStoreSettings.setDeviceId(deviceId);
                 deviceConfigurationStoreSettings.setEnablementPolicy(DeviceConfigurationStoreEnablementPolicy.valueOf(gwtDeviceConfigurationStoreSettings.getStoreEnablementPolicy()));
             }
-            if (DEVICE_CONFIGURATION_STORE_SERVICE.isServiceEnabled(scopeId)) {
-                DEVICE_CONFIGURATION_STORE_SERVICE.setApplicationSettings(scopeId, deviceId, deviceConfigurationStoreSettings);
-            } else {
-                throw new KapuaServiceDisabledException(DEVICE_CONFIGURATION_STORE_SERVICE.getClass().getName());
-            }
+            DEVICE_CONFIGURATION_STORE_SERVICE.setApplicationSettings(scopeId, deviceId, deviceConfigurationStoreSettings);
         } catch (Throwable t) {
             throw KapuaExceptionHandler.buildExceptionFromError(t);
         }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -44,6 +44,7 @@ import org.eclipse.kapua.app.console.module.device.shared.model.management.packa
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
 import org.eclipse.kapua.commons.configuration.metatype.Password;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTicon;
@@ -462,6 +463,7 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
     // Configuration Store Settings
     // 
 
+    @Override
     public boolean isStoreServiceEnabled(String scopeIdString, String deviceIdString) throws GwtKapuaException {
         try {
             KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(scopeIdString);
@@ -478,13 +480,16 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
         try {
             KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(scopeIdString);
             KapuaId deviceId = GwtKapuaCommonsModelConverter.convertKapuaId(deviceIdString);
-
-            DeviceConfigurationStoreSettings deviceConfigurationStoreSettings = DEVICE_CONFIGURATION_STORE_SERVICE.getApplicationSettings(scopeId, deviceId);
-
-            GwtDeviceConfigurationStoreSettings gwtDeviceConfigurationStoreSettings = new GwtDeviceConfigurationStoreSettings();
-            gwtDeviceConfigurationStoreSettings.setStoreEnablementPolicy(GwtDeviceConfigurationStoreSettings.GwtDeviceConfigurationStoreEnablementPolicy.valueOf(deviceConfigurationStoreSettings.getEnablementPolicy().name()));
-
-            return gwtDeviceConfigurationStoreSettings;
+            DeviceConfigurationStoreSettings deviceConfigurationStoreSettings = null;
+            GwtDeviceConfigurationStoreSettings gwtDeviceConfigurationStoreSettings = null;
+            if (DEVICE_CONFIGURATION_STORE_SERVICE.isServiceEnabled(scopeId)) {
+                deviceConfigurationStoreSettings = DEVICE_CONFIGURATION_STORE_SERVICE.getApplicationSettings(scopeId, deviceId);
+                gwtDeviceConfigurationStoreSettings = new GwtDeviceConfigurationStoreSettings();
+                gwtDeviceConfigurationStoreSettings.setStoreEnablementPolicy(GwtDeviceConfigurationStoreSettings.GwtDeviceConfigurationStoreEnablementPolicy.valueOf(deviceConfigurationStoreSettings.getEnablementPolicy().name()));
+                return gwtDeviceConfigurationStoreSettings;
+            } else {
+                throw new KapuaServiceDisabledException(DEVICE_CONFIGURATION_STORE_SERVICE.getClass().getName());
+            }
         } catch (Throwable t) {
             throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
@@ -499,11 +504,16 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
             KapuaId deviceId = GwtKapuaCommonsModelConverter.convertKapuaId(deviceIdString);
 
             DeviceConfigurationStoreSettings deviceConfigurationStoreSettings = DEVICE_CONFIGURATION_STORE_FACTORY.newDeviceConfigurationStoreSettings();
-            deviceConfigurationStoreSettings.setScopeId(scopeId);
-            deviceConfigurationStoreSettings.setDeviceId(deviceId);
-            deviceConfigurationStoreSettings.setEnablementPolicy(DeviceConfigurationStoreEnablementPolicy.valueOf(gwtDeviceConfigurationStoreSettings.getStoreEnablementPolicy()));
-
-            DEVICE_CONFIGURATION_STORE_SERVICE.setApplicationSettings(scopeId, deviceId, deviceConfigurationStoreSettings);
+            if (deviceConfigurationStoreSettings != null) {
+                deviceConfigurationStoreSettings.setScopeId(scopeId);
+                deviceConfigurationStoreSettings.setDeviceId(deviceId);
+                deviceConfigurationStoreSettings.setEnablementPolicy(DeviceConfigurationStoreEnablementPolicy.valueOf(gwtDeviceConfigurationStoreSettings.getStoreEnablementPolicy()));
+            }
+            if (DEVICE_CONFIGURATION_STORE_SERVICE.isServiceEnabled(scopeId)) {
+                DEVICE_CONFIGURATION_STORE_SERVICE.setApplicationSettings(scopeId, deviceId, deviceConfigurationStoreSettings);
+            } else {
+                throw new KapuaServiceDisabledException(DEVICE_CONFIGURATION_STORE_SERVICE.getClass().getName());
+            }
         } catch (Throwable t) {
             throw KapuaExceptionHandler.buildExceptionFromError(t);
         }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
-import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.device.management.configuration.DeviceComponentConfiguration;
@@ -153,11 +152,7 @@ public class DeviceManagementConfigurations extends AbstractKapuaResource {
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("deviceId") EntityId deviceId)
             throws KapuaException {
-        if (deviceConfigurationStoreService.isServiceEnabled(scopeId)) {
-            return deviceConfigurationStoreService.getApplicationSettings(scopeId, deviceId);
-        } else {
-            throw new KapuaServiceDisabledException(deviceConfigurationStoreService.getClass().getName());
-        }
+        return deviceConfigurationStoreService.getApplicationSettings(scopeId, deviceId);
     }
 
     @POST
@@ -167,12 +162,8 @@ public class DeviceManagementConfigurations extends AbstractKapuaResource {
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("deviceId") EntityId deviceId,
             DeviceConfigurationStoreSettings deviceConfigurationStoreSettings) throws KapuaException {
-        if (deviceConfigurationStoreService.isServiceEnabled(scopeId)) {
-            deviceConfigurationStoreService.setApplicationSettings(scopeId, deviceId, deviceConfigurationStoreSettings);
-            return returnNoContent();
-        } else {
-            throw new KapuaServiceDisabledException(deviceConfigurationStoreService.getClass().getName());
-        }
+        deviceConfigurationStoreService.setApplicationSettings(scopeId, deviceId, deviceConfigurationStoreSettings);
+        return returnNoContent();
     }
 
 }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.device.management.configuration.DeviceComponentConfiguration;
@@ -152,7 +153,11 @@ public class DeviceManagementConfigurations extends AbstractKapuaResource {
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("deviceId") EntityId deviceId)
             throws KapuaException {
-        return deviceConfigurationStoreService.getApplicationSettings(scopeId, deviceId);
+        if (deviceConfigurationStoreService.isServiceEnabled(scopeId)) {
+            return deviceConfigurationStoreService.getApplicationSettings(scopeId, deviceId);
+        } else {
+            throw new KapuaServiceDisabledException(deviceConfigurationStoreService.getClass().getName());
+        }
     }
 
     @POST
@@ -162,8 +167,12 @@ public class DeviceManagementConfigurations extends AbstractKapuaResource {
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("deviceId") EntityId deviceId,
             DeviceConfigurationStoreSettings deviceConfigurationStoreSettings) throws KapuaException {
-        deviceConfigurationStoreService.setApplicationSettings(scopeId, deviceId, deviceConfigurationStoreSettings);
-
-        return returnNoContent();
+        if (deviceConfigurationStoreService.isServiceEnabled(scopeId)) {
+            deviceConfigurationStoreService.setApplicationSettings(scopeId, deviceId, deviceConfigurationStoreSettings);
+            return returnNoContent();
+        } else {
+            throw new KapuaServiceDisabledException(deviceConfigurationStoreService.getClass().getName());
+        }
     }
+
 }

--- a/service/device/management/configuration-store/dummy/src/main/java/org/eclipse/kapua/service/device/management/configuration/store/dummy/DeviceConfigurationStoreServiceDummy.java
+++ b/service/device/management/configuration-store/dummy/src/main/java/org/eclipse/kapua/service/device/management/configuration/store/dummy/DeviceConfigurationStoreServiceDummy.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration.store.dummy;
 
+import org.eclipse.kapua.commons.configuration.metatype.EmptyTocd;
+import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.configuration.DeviceComponentConfiguration;
@@ -31,26 +33,28 @@ import java.util.Map;
 public class DeviceConfigurationStoreServiceDummy implements DeviceConfigurationStoreService {
 
     @Override
-    public DeviceComponentConfiguration getConfigurations(KapuaId scopeId, KapuaId deviceId, String configurationComponentPid) {
-        return null;
+    public DeviceComponentConfiguration getConfigurations(KapuaId scopeId, KapuaId deviceId, String configurationComponentPid) throws KapuaServiceDisabledException {
+        throw new KapuaServiceDisabledException(this.getClass().getName());
     }
 
     @Override
-    public DeviceConfiguration getConfigurations(KapuaId scopeId, KapuaId deviceId) {
-        return null;
+    public DeviceConfiguration getConfigurations(KapuaId scopeId, KapuaId deviceId) throws KapuaServiceDisabledException {
+        throw new KapuaServiceDisabledException(this.getClass().getName());
     }
 
     @Override
-    public void storeConfigurations(KapuaId scopeId, KapuaId deviceId, DeviceComponentConfiguration deviceComponentConfiguration) {
+    public void storeConfigurations(KapuaId scopeId, KapuaId deviceId, DeviceComponentConfiguration deviceComponentConfiguration) throws KapuaServiceDisabledException {
+        throw new KapuaServiceDisabledException(this.getClass().getName());
     }
 
     @Override
-    public void storeConfigurations(KapuaId scopeId, KapuaId deviceId, DeviceConfiguration deviceConfiguration) {
+    public void storeConfigurations(KapuaId scopeId, KapuaId deviceId, DeviceConfiguration deviceConfiguration) throws KapuaServiceDisabledException {
+        throw new KapuaServiceDisabledException(this.getClass().getName());
     }
 
     @Override
     public KapuaTocd getConfigMetadata(KapuaId scopeId) {
-        return null;
+        return new EmptyTocd();
     }
 
     @Override

--- a/service/device/management/configuration-store/dummy/src/main/java/org/eclipse/kapua/service/device/management/configuration/store/dummy/DeviceConfigurationStoreServiceDummy.java
+++ b/service/device/management/configuration-store/dummy/src/main/java/org/eclipse/kapua/service/device/management/configuration/store/dummy/DeviceConfigurationStoreServiceDummy.java
@@ -67,12 +67,13 @@ public class DeviceConfigurationStoreServiceDummy implements DeviceConfiguration
     }
 
     @Override
-    public DeviceConfigurationStoreSettings getApplicationSettings(KapuaId scopeId, KapuaId deviceId) {
-        return null;
+    public DeviceConfigurationStoreSettings getApplicationSettings(KapuaId scopeId, KapuaId deviceId) throws KapuaServiceDisabledException {
+        throw new KapuaServiceDisabledException(this.getClass().getName());
     }
 
     @Override
-    public void setApplicationSettings(KapuaId scopeId, KapuaId deviceId, DeviceConfigurationStoreSettings deviceApplicationSettings) {
+    public void setApplicationSettings(KapuaId scopeId, KapuaId deviceId, DeviceConfigurationStoreSettings deviceApplicationSettings) throws KapuaServiceDisabledException {
+        throw new KapuaServiceDisabledException(this.getClass().getName());
     }
 
     @Override


### PR DESCRIPTION
The device store configurations service is revisited taking into account the fact that here in Kapua is disabled/ a dummy implementation. The most important contribution is the fact that the respective button in the console has been hidden depending on the presence of this service. 