### PR TITLE
[FEATURE] Inserted a way to automatically obtain rest API url endpoint with swagger

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -26,7 +26,9 @@ info:
     All Eclipse Kapua REST API, except the Authentication endpoints that performs an Authentication, need an Authentication Token to be executed. You will retrieve such token as a response of one of the Authentication calls, in the form of a [JWT](https://jwt.io) as the value of the property `tokenId`. For every subsequent call, you need to pass such token in the `Authorization` HTTP Header, with the `Bearer` type.
 
 servers:
-  - description: Kapua REST API Endpoint
+  - description: Kapua REST API Endpoint hosted where this definition file is hosted
+    url: /v1
+  - description: Kapua REST API Endpoint custom
     url: "{scheme}://{host}:{port}/{basePath}"
     variables:
       scheme:


### PR DESCRIPTION
here I inserted a new "server" field in the openAPI root specification that allows to automatically populating the URL that will be used in subsequent rest API calls by swagger. This is based by the fact that swagger defaults to the url used to host the definition file, so if this is the case, upon opening swagger automatically the selected "server" field will be the one I inserted which references to the same host where the file is placed. 

[possible side effects]
it should be noted that I had to hardcode in the definition of this field only the version (/v1) so if in the future we will have a new one this field will need to be changed. I did not find a way to let Swagger populate all the url EXCEPT FOR the version, customizable with a field.  

![image](https://user-images.githubusercontent.com/39708353/232448025-b794d4e3-8ac4-4182-bd75-7e514bfa773f.png)
