### PR TITLE
fix(git): Added missing JEnv .java-version in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,9 @@ local.properties
 # SonarLint folders
 .sonarlint/
 
+#
 # IDEA
+#
 .idea/
 **/*.iml
 
@@ -109,6 +111,13 @@ velocity.log
 
 # Temporarly hide consoleV2 folder until it's merged from its branch
 console-v2/
+
+#
+# Misc
+#
+
+# Jenv
+.java-version
 
 # Visual Studio Code project settings
 .vscode


### PR DESCRIPTION
This PR adds a new entry in `.gitignore` to ignore config files of [JEnv](https://www.jenv.be/)

**Related Issue**
_None_

**Description of the solution adopted**
Added `.java-version` as a new entry in `.gitignore`

**Screenshots**
_None_

**Any side note on the changes made**
_None_