### PR TITLE
FIX - mods. to DeviceTab classes to correctly handle background tabs

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -126,7 +126,6 @@ public class DeviceAssetsValues extends LayoutContainer {
         if (selectedDevice != null && settings != null) {
             refreshVisibilityStoreSettingButton();
         }
-        refresh();
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssets.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssets.java
@@ -81,9 +81,10 @@ public class DeviceTabAssets extends KapuaTabItem<GwtDevice> {
             getHeader().setVisible(false);
         }
 
-        assetsValues.setDevice(gwtDevice);
+        if (selectedEntity != null) {
+            assetsValues.setDevice(gwtDevice);
+        }
 
-        doRefresh();
     }
 
     @Override
@@ -92,7 +93,7 @@ public class DeviceTabAssets extends KapuaTabItem<GwtDevice> {
             return;
         }
 
-        if (tabsPanel.getSelectedItem() == this) {
+        if (tabsPanel.getSelectedItem() == tabValues) {
             assetsValues.refresh();
         }
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
@@ -72,7 +72,6 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
 
     private final GwtDeviceManagementServiceAsync gwtDeviceManagementService = GWT.create(GwtDeviceManagementService.class);
     private final GwtSecurityTokenServiceAsync gwtXSRFService = GWT.create(GwtSecurityTokenService.class);
-
     private DeviceView devicesView;
 
     private boolean initialized;
@@ -107,7 +106,6 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
             setEnabled(false);
             getHeader().setVisible(false);
         }
-        doRefresh();
     }
 
     @Override
@@ -406,7 +404,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
         @Override
         public void loaderBeforeLoad(LoadEvent le) {
             disableButtons();
-            grid.mask(MSGS.loading());
+            //grid.mask(MSGS.loading());
         }
 
         @Override
@@ -422,7 +420,6 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
 
         @Override
         public void loaderLoadException(LoadEvent le) {
-
             if (le.exception != null && le.exception instanceof GwtKapuaException) {
                 FailureHandler.handle(le.exception);
             } else {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -109,7 +109,6 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
             setEnabled(false);
             getHeader().setVisible(false);
         }
-        doRefresh();
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -82,6 +82,7 @@ public class DeviceConfigComponents extends LayoutContainer {
 
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private static final ConsoleDeviceMessages DEVICE_MSGS = GWT.create(ConsoleDeviceMessages.class);
+
     private final GwtDeviceServiceAsync gwtDeviceService = GWT.create(GwtDeviceService.class);
     private final GwtDeviceManagementServiceAsync gwtDeviceManagementService = GWT.create(GwtDeviceManagementService.class);
     private final GwtSecurityTokenServiceAsync gwtXSRFService = GWT.create(GwtSecurityTokenService.class);
@@ -158,8 +159,9 @@ public class DeviceConfigComponents extends LayoutContainer {
     public void setDevice(GwtDevice selectedDevice) {
         dirty = true;
         this.selectedDevice = selectedDevice;
-        refreshVisibilityStoreSettingButton();
-        refresh();
+        if (selectedDevice != null && settings != null) {
+            refreshVisibilityStoreSettingButton();
+        }
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfiguration.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfiguration.java
@@ -87,30 +87,31 @@ public class DeviceTabConfiguration extends KapuaTabItem<GwtDevice> {
             getHeader().setVisible(false);
         }
 
-        doRefresh();
-    }
-
-    @Override
-    public void doRefresh() {
-
-        if (tabsPanel == null) {
-            return;
-        }
-
-        if (tabsPanel.getSelectedItem() == tabComponents) {
-            configComponents.refresh();
-        } else if (tabsPanel.getSelectedItem() == tabSnapshots) {
-            configSnapshots.refresh();
-        }
-
         if (selectedEntity != null) {
             // Configurations
             configComponents.setDevice(selectedEntity);
 
             // Snapshot
             configSnapshots.setDevice(selectedEntity);
+        }
+
+    }
+
+    @Override
+    public void doRefresh() {
+        if (tabsPanel == null) {
+            return;
+        }
+
+        if (selectedEntity != null) {
             tabSnapshots.setEnabled(selectedEntity.isOnline());
         }
+        if (tabsPanel.getSelectedItem() == tabComponents) {
+            configComponents.refresh();
+        } else if (tabsPanel.getSelectedItem() == tabSnapshots) {
+            configSnapshots.refresh();
+        }
+
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventory.java
@@ -74,7 +74,6 @@ public class DeviceTabInventory extends KapuaTabItem<GwtDevice> {
             tabsPanel.setSelection(inventoryDeploymentPackageTab);
         }
 
-        doRefresh();
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/keystore/DeviceTabKeystore.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/keystore/DeviceTabKeystore.java
@@ -100,7 +100,6 @@ public class DeviceTabKeystore extends KapuaTabItem<GwtDevice> {
             getHeader().setVisible(false);
         }
 
-        refresh();
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -105,7 +105,6 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
             historyPackageTab.setEntity(gwtDevice);
         }
 
-        doRefresh();
     }
 
     @Override


### PR DESCRIPTION
The device management tabs had a bug with the device setting method which was refreshing the tab even when not active. This, besides performance drawbacks, caused incorrect insertion of device events, even in the case of devices where those tabs have not been opened at all before.