### PR TITLE
[FIX] update in openAPI documentation to reach consistency with responseCode field

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/device/device.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device.yaml
@@ -339,6 +339,7 @@ components:
               type: string
               enum:
                 - ACCEPTED
+                - SENT
                 - BAD_REQUEST
                 - NOT_FOUND
                 - INTERNAL_ERROR

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent.yaml
@@ -47,6 +47,7 @@ components:
               type: string
               enum:
                 - ACCEPTED
+                - SENT
                 - BAD_REQUEST
                 - NOT_FOUND
                 - INTERNAL_ERROR

--- a/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest.yaml
@@ -108,6 +108,7 @@ components:
           type: string
           enum:
             - ACCEPTED
+            - SENT
             - BAD_REQUEST
             - NOT_FOUND
             - INTERNAL_ERROR


### PR DESCRIPTION
Analyzing the code I found that the "responseCode" device Events field possible set of values was updated in release 1.5 with the SENT value and the documentation was not consequently updated, something that I have done with this PR