### PR TITLE
FIX - fixed missing properties on device Event openAPI.yaml schema definition

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent.yaml
@@ -25,6 +25,7 @@ components:
   schemas:
     deviceEvent:
       allOf:
+        - $ref: '../openapi.yaml#/components/schemas/kapuaEntity'
         - type: object
           properties:
             deviceId:


### PR DESCRIPTION
on the deviceEvent entity schema definition, some parameters are missing. External code dependant on this definition could be broken as a result. The schema definition has to be coherent with the code