### PR TITLE
FIX - removed timestamp from the tag of docker images built

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -85,7 +85,6 @@
                                 <build>
                                     <tags>
                                         <tag>${project.version}</tag>
-                                        <tag>${timestamp}</tag>
                                     </tags>
                                 </build>
                             </image>


### PR DESCRIPTION
On Kapua, other than images tagged as the latest and with the version number, a set of images tagged with the current timestamp is created during the build. If this feature could be useful in some contexts, where for example daily builds are performed and you need to save a temporal snapshot of images, this is needless in our context and, mainly, creates overhead because for each different timestamp (currently it has a granularity of 1 day) a new image is created which occupies memory on disk, resulting in a prune of images after some time to save disk space if the building is repeated over time.

This PR removes the timestamped tagged images being built.