### PR TITLE
feat(jobs): Added JobStepProperty overrides on JobEngineStartOptions

### DIFF
--- a/consumer/lifecycle-app/src/main/java/org/eclipse/kapua/consumer/lifecycle/LifecycleJAXBContextProvider.java
+++ b/consumer/lifecycle-app/src/main/java/org/eclipse/kapua/consumer/lifecycle/LifecycleJAXBContextProvider.java
@@ -33,6 +33,7 @@ import org.eclipse.kapua.commons.service.event.store.api.EventStoreXmlRegistry;
 import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.job.engine.JobStartOptions;
+import org.eclipse.kapua.job.engine.commons.model.JobStepPropertiesOverrides;
 import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTdesignate;
@@ -114,6 +115,8 @@ public class LifecycleJAXBContextProvider implements JAXBContextProvider {
                     // Job Engine
                     JobStartOptions.class,
                     JobTargetSublist.class,
+                    JobStepPropertiesOverrides.class,
+
                     // Jobs Exception Info
                     CleanJobDataExceptionInfo.class,
                     JobAlreadyRunningExceptionInfo.class,

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptions.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptions.java
@@ -15,6 +15,7 @@ package org.eclipse.kapua.job.engine;
 import org.eclipse.kapua.KapuaSerializable;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 import org.eclipse.kapua.service.job.targets.JobTarget;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -25,6 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -74,6 +76,12 @@ public interface JobStartOptions extends KapuaSerializable {
     @XmlTransient
     void addTargetIdToSublist(KapuaId targetId);
 
+    List<JobStepProperty> getStepPropertiesOverrides();
+
+    void addStepPropertyOverride(JobStepProperty jobStepPropertyOverride);
+
+    void setStepPropertiesOverrides(List<JobStepProperty> jobStepPropertiesOverrides);
+
     /**
      * Gets whether or not the {@link JobTarget#getStepIndex()} needs to be reset to the given {@link #getFromStepIndex()}.
      *
@@ -121,4 +129,5 @@ public interface JobStartOptions extends KapuaSerializable {
      * @since 1.1.0
      */
     void setEnqueue(boolean enqueue);
+
 }

--- a/job-engine/app/core/pom.xml
+++ b/job-engine/app/core/pom.xml
@@ -39,6 +39,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-rest-api-core</artifactId>
         </dependency>
         <dependency>

--- a/job-engine/app/core/src/main/java/org/eclipse/kapua/job/engine/app/core/jackson/ObjectMapperProvider.java
+++ b/job-engine/app/core/src/main/java/org/eclipse/kapua/job/engine/app/core/jackson/ObjectMapperProvider.java
@@ -17,8 +17,10 @@ import org.eclipse.kapua.commons.rest.model.IsJobRunningResponse;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.job.engine.app.core.jackson.mixin.IsJobRunningResponseMixin;
 import org.eclipse.kapua.job.engine.app.core.jackson.mixin.JobStartOptionsMixin;
+import org.eclipse.kapua.job.engine.app.core.jackson.mixin.JobStepPropertyMixin;
 import org.eclipse.kapua.job.engine.app.core.jackson.mixin.KapuaIdMixin;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
@@ -32,6 +34,7 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
         objectMapper = new ObjectMapper();
         objectMapper.addMixIn(KapuaId.class, KapuaIdMixin.class);
         objectMapper.addMixIn(JobStartOptions.class, JobStartOptionsMixin.class);
+        objectMapper.addMixIn(JobStepProperty.class, JobStepPropertyMixin.class);
         objectMapper.addMixIn(IsJobRunningResponse.class, IsJobRunningResponseMixin.class);
     }
 

--- a/job-engine/app/core/src/main/java/org/eclipse/kapua/job/engine/app/core/jackson/mixin/JobStepPropertyMixin.java
+++ b/job-engine/app/core/src/main/java/org/eclipse/kapua/job/engine/app/core/jackson/mixin/JobStepPropertyMixin.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.job.engine.app.core.jackson.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.eclipse.kapua.service.job.step.definition.internal.JobStepPropertyImpl;
+
+@JsonDeserialize(as = JobStepPropertyImpl.class)
+@JsonIgnoreProperties("type")
+public interface JobStepPropertyMixin {
+}

--- a/job-engine/app/web/src/main/java/org/eclipse/kapua/job/engine/app/web/jaxb/JaxbContextResolver.java
+++ b/job-engine/app/web/src/main/java/org/eclipse/kapua/job/engine/app/web/jaxb/JaxbContextResolver.java
@@ -31,6 +31,7 @@ import org.eclipse.kapua.commons.rest.model.errors.JobStoppingExceptionInfo;
 import org.eclipse.kapua.commons.rest.model.errors.SubjectUnauthorizedExceptionInfo;
 import org.eclipse.kapua.commons.rest.model.errors.ThrowableInfo;
 import org.eclipse.kapua.job.engine.JobStartOptions;
+import org.eclipse.kapua.job.engine.commons.model.JobStepPropertiesOverrides;
 import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
 import org.eclipse.kapua.service.authentication.AuthenticationXmlRegistry;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
@@ -115,6 +116,8 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     // Job Engine
                     JobStartOptions.class,
                     JobTargetSublist.class,
+                    JobStepPropertiesOverrides.class,
+
                     // Jobs Exception Info
                     CleanJobDataExceptionInfo.class,
                     JobAlreadyRunningExceptionInfo.class,

--- a/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobStartOptionsClient.java
+++ b/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobStartOptionsClient.java
@@ -76,7 +76,7 @@ public class JobStartOptionsClient implements JobStartOptions {
 
     @Override
     public void setStepPropertiesOverrides(List<JobStepProperty> stepPropertiesOverrides) {
-        this.stepPropertiesOverrides = stepPropertiesOverrides;
+        this.stepPropertiesOverrides = new ArrayList<>(stepPropertiesOverrides);
     }
 
     @Override

--- a/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobStartOptionsClient.java
+++ b/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobStartOptionsClient.java
@@ -14,8 +14,11 @@ package org.eclipse.kapua.job.engine.client;
 
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -28,6 +31,7 @@ public class JobStartOptionsClient implements JobStartOptions {
     private static final long serialVersionUID = 7890046123237425642L;
 
     private Set<KapuaId> targetIdSublist;
+    private List<JobStepProperty> stepPropertiesOverrides;
     private boolean resetStepIndex;
     private Integer fromStepIndex;
     private boolean enqueue;
@@ -54,6 +58,25 @@ public class JobStartOptionsClient implements JobStartOptions {
     @Override
     public void removeTargetIdToSublist(KapuaId targetId) {
         getTargetIdSublist().remove(targetId);
+    }
+
+    @Override
+    public List<JobStepProperty> getStepPropertiesOverrides() {
+        if (stepPropertiesOverrides == null) {
+            stepPropertiesOverrides = new ArrayList<>();
+        }
+
+        return stepPropertiesOverrides;
+    }
+
+    @Override
+    public void addStepPropertyOverride(JobStepProperty jobStepPropertyOverride) {
+        getStepPropertiesOverrides().add(jobStepPropertyOverride);
+    }
+
+    @Override
+    public void setStepPropertiesOverrides(List<JobStepProperty> stepPropertiesOverrides) {
+        this.stepPropertiesOverrides = stepPropertiesOverrides;
     }
 
     @Override

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobStepPropertiesOverrides.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobStepPropertiesOverrides.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.job.engine.commons.model;
+
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@XmlRootElement(name = "jobStepPropertiesOverrides")
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType
+public class JobStepPropertiesOverrides implements Iterable<JobStepProperty> {
+
+    @XmlElementWrapper(name = "jobStepPropertiesOverrides")
+    private List<JobStepProperty> jobStepPropertiesOverrides = new ArrayList<>();
+
+    public JobStepPropertiesOverrides() {
+    }
+
+    public JobStepPropertiesOverrides(List<JobStepProperty> targetIds) {
+        this.jobStepPropertiesOverrides.addAll(targetIds);
+    }
+
+    public List<JobStepProperty> getJobStepPropertiesOverrides() {
+        if (jobStepPropertiesOverrides == null) {
+            jobStepPropertiesOverrides = new ArrayList<>();
+        }
+
+        return jobStepPropertiesOverrides;
+    }
+
+    public void setJobStepPropertiesOverrides(List<JobStepProperty> jobStepPropertiesOverrides) {
+        this.jobStepPropertiesOverrides = jobStepPropertiesOverrides;
+    }
+
+    @Override
+    public Iterator<JobStepProperty> iterator() {
+        return jobStepPropertiesOverrides.iterator();
+    }
+
+    public boolean isEmpty() {
+        return getJobStepPropertiesOverrides().isEmpty();
+    }
+
+    public int size() {
+        return getJobStepPropertiesOverrides().size();
+    }
+}

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextPropertyNames.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextPropertyNames.java
@@ -43,6 +43,11 @@ public class JobContextPropertyNames {
     public static final String RESUMED_KAPUA_EXECUTION_ID = "job.execution.resumedId";
 
     /**
+     * @since 2.0.0
+     */
+    public static final String JOB_STEP_PROPERTIES_OVERRIDES = "job.step.properties.overrides";
+
+    /**
      * since 1.1.0
      */
     public static final String RESET_STEP_INDEX = "job.step.resetIndex";

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
@@ -17,6 +17,7 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.job.engine.commons.exception.ReadJobPropertyException;
 import org.eclipse.kapua.job.engine.commons.logger.JobLogger;
+import org.eclipse.kapua.job.engine.commons.model.JobStepPropertiesOverrides;
 import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
 import org.eclipse.kapua.job.engine.commons.model.JobTransientUserData;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -88,6 +89,22 @@ public class JobContextWrapper {
             return XmlUtil.unmarshal(jobTargetSublistString, JobTargetSublist.class);
         } catch (JAXBException | SAXException e) {
             throw new ReadJobPropertyException(e, JobContextPropertyNames.JOB_TARGET_SUBLIST, jobTargetSublistString);
+        }
+    }
+
+    /**
+     * Gets the {@link JobStepPropertiesOverrides} of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     *
+     * @return The current {@link JobStepPropertiesOverrides} of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     * @since 2.0.0
+     */
+    public JobStepPropertiesOverrides getJobStepPropertiesOverrides() {
+        String jobStepPropertiesOverrides = getProperties().getProperty(JobContextPropertyNames.JOB_STEP_PROPERTIES_OVERRIDES);
+
+        try {
+            return XmlUtil.unmarshal(jobStepPropertiesOverrides, JobStepPropertiesOverrides.class);
+        } catch (JAXBException | SAXException e) {
+            throw new ReadJobPropertyException(e, JobContextPropertyNames.JOB_STEP_PROPERTIES_OVERRIDES, jobStepPropertiesOverrides);
         }
     }
 

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
@@ -99,7 +99,7 @@ public class JobStartOptionsImpl implements JobStartOptions {
 
     @Override
     public void setStepPropertiesOverrides(List<JobStepProperty> stepPropertiesOverrides) {
-        this.stepPropertiesOverrides = stepPropertiesOverrides;
+        this.stepPropertiesOverrides = new ArrayList<>(stepPropertiesOverrides);
     }
 
     @Override

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
@@ -14,8 +14,11 @@ package org.eclipse.kapua.job.engine.jbatch;
 
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -28,6 +31,7 @@ public class JobStartOptionsImpl implements JobStartOptions {
     private static final long serialVersionUID = 5339966879340542119L;
 
     private Set<KapuaId> targetIdSublist;
+    private List<JobStepProperty> stepPropertiesOverrides;
     private boolean resetStepIndex;
     private Integer fromStepIndex;
     private boolean enqueue;
@@ -77,6 +81,25 @@ public class JobStartOptionsImpl implements JobStartOptions {
     @Override
     public void removeTargetIdToSublist(KapuaId targetId) {
         getTargetIdSublist().remove(targetId);
+    }
+
+    @Override
+    public List<JobStepProperty> getStepPropertiesOverrides() {
+        if (stepPropertiesOverrides == null) {
+            stepPropertiesOverrides = new ArrayList<>();
+        }
+
+        return stepPropertiesOverrides;
+    }
+
+    @Override
+    public void addStepPropertyOverride(JobStepProperty stepPropertyOverride) {
+        getStepPropertiesOverrides().add(stepPropertyOverride);
+    }
+
+    @Override
+    public void setStepPropertiesOverrides(List<JobStepProperty> stepPropertiesOverrides) {
+        this.stepPropertiesOverrides = stepPropertiesOverrides;
     }
 
     @Override

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
@@ -164,7 +164,7 @@ public class JbatchDriver {
                     jslStep.setNextFromAttribute("step-" + (jobStep.getStepIndex() + 1));
                 }
 
-                jslStep.setProperties(JobDefinitionBuildUtils.buildStepProperties(jobStepDefinition, jobStep, jobStepIterator.hasNext()));
+                jslStep.setProperties(JobDefinitionBuildUtils.buildStepProperties(jobStepDefinition, jobStep, jobStepIterator.hasNext(), jobStartOptions.getStepPropertiesOverrides()));
 
                 jslExecutionElements.add(jslStep);
             }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
@@ -110,11 +110,21 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
 
         jobLogger.info("Running before job...");
         jobLogger.info("Run configuration:");
-        jobLogger.info("\tTarget count:           {}", jobContextWrapper.getTargetSublist().size() != 0 ? jobContextWrapper.getTargetSublist().size() : "all");
-        jobLogger.info("\tReset step index:       {}", jobContextWrapper.getResetStepIndex());
-        jobLogger.info("\tFrom step index:        {}", jobContextWrapper.getFromStepIndex() != null ? jobContextWrapper.getFromStepIndex() : 0);
-        jobLogger.info("\tResuming job execution: {}", jobContextWrapper.getResumedJobExecutionId() != null ? jobContextWrapper.getResumedJobExecutionId() : "none");
-        jobLogger.info("\tEnqueue:                {}", jobContextWrapper.getEnqueue());
+        jobLogger.info("\tTarget count:                 {}", jobContextWrapper.getTargetSublist().size() != 0 ? jobContextWrapper.getTargetSublist().size() : "all");
+        jobLogger.info("\tReset step index:             {}", jobContextWrapper.getResetStepIndex());
+        jobLogger.info("\tFrom step index:              {}", jobContextWrapper.getFromStepIndex() != null ? jobContextWrapper.getFromStepIndex() : 0);
+        jobLogger.info("\tResuming job execution:       {}", jobContextWrapper.getResumedJobExecutionId() != null ? jobContextWrapper.getResumedJobExecutionId() : "none");
+        jobLogger.info("\tEnqueue:                      {}", jobContextWrapper.getEnqueue());
+
+        if (jobContextWrapper.getJobStepPropertiesOverrides().isEmpty()) {
+            jobLogger.info("\tStep Properties Overrides:    none");
+        } else {
+            jobLogger.info("\tStep Properties Overrides:    ");
+            jobContextWrapper
+                    .getJobStepPropertiesOverrides()
+                    .getJobStepPropertiesOverrides()
+                    .forEach(jsp -> jobLogger.info("\t - {}: {}", jsp.getName(), jsp.getPropertyValue()));
+        }
 
         JobExecution jobExecution;
         if (jobContextWrapper.getResumedJobExecutionId() != null) {

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestJAXBContextProvider.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestJAXBContextProvider.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.job.engine.client.JobStartOptionsClient;
+import org.eclipse.kapua.job.engine.commons.model.JobStepPropertiesOverrides;
 import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTdesignate;
@@ -132,6 +133,8 @@ public class TestJAXBContextProvider implements JAXBContextProvider {
                     JobListResult.class,
                     JobXmlRegistry.class,
                     JobTargetSublist.class,
+                    JobStepPropertiesOverrides.class,
+
                     DeviceCommandInput.class,
                     DeviceCommandOutput.class,
 


### PR DESCRIPTION
This PR adds the capability of override on the fly `JobStepProperties` of the `Job` upon `JobEngineService.start` operation.

This is useful because once started once a Job configuration cannot be updated and you always required to delete the job and re-create which sometimes is not a preferred thing to do.

**Related Issue**
_None_

**Description of the solution adopted**
Added a `List` of `JobStepProperties` to `JobStartOptions` in which is is possible to add multiple `JobStepProperties` that will override any matching `JopStepProperty` defined in any of the `JobStep`.

**Screenshots**
_None_

**Any side note on the changes made**
Further improvements:
- JobStepProperty overrides for specific JobStep
- Report that a JobExecution has started with a different configuration