### PR TITLE
Mount `Credential` API resources also under `User` resource path

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserCredentialFiltered.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserCredentialFiltered.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.app.api.core.model.CountResult;
+import org.eclipse.kapua.app.api.core.model.EntityId;
+import org.eclipse.kapua.app.api.core.model.ScopeId;
+import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialAttributes;
+import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
+import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
+import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
+import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
+import org.eclipse.kapua.service.authentication.credential.CredentialService;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/{scopeId}/user/{userId}/credentials")
+public class UserCredentialFiltered extends AbstractKapuaResource {
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final CredentialService credentialService = locator.getService(CredentialService.class);
+    private final CredentialFactory credentialFactory = locator.getFactory(CredentialFactory.class);
+
+
+    /**
+     * Gets the {@link Credential} list in the scope.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param userId  The {@link EntityId} for which search results.
+     * @param offset  The result set offset.
+     * @param limit   The result set limit.
+     * @return The {@link CredentialListResult} of all the credentials associated to the current selected scope.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public CredentialListResult getAll(
+        @PathParam("scopeId") ScopeId scopeId,
+        @PathParam("userId") EntityId userId,
+        @QueryParam("offset") @DefaultValue("0") int offset,
+        @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
+        CredentialQuery query = credentialFactory.newQuery(scopeId);
+
+        AndPredicate andPredicate = query.andPredicate();
+        andPredicate.and(query.attributePredicate(CredentialAttributes.USER_ID, userId));
+        query.setPredicate(andPredicate);
+
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return credentialService.query(query);
+    }
+
+
+    /**
+     * Counts the results with the given {@link CredentialQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to count results.
+     * @param userId  The {@link EntityId} for which count results.
+     * @param query   The {@link CredentialQuery} to use to filter results.
+     * @return The count of all the result matching the given {@link CredentialQuery} parameter.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_count")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public CountResult count(
+        @PathParam("scopeId") ScopeId scopeId,
+        @PathParam("userId") EntityId userId,
+        CredentialQuery query) throws KapuaException {
+        AndPredicate andPredicate = query.andPredicate();
+        andPredicate.and(query.attributePredicate(CredentialAttributes.USER_ID, userId));
+        query.setPredicate(andPredicate);
+
+        return new CountResult(credentialService.count(query));
+    }
+
+
+    /**
+     * Creates a new Credential based on the information provided in CredentialCreator
+     * parameter.
+     *
+     * @param scopeId           The {@link ScopeId} in which to create the {@link Credential}.
+     * @param userId            The {@link EntityId} for which create the {@link Credential}.
+     * @param credentialCreator Provides the information for the new Credential to be created.
+     * @return The newly created Credential object.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response create(
+        @PathParam("scopeId") ScopeId scopeId,
+        @PathParam("userId") EntityId userId,
+        CredentialCreator credentialCreator) throws KapuaException {
+        credentialCreator.setScopeId(scopeId);
+        credentialCreator.setUserId(userId);
+
+        return returnCreated(credentialService.create(credentialCreator));
+    }
+}

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -428,6 +428,11 @@ paths:
     $ref: './userCredentials/userCredentials-scopeId.yaml#/paths/~1{scopeId}~1user~1credentials~1password'
   /{scopeId}/user/credentials/{credentialId}/_reset:
     $ref: './userCredentials/userCredentials-scopeId-credentialId-_reset.yaml#/paths/~1{scopeId}~1user~1credentials~1{credentialId}~1_reset'
+  ### User Credentials Filtered ###
+  /{scopeId}/user/{userId}/credentials/:
+    $ref: './userCredentialsFiltered/credential-scopeId.yaml#/paths/~1{scopeId}~1user~1{userId}~1credentials'
+  /{scopeId}/user/{userId}/credentials/_count:
+    $ref: './userCredentialsFiltered/credential-scopeId-_count.yaml#/paths/~1{scopeId}~1user~1{userId}~1credentials~1_count'
   ### User Profile ###
   /{scopeId}/user/profile/:
     $ref: './userProfile/userProfile-scopeId.yaml#/paths/~1{scopeId}~1user~1profile~1'

--- a/rest-api/resources/src/main/resources/openapi/userCredentialsFiltered/credential-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userCredentialsFiltered/credential-scopeId-_count.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.2
+
+info:
+  title: Eclipse Kapua REST API - User Credentials Filtered
+  version: '1.0'
+  contact:
+    name: Eclipse Kapua Dev Team
+    url: https://eclipse.org/kapua
+    email: kapua-dev@eclipse.org
+  license:
+    name: Eclipse Public License 2.0
+    url: https://www.eclipse.org/legal/epl-2.0
+
+paths:
+  /{scopeId}/user/{userId}/credentials/_count:
+    post:
+      tags:
+        - User Credentials Filtered
+      summary: Count the Credentials for the User
+      operationId: userCredentialFilteredCount
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../user/user.yaml#/components/parameters/userId'
+      requestBody:
+        $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
+      responses:
+        200:
+          $ref: '../openapi.yaml#/components/responses/countResult'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/resources/src/main/resources/openapi/userCredentialsFiltered/credential-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userCredentialsFiltered/credential-scopeId.yaml
@@ -1,0 +1,156 @@
+openapi: 3.0.2
+
+info:
+  title: Eclipse Kapua REST API - User Credentials Filtered
+  version: '1.0'
+  contact:
+    name: Eclipse Kapua Dev Team
+    url: https://eclipse.org/kapua
+    email: kapua-dev@eclipse.org
+  license:
+    name: Eclipse Public License 2.0
+    url: https://www.eclipse.org/legal/epl-2.0
+
+paths:
+  /{scopeId}/user/{userId}/credentials:
+    get:
+      tags:
+        - User Credentials Filtered
+      summary: Get all the Credentials for the User
+      operationId: userCredentialFilteredList
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/limit'
+        - $ref: '../openapi.yaml#/components/parameters/offset'
+
+      responses:
+        200:
+          description: The list of the Credentials available for the User
+          content:
+            application/json:
+              schema:
+                $ref: '../credential/credential.yaml#/components/schemas/credentialListResult'
+              example:
+                type: credentialListResult
+                limitExceeded: false
+                size: 2
+                items:
+                  - id: LgJHjS2jvdE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    optlock: 0
+                    userId: AQ
+                    credentialType: PASSWORD
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
+                  - id: LgREjS2jadE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    optlock: 0
+                    userId: AQ
+                    credentialType: API_KEY
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
+    post:
+      tags:
+        - User Credentials Filtered
+      summary: Create a new Credential for the User
+      operationId: userCredentialFilteredCreate
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../user/user.yaml#/components/parameters/userId'
+      requestBody:
+        description: An object containing the properties for the new Credential to be created
+        content:
+          application/json:
+            schema:
+              $ref: '../credential/credential.yaml#/components/schemas/credentialCreator'
+            examples:
+              password:
+                description: Password
+                value:
+                    userId: "AQ"
+                    credentialType: PASSWORD
+                    credentialKey: "New-password-123!"
+                    credentialStatus: ENABLED
+                    expirationDate: "2019-12-31T00:00:00.000Z"
+              apikey:
+                description: API Key
+                value:
+                  userId: "AQ"
+                  credentialType: API_KEY
+                  credentialStatus: ENABLED
+                  expirationDate: "2019-12-31T00:00:00.000Z"
+        required: true
+      responses:
+        201:
+          description: The Credential that has just been created
+          content:
+            application/json:
+              schema:
+                $ref: '../credential/credential.yaml#/components/schemas/credential'
+              examples:
+                Password:
+                  value:
+                    id: LgJHjS2jvdE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    optlock: 0
+                    userId: AQ
+                    credentialType: PASSWORD
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
+                API Key:
+                  value:
+                    id: LgJHjS2jvdE
+                    scopeId: AQ
+                    createdOn: "2023-03-09T13:58:30.385Z"
+                    createdBy: AQ
+                    modifiedOn: "2023-03-09T13:58:30.385Z"
+                    modifiedBy: AQ
+                    credentialKey: $2a$12$BjLeC/gqcnEyk.XNo2qorul.a/v4HDuOUlfmojdSZXRSFTjymPdVm
+                    optlock: 0
+                    userId: AQ
+                    credentialType: PASSWORD
+                    status: ENABLED
+                    expirationDate: "2023-04-09T13:58:30.385Z"
+                    loginFailures: 0
+                    firstLoginFailure: "2023-03-09T13:58:30.385Z"
+                    loginFailuresReset: "2023-03-10T13:58:30.385Z"
+                    lockoutReset: "2023-03-09T14:58:30.385Z"
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -129,6 +129,11 @@ kapuaAuthcAccessToken = org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthentica
 /v1/*/user/credentials.xml      = kapuaAuthcAccessToken
 /v1/*/user/credentials/**       = kapuaAuthcAccessToken
 
+# User Filtered Credentials
+/v1/*/user/*/credentials.json   = kapuaAuthcAccessToken
+/v1/*/user/*/credentials.xml    = kapuaAuthcAccessToken
+/v1/*/user/*/credentials/**     = kapuaAuthcAccessToken
+
 # User Profile
 /v1/*/user/profile.json         = kapuaAuthcAccessToken
 /v1/*/user/profile.xml          = kapuaAuthcAccessToken


### PR DESCRIPTION
Brief description of the PR.
This PR fixes #3775, i.e. mount the `credential create`, `credential count`, `credential get all` API also under the `User` resource path.

**Related Issue**
#3775
