### PR TITLE
Fix URL regex marking as invalid legal URL

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
@@ -16,7 +16,6 @@ import com.extjs.gxt.ui.client.widget.form.Field;
 import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.extjs.gxt.ui.client.widget.form.Validator;
 import com.google.gwt.core.client.GWT;
-
 import org.eclipse.kapua.app.console.module.api.client.messages.ValidationMessages;
 
 import java.util.MissingResourceException;
@@ -70,7 +69,7 @@ public class TextFieldValidator implements Validator {
         ALPHANUMERIC("alphanumeric", "^[a-zA-Z0-9_]+$"),
         NUMERIC("numeric", "^[+0-9.]+$"),
         PACKAGE_VERSION("package_version", "^[a-zA-Z0-9.\\-\\_]*$"),
-        URL("url", "(http(s)?:\\/\\/.)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)");
+        URL("url", "^(https?:\\/\\/)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=//]{1,256}\\.[a-zA-Z0-9()//]{2,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$");
 
         private String name;
         private String regex;

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.management.packages.internal;
 
 import com.google.common.base.MoreObjects;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.model.id.IdGenerator;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
@@ -50,6 +51,7 @@ import org.eclipse.kapua.service.device.management.packages.model.uninstall.Devi
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 
 import javax.inject.Singleton;
+import java.net.MalformedURLException;
 import java.util.Date;
 
 /**
@@ -142,6 +144,12 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         //
         // Check Access
         AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
+
+        try {
+            packageDownloadRequest.getUri().toURL();
+        } catch (MalformedURLException | IllegalArgumentException ignored) {
+            throw new KapuaIllegalArgumentException("packageDownloadRequest.uri", packageDownloadRequest.getUri().toString());
+        }
 
         //
         // Generate requestId


### PR DESCRIPTION
**Brief description of the PR.**
Some valid URLs was considered illegal, for example the following: `http://172.16.0.2:1234/static/com.eurotech.opcua.driver_1.1.1.dp`.
This PR is to fix this issue.

**Related Issue**
This PR fixes #3788.

**Description of the solution adopted**
Change the regex in order to include more URLs.

**Any side note on the changes made**
Added also the validation check on the backend side, in order to avoid console parameter validation bypass.