### PR TITLE
Fix - changed IMAGE_VERSION env. variable default value

### DIFF
--- a/deployment/commons/sso/keycloak/build
+++ b/deployment/commons/sso/keycloak/build
@@ -14,7 +14,7 @@
 
 echo "Building Kapua Keycloak Docker image..."
 
-docker build -f ./docker/Dockerfile -t kapua/kapua-keycloak:"${IMAGE_VERSION:=latest}" . ||
+docker build -f ./docker/Dockerfile -t kapua/kapua-keycloak:"${IMAGE_VERSION:=2.0.0-SNAPSHOT}" . ||
 {
     echo "Building Kapua Keycloak docker image... ERROR!"
     exit 1

--- a/deployment/docker/unix/docker-common.sh
+++ b/deployment/docker/unix/docker-common.sh
@@ -15,5 +15,5 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-export IMAGE_VERSION=${IMAGE_VERSION:=latest}
+export IMAGE_VERSION=${IMAGE_VERSION:=2.0.0-SNAPSHOT}
 export CRYPTO_SECRET_KEY="${CRYPTO_SECRET_KEY:=dockerSecretKey!}"

--- a/deployment/docker/unix/docker-deploy.sh
+++ b/deployment/docker/unix/docker-deploy.sh
@@ -98,7 +98,7 @@ done
 
 docker_common
 
-echo "Deploying Eclipse Kapua..."
+echo "Deploying Eclipse Kapua version $IMAGE_VERSION..."
 docker_compose ${DEBUG_MODE} ${DEV_MODE} ${SSO_MODE} ${SWAGGER} || {
     echo "Deploying Eclipse Kapua... ERROR!"
     exit 1

--- a/deployment/minishift/minishift-importer.sh
+++ b/deployment/minishift/minishift-importer.sh
@@ -29,7 +29,7 @@
 
 ERROR=0
 DOCKER_ACCOUNT=${DOCKER_ACCOUNT:=kapua}
-IMAGE_VERSION=${IMAGE_VERSION:=latest}
+IMAGE_VERSION=${IMAGE_VERSION:=2.0.0-SNAPSHOT}
 SERVICES=("console" "api" "sql" "broker" "events-broker")
 TMP_DIR="/tmp/kapua-containers-$(date +%s)"
 

--- a/deployment/minishift/minishift-pull-images.sh
+++ b/deployment/minishift/minishift-pull-images.sh
@@ -17,7 +17,7 @@
 #
 
 DOCKER_ACCOUNT=${DOCKER_ACCOUNT:=kapua}
-IMAGE_VERSION=${IMAGE_VERSION:=latest}
+IMAGE_VERSION=${IMAGE_VERSION:=2.0.0-SNAPSHOT}
 SERVICES=("console" "api" "sql" "broker" "events-broker")
 
 echo "Pulling Kapua images..."

--- a/deployment/minishift/sso/keycloak-importer
+++ b/deployment/minishift/sso/keycloak-importer
@@ -14,7 +14,7 @@
 
 ERROR=0
 DOCKER_ACCOUNT=${DOCKER_ACCOUNT:=kapua}
-IMAGE_VERSION=${IMAGE_VERSION:=latest}
+IMAGE_VERSION=${IMAGE_VERSION:=2.0.0-SNAPSHOT}
 KEYCLOAK="keycloak"
 TMP_DIR="/tmp/keycloak-container-$(date +%s)"
 

--- a/deployment/openshift/openshift-deploy.sh
+++ b/deployment/openshift/openshift-deploy.sh
@@ -19,7 +19,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . ${SCRIPT_DIR}/openshift-common.sh
 
 : DOCKER_ACCOUNT=${DOCKER_ACCOUNT:=kapua}
-: IMAGE_VERSION=${IMAGE_VERSION:=latest}
+: IMAGE_VERSION=${IMAGE_VERSION:=2.0.0-SNAPSHOT}
 : JAVA_OPTS_EXTRA=${JAVA_OPTS_EXTRA:=''}
 
 ### Test if the project is already created ... fail otherwise


### PR DESCRIPTION
The IMAGE_VERSION environment variable default value was set to "latest". This change will simplify the deployment of future Kapua versions because before this fix a manual modification of such variable was needed in order to deploy specific versions of the project. 
Furthermore, the deployment script has been modified to log the current value of that variable, in order to be more clear with the specific versions that it is in deployment