### PR TITLE
Make `JobStepCreator` fields more consistent through the api

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
@@ -62,8 +62,13 @@ components:
             jobStepDefinitionId:
               allOf:
                 - $ref: '../openapi.yaml#/components/schemas/kapuaId'
+            stepProperties:
+              type: array
+              items:
+                $ref: '../jobStepDefinition/jobStepDefinition.yaml#/components/schemas/jobStepDefinitionProperty'
             jobStepProperties:
               type: array
+              deprecated: true
               items:
                 $ref: '../jobStepDefinition/jobStepDefinition.yaml#/components/schemas/jobStepDefinitionProperty'
       example:
@@ -72,6 +77,10 @@ components:
         description: A step with a description
         stepIndex: 0
         jobStepDefinitionId: Aw
+        stepProperties:
+          - name: bundleId
+            propertyType: java.lang.String
+            propertyValue: '999'
         jobStepProperties:
           - name: bundleId
             propertyType: java.lang.String

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepCreator.java
@@ -50,9 +50,39 @@ public interface JobStepCreator extends KapuaNamedEntityCreator<JobStep> {
 
     void setJobStepDefinitionId(KapuaId jobStepDefinitionId);
 
-    @XmlElementWrapper(name = "jobStepProperties")
-    @XmlElement(name = "jobStepProperty")
+    @XmlElementWrapper(name = "stepProperties")
+    @XmlElement(name = "stepProperty")
     <P extends JobStepProperty> List<P> getStepProperties();
 
-    void setJobStepProperties(List<JobStepProperty> jobStepProperties);
+    void setStepProperties(List<JobStepProperty> jobStepProperties);
+
+    /**
+     * @deprecated since 2.0.0. Please make use of {@link #getStepProperties()}. This method is deprecated
+     * because of issue #3580 (i.e. the step properties' field is called different depending on what request are you using).
+     */
+    @Deprecated
+    @XmlElementWrapper(name = "jobStepProperties")
+    @XmlElement(name = "jobStepProperty")
+    default <P extends JobStepProperty> List<P> getJobStepPropertiesDeprecated() {
+        return getStepProperties();
+    }
+
+    /**
+     * @deprecated since 2.0.0. Please make use of {@link #setStepProperties(List)}. This method is deprecated
+     * because of issue #3580 (i.e. the step properties' field is called different depending on what request are you using).
+     */
+    @Deprecated
+    default void setJobStepProperties(List<JobStepProperty> jobStepProperties) {
+        setStepProperties(jobStepProperties);
+    }
+
+
+    /**
+     * @deprecated since 2.0.0. Please make use of {@link #setStepProperties(List)}. This method is deprecated
+     * because of issue #3580 (i.e. the step properties' field is called different depending on what request are you using).
+     */
+    @Deprecated
+    default void setJobStepPropertiesDeprecated(List<JobStepProperty> jobStepProperties) {
+        setStepProperties(jobStepProperties);
+    }
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepCreatorImpl.java
@@ -79,7 +79,7 @@ public class JobStepCreatorImpl extends AbstractKapuaNamedEntityCreator<JobStep>
     }
 
     @Override
-    public void setJobStepProperties(List<JobStepProperty> jobStepProperty) {
+    public void setStepProperties(List<JobStepProperty> jobStepProperty) {
         this.jobStepProperty = jobStepProperty;
     }
 


### PR DESCRIPTION
Brief description of the PR.
This PR makes the `jobStepProperties` more consistent through the api.

**Related Issue**
This PR fixes #3580.

**Description of the solution adopted**
Before the changes the following were the getter and setter methods of the `JobStepCreator`
* `getStepProperties`
* `setJobStepProperties`

After the changes the getter and setter methods of the `JobStepCreator` are:
* `getStepProperties`
* `setStepProperties`: to use instead of the old `setJobStepProperties`
* `setJobStepProperties`: deprecated, left there only to ensure backward compatibility
* `getJobStepPropertiesDeprecated`: deprecated, left there only to ensure backward compatibility
* `setJobStepPropertiesDeprecated`: deprecated, left there only to ensure backward compatibility

**Any side note on the changes made**
* In a future release the deprecated methods will be removed
* Until the removal of the deprecated methods, the Swagger UI example of `JobStepCreator` will be the following:
  ```
  {
    "type": "jobStepCreator",
    "name": "Step 1",
    "description": "A step with a description",
    "stepIndex": 0,
    "jobStepDefinitionId": "Aw",
    "stepProperties": [
      {
        "name": "bundleId",
        "propertyType": "java.lang.String",
        "propertyValue": "999"
      }
    ],
    "jobStepProperties": [
      {
        "name": "bundleId",
        "propertyType": "java.lang.String",
        "propertyValue": "999"
      }
    ]
  }
  ```
  Both `stepProperties` and `jobStepProperties` will be present and functional, even if the latter is deprecated.