### PR TITLE
FIX - EndpointInfoService bugged count method

### DIFF
--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -234,17 +234,16 @@ public class EndpointInfoServiceImpl
         return entityManagerSession.doAction(em -> {
             EndpointInfoListResult endpointInfoListResult = EndpointInfoDAO.query(em, query);
 
-            if (endpointInfoListResult.isEmpty() && query.getScopeId() != null) {
-
-                // First check if there are any endpoint specified at all
-                if (countAllEndpointsInScope(em, query.getScopeId(), section)) {
-                    // if there are endpoints (even not matching the query), return the empty list
-                    return endpointInfoListResult;
-                }
+            if (endpointInfoListResult.isEmpty() && query.getScopeId() != null) { //query did not find results
 
                 KapuaId originalScopeId = query.getScopeId();
 
                 do {
+                    // First check if there are any endpoint AT ALL specified in this scope
+                    if (countAllEndpointsInScope(em, query.getScopeId(), section)) {
+                        // There are endpoints (even not matching the query), exit because I found the "nearest usable" endpoints which don't have what I'm searching
+                        break;
+                    }
                     Account account = KapuaSecurityUtils.doPrivileged(() -> ACCOUNT_SERVICE.find(query.getScopeId()));
 
                     if (account == null) {
@@ -291,15 +290,14 @@ public class EndpointInfoServiceImpl
 
             if (endpointInfoCount == 0 && query.getScopeId() != null) {
 
-                // First check if there are any endpoint specified at all
-                if (countAllEndpointsInScope(em, query.getScopeId(), section)) {
-                    // if there are endpoints (even not matching the query), return 0
-                    return endpointInfoCount;
-                }
-
                 KapuaId originalScopeId = query.getScopeId();
 
                 do {
+                    // First check if there are any endpoint AT ALL specified in this scope
+                    if (countAllEndpointsInScope(em, query.getScopeId(), section)) {
+                        // There are endpoints (even not matching the query), exit because I found the "nearest usable" endpoints which don't have what I'm searching
+                        break;
+                    }
                     Account account = KapuaSecurityUtils.doPrivileged(() -> ACCOUNT_SERVICE.find(query.getScopeId()));
 
                     if (account == null) {

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -46,6 +46,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * {@link EndpointInfoService} implementation.
@@ -212,13 +213,17 @@ public class EndpointInfoServiceImpl
         }
     }
 
-    @Override
-    public EndpointInfoListResult query(KapuaQuery query) throws KapuaException {
-        return query(query, EndpointInfo.ENDPOINT_TYPE_RESOURCE);
-    }
-
-    @Override
-    public EndpointInfoListResult query(KapuaQuery query, String section)
+    /**
+     * Traverse the account hierarchy bottom-up to search for {@link EndpointInfo} respecting the given query,
+     * performing for each layer the given operationToPerform until the given emptinessPredicate dictates to stop OR when endpoints of the same section are found in one layer
+     * In other terms, this method applies a given function to the "nearest usable endpoints", aka the ones that I see in a given scopeID
+     *
+     * @param query  The query to filter the {@link EndpointInfo}s.
+     * @param section section of {@link EndpointInfo} where we want to search the information
+     * @param operationToPerform  function to apply at each layer
+     * @param emptinessPredicate  predicate that dictates to stop the traversal when false
+     */
+    public Object traverse(KapuaQuery query, String section, myBifunction<EntityManager, KapuaQuery, Object, KapuaException> operationToPerform, Predicate<Object> emptinessPredicate)
             throws KapuaException {
         ArgumentValidator.notNull(query, "query");
 
@@ -232,14 +237,14 @@ public class EndpointInfoServiceImpl
         //
         // Do Query
         return entityManagerSession.doAction(em -> {
-            EndpointInfoListResult endpointInfoListResult = EndpointInfoDAO.query(em, query);
+            Object res = operationToPerform.apply(em, query);
 
-            if (endpointInfoListResult.isEmpty() && query.getScopeId() != null) { //query did not find results
+            if (emptinessPredicate.test(res) && query.getScopeId() != null) { //query did not find results
 
                 KapuaId originalScopeId = query.getScopeId();
 
                 do {
-                    // First check if there are any endpoint AT ALL specified in this scope
+                    // First check if there are any endpoint AT ALL specified in this scope/layer
                     if (countAllEndpointsInScope(em, query.getScopeId(), section)) {
                         // There are endpoints (even not matching the query), exit because I found the "nearest usable" endpoints which don't have what I'm searching
                         break;
@@ -255,14 +260,14 @@ public class EndpointInfoServiceImpl
                         break;
                     }
                     query.setScopeId(account.getScopeId());
-                    endpointInfoListResult = EndpointInfoDAO.query(em, query);
+                    res = operationToPerform.apply(em, query);
                 }
-                while (query.getScopeId() != null && endpointInfoListResult.isEmpty());
+                while (query.getScopeId() != null && emptinessPredicate.test(res));
 
                 query.setScopeId(originalScopeId);
             }
 
-            return endpointInfoListResult;
+            return res;
         });
     }
 
@@ -272,58 +277,29 @@ public class EndpointInfoServiceImpl
     }
 
     @Override
-    public long count(KapuaQuery query, String section)
-            throws KapuaException {
-        ArgumentValidator.notNull(query, "query");
+    public long count(KapuaQuery query, String section) throws KapuaException {
+        return (long) traverse(query, section, EndpointInfoDAO::count, a -> (long)a == 0);
+    }
 
-        //
-        // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(
-                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, query.getScopeId())
-        );
-        addSectionToPredicate(query, section);
+    @Override
+    public EndpointInfoListResult query(KapuaQuery query) throws KapuaException {
+        return query(query, EndpointInfo.ENDPOINT_TYPE_RESOURCE);
+    }
 
-        //
-        // Do count
-        return entityManagerSession.doAction(em -> {
-            long endpointInfoCount = EndpointInfoDAO.count(em, query);
-
-            if (endpointInfoCount == 0 && query.getScopeId() != null) {
-
-                KapuaId originalScopeId = query.getScopeId();
-
-                do {
-                    // First check if there are any endpoint AT ALL specified in this scope
-                    if (countAllEndpointsInScope(em, query.getScopeId(), section)) {
-                        // There are endpoints (even not matching the query), exit because I found the "nearest usable" endpoints which don't have what I'm searching
-                        break;
-                    }
-                    Account account = KapuaSecurityUtils.doPrivileged(() -> ACCOUNT_SERVICE.find(query.getScopeId()));
-
-                    if (account == null) {
-                        throw new KapuaEntityNotFoundException(Account.TYPE, query.getScopeId());
-                    }
-                    if (account.getScopeId() == null) {
-                        // Query was originally on root account, and querying on parent scope id would mean querying in null,
-                        // i.e. querying on all accounts. Since that's not what we want, break away.
-                        break;
-                    }
-
-                    query.setScopeId(account.getScopeId());
-                    endpointInfoCount = EndpointInfoDAO.count(em, query);
-                }
-                while (query.getScopeId() != null && endpointInfoCount == 0);
-
-                query.setScopeId(originalScopeId);
-            }
-
-            return endpointInfoCount;
-        });
+    public EndpointInfoListResult query(KapuaQuery query, String section) throws KapuaException {
+        return (EndpointInfoListResult) traverse(query, section, EndpointInfoDAO::query, a -> ((EndpointInfoListResult)a).isEmpty());
     }
 
     //
-    // Private methods
+    // Private methods and interfaces
     //
+
+    //this interface is created solely because java complains if you pass lambdas throwing checked exception
+    //to overcome this, I created this interface which is a custom form of a Bifunction throwing the checked KapuaException
+    @FunctionalInterface
+    private interface myBifunction<A, B, C, E extends KapuaException> {
+        C apply(A input1, B input2) throws E;
+    }
 
     /**
      * Checks whether another {@link EndpointInfo} already exists with the given values.


### PR DESCRIPTION
This PR is born from an issue that exposed a problem regarding the creation of similar CORS endpoints (aka same schema, port, and domain) in 2 different accounts. The root cause was a bug inside the _count_ method of the endpointService class. Essentially, the _query_ method of this class (that shared a lot of similar code with the _count_ method) has been modified in the past in order to consider different endpoint sections ("resource" and "cors") BUT this modification has not been "ported" also in the _count_ method. By doing so, the original exposed issue was fixed because the creation of endpoints (and also updates) depends on the _count_ method to verify if a similar endpoint already exists in the platform. 
This means that this PR, technically, fixes creation, and updates of CORS endpoints as well as, in general, counting of endpoints (for example, performed via the rest API call). In fact, before this fix, I personally noticed that the COUNT rest API call was bugged and was counting all endpoints in the given scope regardless of their section.

**Description of the solution adopted**
mixed with what I wrote above to create a more complete discourse. Other than that, I decided to compact the query and count methods of the endpointInfoService class by creating a more general _traverse_ method, that is specialized for the query and the count. This is mainly because I suspect that the missing of the "porting" of the modification I talked about earlier (from the query to the count method) has been caused by this code redundancy. Furthermore, this traverse method could be used in the future for other use cases, and in general this solution improves maintainability
