### PR TITLE
Print job execution log timestamps in ISO 8601 UTC format

### DIFF
--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
@@ -20,12 +20,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+import java.text.DateFormat;
 import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 /**
  * Logger for {@link org.eclipse.kapua.service.job.Job} processing.
@@ -141,7 +144,7 @@ public class JobLogger {
             formatSb.append(format);
 
             List<Object> finalArguments = new ArrayList<>();
-            finalArguments.add(new Date());
+            finalArguments.add(formatDate(new Date()));
             finalArguments.addAll(Arrays.asList(arguments));
 
             tokenizeFormat(formatSb);
@@ -221,7 +224,7 @@ public class JobLogger {
             formatSb.append(format);
 
             List<Object> finalArguments = new ArrayList<>();
-            finalArguments.add(new Date());
+            finalArguments.add(formatDate(new Date()));
             finalArguments.addAll(Arrays.asList(arguments));
 
             if (exception != null) {
@@ -306,7 +309,7 @@ public class JobLogger {
             formatSb.append(format);
 
             List<Object> finalArguments = new ArrayList<>();
-            finalArguments.add(new Date());
+            finalArguments.add(formatDate(new Date()));
             finalArguments.addAll(Arrays.asList(arguments));
 
             if (exception != null) {
@@ -411,5 +414,13 @@ public class JobLogger {
             offset = formatSb.indexOf("{}");
             formatSb.insert(offset + 1, i++);
         }
+    }
+
+
+    private String formatDate(Date date) {
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'");
+        df.setTimeZone(tz);
+        return df.format(date);
     }
 }


### PR DESCRIPTION
**Brief description of the PR**
The timestamp of the batch-job was in a non-standard format `dd/mm/yy HH:MM AM/PM`.
This PR is to change it in order to comply with the following format: `yyyy-mm-dd'T'HH:mm:ss.SS'Z'`

**Screenshots**
Before the PR:
<img width="610" alt="Screenshot 2023-05-11 at 11 26 38" src="https://github.com/eclipse/kapua/assets/66636702/76b80ac7-2f1e-4ccd-9886-0ace22d053b6">

After the PR:
<img width="615" alt="Screenshot 2023-05-11 at 14 20 09" src="https://github.com/eclipse/kapua/assets/66636702/aba94bd4-9953-4ff9-b64d-b9cb60eac13d">


