### PR TITLE
FIX - Ci improvement - maven artifact caching and various tweaks

### DIFF
--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -12,8 +12,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Clones Kapua repo inside the runner
-      uses: actions/checkout@v3
     - name: Setup java
       uses: actions/setup-java@v3
       with:
@@ -28,15 +26,15 @@ runs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Docker images creation
-      if: ${{ inputs.needs-docker-images }}
+      if: ${{ inputs.needs-docker-images == 'true' }}
       run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       shell: bash
     - name: Dns look-up containers needed for tests - message-broker
-      if: ${{ inputs.needs-docker-images }}
+      if: ${{ inputs.needs-docker-images == 'true' }}
       run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
       shell: bash
     - name: Dns look-up containers needed for tests - job-engine
-      if: ${{ inputs.needs-docker-images }}
+      if: ${{ inputs.needs-docker-images == 'true' }}
       run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
       shell: bash
     - name: Test execution step

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -43,7 +43,7 @@ runs:
         timeout_minutes: 45
         retry_on: error
         max_attempts: 1
-        command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags=${{ inputs.tag }} -pl ${TEST_PROJECTS} verify
+        command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify
     - name: Code-coverage results
       run: bash <(curl -s https://codecov.io/bash)
       shell: bash

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -43,7 +43,7 @@ runs:
         timeout_minutes: 45
         retry_on: error
         max_attempts: 1
-        command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags=${{ inputs.tag }} verify
+        command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags=${{ inputs.tag }} -pl ${TEST_PROJECTS} verify
     - name: Code-coverage results
       run: bash <(curl -s https://codecov.io/bash)
       shell: bash

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -1,0 +1,51 @@
+name: 'Execute tests tagged in a certain way'
+description: 'Execute tests suite for tests tagged as specified'
+inputs:
+  tag:
+    description: Cucumber tag of the tests to run
+    required: true
+  needs-docker-images:
+    description: true if this suite needs docker images, false otherwise
+    required: false
+    default: 'true'
+#outputs:
+runs:
+  using: "composite"
+  steps:
+    - name: Clones Kapua repo inside the runner
+      uses: actions/checkout@v3
+    - name: Setup java
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: 11
+        cache: 'maven' #TODO
+    - name: Cache Maven repository #TODO
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Docker images creation
+      if: ${{ inputs.needs-docker-images }}
+      run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
+      shell: bash
+    - name: Dns look-up containers needed for tests - message-broker
+      if: ${{ inputs.needs-docker-images }}
+      run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
+      shell: bash
+    - name: Dns look-up containers needed for tests - job-engine
+      if: ${{ inputs.needs-docker-images }}
+      run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
+      shell: bash
+    - name: Test execution step
+      uses: nick-fields/retry@v2.8.1
+      with:
+        timeout_minutes: 45
+        retry_on: error
+        max_attempts: 1
+        command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags=${{ inputs.tag }} verify
+    - name: Code-coverage results
+      run: bash <(curl -s https://codecov.io/bash)
+      shell: bash

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -17,12 +17,11 @@ runs:
       with:
         distribution: 'zulu'
         java-version: 11
-        cache: 'maven' #TODO
-    - name: Cache Maven repository #TODO
+    - name: Cache Maven repository
       uses: actions/cache@v3
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Docker images creation

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -22,8 +22,6 @@ runs:
       with:
         path: ~/.m2/repository
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-        restore-keys: |
-          ${{ runner.os }}-maven-
     - name: Docker images creation
       if: ${{ inputs.needs-docker-images == 'true' }}
       run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -35,12 +35,8 @@ runs:
       run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
       shell: bash
     - name: Test execution step
-      uses: nick-fields/retry@v2.8.1
-      with:
-        timeout_minutes: 45
-        retry_on: error
-        max_attempts: 1
-        command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify
+      run: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify
+      shell: bash
     - name: Code-coverage results
       run: bash <(curl -s https://codecov.io/bash)
       shell: bash

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -24,7 +24,7 @@ runs:
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
     - name: Docker images creation
       if: ${{ inputs.needs-docker-images == 'true' }}
-      run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
+      run: mvn clean install -pl ${APP_PROJECTS} && mvn clean install -Pdocker --f assembly/pom.xml
       shell: bash
     - name: Dns look-up containers needed for tests - message-broker
       if: ${{ inputs.needs-docker-images == 'true' }}

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -31,710 +31,282 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@brokerAcl" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@brokerAcl'
+          needs-docker-images: 'true'
   test-tag:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@tag" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@tag'
+          needs-docker-images: 'false'
   test-broker:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@broker" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@broker'
+          needs-docker-images: 'true'
   test-device:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@device" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@device'
+          needs-docker-images: 'true'
   test-device-management:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@deviceManagement" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@deviceManagement'
+          needs-docker-images: 'true'
   test-connection:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@connection" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@connection'
+          needs-docker-images: 'true'
   test-datastore:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@datastore" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@datastore'
+          needs-docker-images: 'true'
   test-user:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@user" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@user'
+          needs-docker-images: 'false'
   test-userIntegrationBase:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@userIntegrationBase" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@userIntegrationBase'
+          needs-docker-images: 'true'
   test-userIntegration:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@userIntegration" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@userIntegration'
+          needs-docker-images: 'true'
   test-security:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@security" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@security'
+          needs-docker-images: 'true'
   test-jobsAndScheduler:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobs or @scheduler" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobs or @scheduler'
+          needs-docker-images: 'true'
   test-jobsIntegrationBase:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobsIntegrationBase" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobsIntegrationBase'
+          needs-docker-images: 'true'
   test-jobsIntegration:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobsIntegration" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobsIntegration'
+          needs-docker-images: 'true'
   test-triggerService:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerService" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@triggerService'
+          needs-docker-images: 'true'
   test-triggerServiceIntegrationBase:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerServiceIntegrationBase" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@triggerServiceIntegrationBase'
+          needs-docker-images: 'true'
   test-triggerServiceIntegration:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerServiceIntegration" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@triggerServiceIntegration'
+          needs-docker-images: 'true'
   test-accountAndTranslator:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@account or @translator" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@account or @translator'
+          needs-docker-images: 'false'
   test-jobEngineStepDefinitions:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStepDefinitions" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobEngineStepDefinitions'
+          needs-docker-images: 'true'
   test-jobEngineStartOfflineDevice:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStartOfflineDevice" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobEngineStartOfflineDevice'
+          needs-docker-images: 'true'
   test-jobEngineStartOnlineDevice:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStartOnlineDevice" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobEngineStartOnlineDevice'
+          needs-docker-images: 'true'
   test-jobEngineRestartOfflineDevice:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOfflineDevice" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobEngineRestartOfflineDevice'
+          needs-docker-images: 'true'
   test-jobEngineRestartOnlineDevice:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOnlineDevice" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobEngineRestartOnlineDevice'
+          needs-docker-images: 'false'
   test-jobEngineRestartOnlineDeviceSecondPart:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOnlineDeviceSecondPart" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobEngineRestartOnlineDeviceSecondPart'
+          needs-docker-images: 'true'
   test-jobEngineServiceStop:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineServiceStop" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@jobEngineServiceStop'
+          needs-docker-images: 'true'
   test-RoleAndGroup:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@role or @group" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@role or @group'
+          needs-docker-images: 'false'
   test-deviceRegistry:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@deviceRegistry" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@deviceRegistry'
+          needs-docker-images: 'false'
   test-endpoint:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-          cache: 'maven'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@endpoint" verify
-      - run: bash <(curl -s https://codecov.io/bash)
+          tag: '@endpoint'
+          needs-docker-images: 'false'
   junit-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -5,6 +5,7 @@ env:
   BUILD_OPTS: ""
   CONFIG_OVERRIDES: "-Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dbroker.host=localhost -Dcrypto.secret.key=kapuaTestsKey!!!"
   MAVEN_OPTS: "-Xmx4096m"
+  TEST_PROJECTS: "org.eclipse.kapua:kapua-security-test,org.eclipse.kapua:kapua-qa-integration,org.eclipse.kapua:kapua-scheduler-test,org.eclipse.kapua:kapua-user-test,org.eclipse.kapua:kapua-system-test,org.eclipse.kapua:kapua-job-test,org.eclipse.kapua:kapua-device-registry-test,org.eclipse.kapua:kapua-account-test,org.eclipse.kapua:kapua-tag-test,org.eclipse.kapua:kapua-translator-test"
 
 jobs:
   build:

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -1,11 +1,12 @@
 name: Kapua CI
 on: [ push, pull_request ] # Triggers the workflow on push or pull request events
 
-env:
+env: #the last 2 env variables defines respectively the maven projects were cucumber tests resides and maven projects were consumers applications needed for docker images building resides.
   BUILD_OPTS: ""
   CONFIG_OVERRIDES: "-Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dbroker.host=localhost -Dcrypto.secret.key=kapuaTestsKey!!!"
   MAVEN_OPTS: "-Xmx4096m"
   TEST_PROJECTS: "org.eclipse.kapua:kapua-security-test,org.eclipse.kapua:kapua-qa-integration,org.eclipse.kapua:kapua-scheduler-test,org.eclipse.kapua:kapua-user-test,org.eclipse.kapua:kapua-system-test,org.eclipse.kapua:kapua-job-test,org.eclipse.kapua:kapua-device-registry-test,org.eclipse.kapua:kapua-account-test,org.eclipse.kapua:kapua-tag-test,org.eclipse.kapua:kapua-translator-test"
+  APP_PROJECTS: "org.eclipse.kapua:kapua-service-authentication-app,org.eclipse.kapua:kapua-consumer-lifecycle-app,org.eclipse.kapua:kapua-consumer-telemetry-app"
 
 jobs:
   build:

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -137,7 +137,7 @@ jobs:
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@security'
-          needs-docker-images: 'true'
+          needs-docker-images: 'false'
   test-jobsAndScheduler:
     needs: build
     runs-on: ubuntu-latest
@@ -147,7 +147,7 @@ jobs:
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobs or @scheduler'
-          needs-docker-images: 'true'
+          needs-docker-images: 'false'
   test-jobsIntegrationBase:
     needs: build
     runs-on: ubuntu-latest
@@ -257,7 +257,7 @@ jobs:
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngineRestartOnlineDevice'
-          needs-docker-images: 'false'
+          needs-docker-images: 'true'
   test-jobEngineRestartOnlineDeviceSecondPart:
     needs: build
     runs-on: ubuntu-latest
@@ -297,7 +297,7 @@ jobs:
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@deviceRegistry'
-          needs-docker-images: 'false'
+          needs-docker-images: 'true'
   test-endpoint:
     needs: build
     runs-on: ubuntu-latest
@@ -307,7 +307,7 @@ jobs:
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@endpoint'
-          needs-docker-images: 'false'
+          needs-docker-images: 'true'
   junit-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -165,36 +165,37 @@ jobs:
         with:
           tag: '@jobsIntegration'
           needs-docker-images: 'true'
-  test-triggerService:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
-      - uses: ./.github/actions/runTestsTaggedAs
-        with:
-          tag: '@triggerService'
-          needs-docker-images: 'true'
-  test-triggerServiceIntegrationBase:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
-      - uses: ./.github/actions/runTestsTaggedAs
-        with:
-          tag: '@triggerServiceIntegrationBase'
-          needs-docker-images: 'true'
-  test-triggerServiceIntegration:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
-      - uses: ./.github/actions/runTestsTaggedAs
-        with:
-          tag: '@triggerServiceIntegration'
-          needs-docker-images: 'true'
+  #the next 3 tests-suites have been disabled because in the code-base I can't find feature files tagged in this way
+#  test-triggerService:
+#    needs: build
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Clones Kapua repo inside the runner
+#        uses: actions/checkout@v3
+#      - uses: ./.github/actions/runTestsTaggedAs
+#        with:
+#          tag: '@triggerService'
+#          needs-docker-images: 'true'
+#  test-triggerServiceIntegrationBase:
+#    needs: build
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Clones Kapua repo inside the runner
+#        uses: actions/checkout@v3
+#      - uses: ./.github/actions/runTestsTaggedAs
+#        with:
+#          tag: '@triggerServiceIntegrationBase'
+#          needs-docker-images: 'true'
+#  test-triggerServiceIntegration:
+#    needs: build
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Clones Kapua repo inside the runner
+#        uses: actions/checkout@v3
+#      - uses: ./.github/actions/runTestsTaggedAs
+#        with:
+#          tag: '@triggerServiceIntegration'
+#          needs-docker-images: 'true'
   test-accountAndTranslator:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -17,11 +17,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-          cache: 'maven'
       - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - run: mvn -v
@@ -321,7 +320,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -344,7 +343,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - run: mvn -B -DskipTests install javadoc:jar

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -166,37 +166,6 @@ jobs:
         with:
           tag: '@jobsIntegration'
           needs-docker-images: 'true'
-  #the next 3 tests-suites have been disabled because in the code-base I can't find feature files tagged in this way
-#  test-triggerService:
-#    needs: build
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Clones Kapua repo inside the runner
-#        uses: actions/checkout@v3
-#      - uses: ./.github/actions/runTestsTaggedAs
-#        with:
-#          tag: '@triggerService'
-#          needs-docker-images: 'true'
-#  test-triggerServiceIntegrationBase:
-#    needs: build
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Clones Kapua repo inside the runner
-#        uses: actions/checkout@v3
-#      - uses: ./.github/actions/runTestsTaggedAs
-#        with:
-#          tag: '@triggerServiceIntegrationBase'
-#          needs-docker-images: 'true'
-#  test-triggerServiceIntegration:
-#    needs: build
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Clones Kapua repo inside the runner
-#        uses: actions/checkout@v3
-#      - uses: ./.github/actions/runTestsTaggedAs
-#        with:
-#          tag: '@triggerServiceIntegration'
-#          needs-docker-images: 'true'
   test-accountAndTranslator:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -21,8 +21,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
@@ -316,13 +314,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 45
@@ -339,12 +334,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - run: mvn -B -DskipTests install javadoc:jar
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3 # Checks out a copy of the repository on the ubuntu-latest machine
       - uses: actions/setup-java@v3
@@ -29,6 +30,7 @@ jobs:
   test-brokerAcl:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -39,6 +41,7 @@ jobs:
   test-tag:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -49,6 +52,7 @@ jobs:
   test-broker:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -59,6 +63,7 @@ jobs:
   test-device:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -69,6 +74,7 @@ jobs:
   test-device-management:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -79,6 +85,7 @@ jobs:
   test-connection:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -89,6 +96,7 @@ jobs:
   test-datastore:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -99,6 +107,7 @@ jobs:
   test-user:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -109,6 +118,7 @@ jobs:
   test-userIntegrationBase:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -119,6 +129,7 @@ jobs:
   test-userIntegration:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -129,6 +140,7 @@ jobs:
   test-security:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -139,6 +151,7 @@ jobs:
   test-jobsAndScheduler:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -149,6 +162,7 @@ jobs:
   test-jobsIntegrationBase:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -159,6 +173,7 @@ jobs:
   test-jobsIntegration:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -169,6 +184,7 @@ jobs:
   test-accountAndTranslator:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -179,6 +195,7 @@ jobs:
   test-jobEngineStepDefinitions:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -189,6 +206,7 @@ jobs:
   test-jobEngineStartOfflineDevice:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -199,6 +217,7 @@ jobs:
   test-jobEngineStartOnlineDevice:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -209,6 +228,7 @@ jobs:
   test-jobEngineRestartOfflineDevice:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -219,6 +239,7 @@ jobs:
   test-jobEngineRestartOnlineDevice:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -229,6 +250,7 @@ jobs:
   test-jobEngineRestartOnlineDeviceSecondPart:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -239,6 +261,7 @@ jobs:
   test-jobEngineServiceStop:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -249,6 +272,7 @@ jobs:
   test-RoleAndGroup:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -259,6 +283,7 @@ jobs:
   test-deviceRegistry:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -269,6 +294,7 @@ jobs:
   test-endpoint:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
         uses: actions/checkout@v3
@@ -279,6 +305,7 @@ jobs:
   junit-tests:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -289,16 +316,12 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-      - uses: nick-fields/retry@v2.8.1
-        with:
-          timeout_minutes: 45
-          retry_on: error
-          max_attempts: 1
-          command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
+      - run: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
       - run: bash <(curl -s https://codecov.io/bash)
   build-javadoc:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3


### PR DESCRIPTION
Brief description of the PR.
This PR improves the CI process, with various tweaks and re-introducing the maven artifacts cache mechanism.

**Related Issue**
This PR addresses https://github.com/eclipse/kapua/issues/3688

**Description of the solution adopted**
I'll present the changes made with a list that covers the different "categories" of improvements, sorted according to the order of implementation of each of them:

1. Duplicated code removal
I've noticed that a lot of code for job definitions was repeated in the kapua-ci.yaml file, especially in the case of jobs that executes the different cucumber tests of the project. This redundancy of code causes difficulty in the maintainability of it, for example, a change that affects the jobs has to be repeated for each of them, with the difficulties associated with this. For example,  I noticed that some of these jobs were using the same GitHub Actions but with different versions. To solve this I used the GitHub composite Actions https://docs.github.com/en/actions/creating-actions/creating-a-composite-action, defining in a separate file the template of these jobs (in the action.yaml file under the "runTestsTaggedAs" folder) that can be "specialized" with the proper tag of cucumber tests to run. To this end, the job definitions inside the Kapua-ci.yaml file re-use this template passing the different tests tag. 

2. Execution of cucumber tests in the proper maven projects
In a past issue related to tests for Kapua, I noticed that cucumber tests reside in a very small set of folders (or, in other words, maven projects). I noticed that, if I ran tests with a naive "mvn verify <test arguments>" a lot of time was spent unnecessarily in the "traversal" of a lot of maven projects not containing tests at all. I wanted to solve this waste of time by launching the maven tests execution only in the projects containing the tests. So, instead of the naive "mvn verify..." I used something like "mvn verify -pl _list of projects containing cucumber tests_". This, obviously, works assuming that maven artifacts and docker images needed by those tests are present in the environment. To retrieve the project containing tests I used the command "grep -l -r --include \*.feature ." 

3. Removal of jobs executing tests no more present in the code-base
I noticed that the jobs _triggerServiceIntegration_ , _triggerServiceIntegrationbase_ , _triggerService_ were trying to launch tests that are no longer present in the code base. Discussing with @Coduz we concluded that probably they may have been moved to the job tests suites, in any case, I will conduct an investigation to try to understand where they have been moved (or lost). I removed those 3 jobs considering that they were using machine time uselessly. 

4. Maven Artifacts Caching
Before this PR, there was an attempt to cache artifacts, exploiting the GitHub Action "actions/cache" but it was incomplete and actually not used. This Action was doing a save-restore for the cache but, despite this, each different job was executing a full build and in this way not re-using the cached artifacts. Other than this, the _key_ parameter used to configure the caching mechanism (precisely _key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}_ ) did not limit the scope of the cache to the specific workflow run but rather to the changes made in the root pom file. The cause of this was that, to propose an example, one could have done a series of commits to the same PR, without modification to the pom file BUT with modifications in the code, and the CI process for each of them would retrieve the same artifacts cache, without noticing changes in the code. To this end, The _key_ parameter has been changed to scope the cache as correctly needed.
This caching allows re-using artifacts in each job. Therefore, a full build is no longer necessary before running the cucumber tests. Rather, it is sufficient to build the docker images only.


The caching of docker images would be another good idea to prevent image re-building for each job. This task presents other difficulties and trade-offs and will be addressed in a separate PR.
 

**Any side note on the changes made**
The execution of tests with the specification of fixed set of maven projects creates the necessity of future modification of the set, if other tests are added in different maven projects. This is the trade-off for the speed-up obtained with the point 2 of the presented list. I think that this won't be a big concern if we consider the fact that the same is, at the moment, also true for the cucumber tags used in the different jobs (one could add tests with different tags and has to remember to add the specific job for it). In other words, a dependency on the kapua-ci file is already present for test addition and removal. 


FINAL NOTES ON THE CORRECTNESS OF THIS PR
I considered from the start the requirement to maintain here the same tests that are run in the old CI process. In this regard, I verified manually that the new CI executes the same tests as the old one (and, also, the tests that are actually present in the code base). I report here the numbers of scenarios for each cucumber tag that I found in the code base and that are executed with this new CI

```
@brokerAcl: 59
@test-tag: 7 
@broker:  25
@device: 7
@devicemanagement: 22
@connection: 11 
@datastore: 56
@user : 30
@userIntegrationBase: 56
@userIntegration : 38
@security: 152 
@jobs,scheduler: 85
@jobsIntegrationBase: 82
@jobsIntegration: 8
@account,translator: 131
@jobEngineStepDefinitions: 5
@jobEngineStartOfflineDevice: 30
@jobEngineStartOnlineDevice: 25
@jobEngineRestartOfflineDevice: 30
@jobEngineRestartOnlineDevice: 14
@jobEngineRestartOnlineDeviceSecondPart: 12
@jobEngineServiceStop: 12
@role,group: 86
@deviceRegistry: 333
@endpoint: 66
```
