### PR TITLE
feat(deployment): Add options to enable JMX on containers

### DIFF
--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -46,7 +46,8 @@ ENV JAVA_OPTS "-Dapi.cors.origins.allowed=\${API_CORS_ORIGINS_ALLOWED} \
                -Djob.engine.client.auth.mode=access_token \
                -Dcipher.key=\${CIPHER_KEY} \
                -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
-               \${JETTY_DEBUG_OPTS}"
+               \${JETTY_DEBUG_OPTS} \
+               \${JETTY_JMX_OPTS}"
 
 USER 0
 

--- a/assembly/broker-artemis/configurations/artemis.profile
+++ b/assembly/broker-artemis/configurations/artemis.profile
@@ -53,7 +53,7 @@ fi
 # JAVA_ARGS="$JAVA_ARGS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${ARTEMIS_OOME_DUMP}"
 
 # Debug args: Uncomment to enable debug
-DEBUG_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
+# DEBUG_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
 # Debug args: Uncomment for async profiler
-#DEBUG_ARGS="-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints"
+# DEBUG_ARGS="-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints"

--- a/assembly/console/docker/Dockerfile
+++ b/assembly/console/docker/Dockerfile
@@ -43,7 +43,8 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Djob.engine.client.auth.mode=access_token \
                -Dcipher.key=\${CIPHER_KEY} \
                -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
-               \${JETTY_DEBUG_OPTS}"
+               \${JETTY_DEBUG_OPTS} \
+               \${JETTY_JMX_OPTS}"
 
 USER 0
 

--- a/assembly/consumer/lifecycle/docker/Dockerfile
+++ b/assembly/consumer/lifecycle/docker/Dockerfile
@@ -28,19 +28,19 @@ ENV SQL_DB_PORT 3306
 ENV SERVICE_BROKER_ADDR failover:(amqp://events-broker:5672)?jms.sendTimeout=1000
 ENV JOB_ENGINE_BASE_ADDR http://job-engine:8080/v1
 
-ENV JAVA_OPTS -Dcommons.db.schema.update=true \
+ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
               -Dcommons.db.connection.host=\${SQL_DB_ADDR} \
               -Dcommons.db.connection.port=\${SQL_DB_PORT} \
               -Dcommons.eventbus.url=\${SERVICE_BROKER_ADDR} \
               -Dbroker.host=\${BROKER_HOST} \
               -Dbroker.port=\${BROKER_PORT} \
-              -Dcommons.eventbus.url=${SERVICE_BROKER_ADDR} \
+              -Dcommons.eventbus.url=\${SERVICE_BROKER_ADDR} \
               -Dconsumer.jaxb_context_class_name=org.eclipse.kapua.consumer.lifecycle.LifecycleJAXBContextProvider \
               -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR} \
               -Dcertificate.jwt.private.key=file:///etc/opt/kapua/key.pk8 \
               -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem \
               -Dcipher.key=\${CIPHER_KEY} \
-              -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY}
+              -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY}"
 
 EXPOSE 8080
 

--- a/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
+++ b/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
@@ -13,4 +13,4 @@
 
 JAVA_OPTS="${JAVA_OPTS} --add-opens java.base/java.lang=ALL-UNNAMED"
 
-java ${JAVA_OPTS} ${DEBUG_OPTIONS} -jar kapua-consumer-lifecycle-2.0.0-SNAPSHOT-app.jar
+java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-lifecycle-2.0.0-SNAPSHOT-app.jar

--- a/assembly/consumer/telemetry/docker/Dockerfile
+++ b/assembly/consumer/telemetry/docker/Dockerfile
@@ -30,7 +30,7 @@ ENV SQL_DB_PORT 3306
 
 ENV SERVICE_BROKER_ADDR failover:(amqp://events-broker:5672)?jms.sendTimeout=1000
 
-ENV JAVA_OPTS -Dcommons.db.schema.update=true \
+ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
               -Dcommons.db.connection.host=\${SQL_DB_ADDR} \
               -Dcommons.db.connection.port=\${SQL_DB_PORT} \
               -Dcommons.eventbus.url=\${SERVICE_BROKER_ADDR} \
@@ -40,11 +40,11 @@ ENV JAVA_OPTS -Dcommons.db.schema.update=true \
               -Ddatastore.client.class=\${DATASTORE_CLIENT} \
               -Dbroker.host=\${BROKER_HOST} \
               -Dbroker.port=\${BROKER_PORT} \
-              -Dcommons.eventbus.url="${SERVICE_BROKER_ADDR}" \
+              -Dcommons.eventbus.url=\${SERVICE_BROKER_ADDR} \
               -Dcertificate.jwt.private.key=file:///etc/opt/kapua/key.pk8 \
               -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem \
               -Dcipher.key=\${CIPHER_KEY} \
-              -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY}
+              -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY}"
 
 EXPOSE 8080
 

--- a/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
+++ b/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
@@ -13,4 +13,4 @@
 
 JAVA_OPTS="${JAVA_OPTS} --add-opens java.base/java.lang=ALL-UNNAMED"
 
-java ${JAVA_OPTS} ${DEBUG_OPTIONS} -jar kapua-consumer-telemetry-2.0.0-SNAPSHOT-app.jar
+java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-telemetry-2.0.0-SNAPSHOT-app.jar

--- a/assembly/job-engine/docker/Dockerfile
+++ b/assembly/job-engine/docker/Dockerfile
@@ -40,6 +40,7 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Djavax.xml.bind.JAXBContextFactory=org.eclipse.persistence.jaxb.JAXBContextFactory \
                -Dcipher.key=\${CIPHER_KEY} \
                -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
+               \${JETTY_JMX_OPTS} \
                \${JETTY_DEBUG_OPTS}"
 
 USER 0

--- a/assembly/service/authentication/entrypoint/run-service-authentication
+++ b/assembly/service/authentication/entrypoint/run-service-authentication
@@ -11,4 +11,4 @@
 #        Eurotech
 ################################################################################
 
-java ${JAVA_OPTS} ${DEBUG_OPTIONS} -jar kapua-service-authentication-2.0.0-SNAPSHOT-app.jar
+java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-service-authentication-2.0.0-SNAPSHOT-app.jar

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -138,14 +138,40 @@ Example:
 
 Following ports will be opened
 
-| Application/Service | Remote JVM debug endpoint |
-|---------------------|---------------------------|
-| Message Broker      | localhost:5005            |
-| Consumer Lifecycle  | localhost:8002            |
-| Consumer Telemetry  | localhost:8001            |
-| Admin WEB Console   | localhost:5007            |
-| REST API endpoint   | localhost:5006            |
-| Job Engine          | localhost:5008            |
+| Application/Service    | Remote JVM debug endpoint |
+|------------------------|---------------------------|
+| Message Broker         | localhost:5005            |
+| Consumer Lifecycle     | localhost:8002            |
+| Consumer Telemetry     | localhost:8001            |
+| Service Authentication | localhost:8004            |
+| Admin WEB Console      | localhost:5007            |
+| REST API endpoint      | localhost:5006            |
+| Job Engine             | localhost:5008            |
+
+---
+
+### Enabling JMX mode
+
+Containers can be accessed via JMX. For example, you can use it to analyse the JVM using jConsole. 
+To enable it, provide the `--jmx` option.
+
+Example:
+
+```bash
+./docker-deploy.sh --jmx
+```
+
+Following ports will be opened
+
+| Application/Service    | Remote JVM debug endpoint |
+|------------------------|---------------------------|
+| Message Broker         | localhost:9875            |
+| Consumer Lifecycle     | localhost:9876            |
+| Consumer Telemetry     | localhost:9877            |
+| Service Authentication | localhost:9880            |
+| REST API endpoint      | localhost:9881            |
+| Admin WEB Console      | localhost:9882            |
+| Job Engine             | localhost:9883            |
 
 ---
 

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -53,7 +53,6 @@ services:
     container_name: service-auth
     ports:
       - 8100:8080
-      - 8011:8001
     depends_on:
       - db
       - events-broker

--- a/deployment/docker/compose/extras/docker-compose.broker-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.broker-debug.yml
@@ -5,4 +5,4 @@ services:
     ports:
       - ${KAPUA_BROKER_DEBUG_PORT:-5005}:5005
     environment:
-      - ACTIVEMQ_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=${KAPUA_BROKER_DEBUG_SUSPEND:-n},address=*:5005
+      - DEBUG_ARGS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=${KAPUA_BROKER_DEBUG_SUSPEND:-n},address=*:5005

--- a/deployment/docker/compose/extras/docker-compose.broker-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.broker-jmx.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+  message-broker:
+    ports:
+      - ${KAPUA_BROKER_JMX_PORT:-9875}:9875
+    environment:
+      - JAVA_ARGS_APPEND=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9875 -Dcom.sun.management.jmxremote.rmi.port=9875 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0

--- a/deployment/docker/compose/extras/docker-compose.console-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.console-jmx.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+  kapua-console:
+    ports:
+      - ${KAPUA_CONSOLE_JMX_PORT:-9882}:${KAPUA_CONSOLE_JMX_PORT:-9882}
+    environment:
+      - JETTY_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${KAPUA_CONSOLE_JMX_PORT:-9882} -Dcom.sun.management.jmxremote.rmi.port=${KAPUA_CONSOLE_JMX_PORT:-9882} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0

--- a/deployment/docker/compose/extras/docker-compose.consumer-lifecycle-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.consumer-lifecycle-debug.yml
@@ -5,4 +5,4 @@ services:
     ports:
       - ${KAPUA_CONSUMER_LIFECYCLE_DEBUG_PORT:-8002}:8001
     environment:
-      - DEBUG_OPTIONS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=${KAPUA_CONSUMER_LIFECYCLE_DEBUG_SUSPEND:-n},address=*:8001
+      - DEBUG_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=${KAPUA_CONSUMER_LIFECYCLE_DEBUG_SUSPEND:-n},address=*:8001

--- a/deployment/docker/compose/extras/docker-compose.consumer-lifecycle-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.consumer-lifecycle-jmx.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+  consumer-lifecycle:
+    ports:
+      - ${KAPUA_CONSUMER_LIFECYCLE_JMX_PORT:-9876}:${KAPUA_CONSUMER_LIFECYCLE_JMX_PORT:-9876}
+    environment:
+      - JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${KAPUA_CONSUMER_LIFECYCLE_JMX_PORT:-9876} -Dcom.sun.management.jmxremote.rmi.port=${KAPUA_CONSUMER_LIFECYCLE_JMX_PORT:-9876} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0

--- a/deployment/docker/compose/extras/docker-compose.consumer-telemetry-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.consumer-telemetry-debug.yml
@@ -5,4 +5,4 @@ services:
     ports:
       - ${KAPUA_CONSUMER_TELEMETRY_DEBUG_PORT:-8001}:8001
     environment:
-      - DEBUG_OPTIONS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=${KAPUA_CONSUMER_TELEMETRY_DEBUG_SUSPEND:-n},address=*:8001
+      - DEBUG_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=${KAPUA_CONSUMER_TELEMETRY_DEBUG_SUSPEND:-n},address=*:8001

--- a/deployment/docker/compose/extras/docker-compose.consumer-telemetry-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.consumer-telemetry-jmx.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+  consumer-telemetry:
+    ports:
+      - ${KAPUA_CONSUMER_TELEMETRY_JMX_PORT:-9877}:${KAPUA_CONSUMER_TELEMETRY_JMX_PORT:-9877}
+    environment:
+      - JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${KAPUA_CONSUMER_TELEMETRY_JMX_PORT:-9877} -Dcom.sun.management.jmxremote.rmi.port=${KAPUA_CONSUMER_TELEMETRY_JMX_PORT:-9877} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0

--- a/deployment/docker/compose/extras/docker-compose.job-engine-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.job-engine-debug.yml
@@ -4,6 +4,5 @@ services:
   job-engine:
     ports:
       - ${KAPUA_JOB_ENGINE_DEBUG_PORT:-5008}:5005
-      - ${KAPUA_JOB_ENGINE_DEBUG_PORT:-5018}:5018
     environment:
       - JETTY_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=${KAPUA_JOB_ENGINE_DEBUG_SUSPEND:-n},address=*:5005

--- a/deployment/docker/compose/extras/docker-compose.job-engine-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.job-engine-debug.yml
@@ -4,5 +4,6 @@ services:
   job-engine:
     ports:
       - ${KAPUA_JOB_ENGINE_DEBUG_PORT:-5008}:5005
+      - ${KAPUA_JOB_ENGINE_DEBUG_PORT:-5018}:5018
     environment:
       - JETTY_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=${KAPUA_JOB_ENGINE_DEBUG_SUSPEND:-n},address=*:5005

--- a/deployment/docker/compose/extras/docker-compose.job-engine-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.job-engine-jmx.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+  job-engine:
+    ports:
+      - ${KAPUA_JOB_ENGINE_DEBUG_PORT:-9883}:${KAPUA_JOB_ENGINE_DEBUG_PORT:-9883}
+    environment:
+      - JETTY_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${KAPUA_JOB_ENGINE_DEBUG_PORT:-9883} -Dcom.sun.management.jmxremote.rmi.port=${KAPUA_JOB_ENGINE_DEBUG_PORT:-9883} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0

--- a/deployment/docker/compose/extras/docker-compose.rest-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.rest-jmx.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+  kapua-api:
+    ports:
+      - ${KAPUA_REST_JMX_PORT:-9881}:${KAPUA_REST_JMX_PORT:-9881}
+    environment:
+      - JETTY_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${KAPUA_REST_JMX_PORT:-9881} -Dcom.sun.management.jmxremote.rmi.port=${KAPUA_REST_JMX_PORT:-9881} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0

--- a/deployment/docker/compose/extras/docker-compose.service-authentication-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.service-authentication-debug.yml
@@ -5,4 +5,4 @@ services:
     ports:
       - ${KAPUA_SERVICE_AUTHENTICATION_DEBUG_PORT:-8004}:8001
     environment:
-      - DEBUG_OPTIONS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=${KAPUA_SERVICE_AUTHENTICATION_DEBUG_SUSPEND:-n},address=*:8001
+      - DEBUG_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=${KAPUA_SERVICE_AUTHENTICATION_DEBUG_SUSPEND:-n},address=*:8001

--- a/deployment/docker/compose/extras/docker-compose.service-authentication-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.service-authentication-jmx.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+  service-authentication:
+    ports:
+      - ${KAPUA_SERVICE_AUTHENTICATION_JMX_PORT:-9880}:${KAPUA_SERVICE_AUTHENTICATION_JMX_PORT:-9880}
+    environment:
+      - JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${KAPUA_SERVICE_AUTHENTICATION_JMX_PORT:-9880} -Dcom.sun.management.jmxremote.rmi.port=${KAPUA_SERVICE_AUTHENTICATION_JMX_PORT:-9880} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0

--- a/deployment/docker/unix/docker-deploy.sh
+++ b/deployment/docker/unix/docker-deploy.sh
@@ -37,14 +37,26 @@ docker_compose() {
       COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.rest-debug.yml")
     fi
 
-    # Dev Mode
+    # JMX Mode
     if [[ "$2" == true ]]; then
+      echo "JMX mode enabled!"
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.broker-jmx.yml")
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.console-jmx.yml")
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.consumer-lifecycle-jmx.yml")
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.consumer-telemetry-jmx.yml")
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.service-authentication-jmx.yml")
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.job-engine-jmx.yml")
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.rest-jmx.yml")
+    fi
+
+    # Dev Mode
+    if [[ "$3" == true ]]; then
       echo "Dev mode enabled!"
       COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.db-dev.yml")
     fi
 
     # SSO Mode
-    if [[ "$3" == true ]]; then
+    if [[ "$4" == true ]]; then
       echo "SSO enabled!"
       . "${SCRIPT_DIR}/sso/docker-sso-config.sh"
 
@@ -53,7 +65,7 @@ docker_compose() {
     fi
 
     # Swagger UI
-    if [[ "$4" == false ]]; then
+    if [[ "$5" == false ]]; then
       echo "Swagger disabled!"
     fi
     export KAPUA_SWAGGER_ENABLE=$4
@@ -62,12 +74,13 @@ docker_compose() {
 }
 
 print_usage_deploy() {
-    echo "Usage: $(basename "$0") [-h|--help] [--dev] [--debug] [--logs] [--sso] [--no-swagger]" >&2
+    echo "Usage: $(basename "$0") [-h|--help] [--dev] [--debug] [--jmx] [--logs] [--sso] [--no-swagger]" >&2
 }
 
 DEBUG_MODE=false
 DEV_MODE=false
 OPEN_LOGS=false
+JMX_MODE=false
 SSO_MODE=false
 SWAGGER=true
 for option in "$@"; do
@@ -84,6 +97,9 @@ for option in "$@"; do
       ;;
     --logs)
       OPEN_LOGS=true
+      ;;
+    --jmx)
+      JMX_MODE=true
       ;;
     --sso)
       SSO_MODE=true
@@ -104,7 +120,7 @@ done
 docker_common
 
 echo "Deploying Eclipse Kapua version $IMAGE_VERSION..."
-docker_compose ${DEBUG_MODE} ${DEV_MODE} ${SSO_MODE} ${SWAGGER} || {
+docker_compose ${DEBUG_MODE} ${JMX_MODE} ${DEV_MODE} ${SSO_MODE} ${SWAGGER} || {
     echo "Deploying Eclipse Kapua... ERROR!"
     exit 1
 }

--- a/deployment/docker/win/docker-deploy.ps1
+++ b/deployment/docker/win/docker-deploy.ps1
@@ -15,6 +15,7 @@
 Param(
     [switch]$dev = $false,
     [switch]$debug = $false,
+    [switch]$jmx = $false,
     [switch]$logs = $false
 )
 
@@ -42,6 +43,25 @@ If ($debug) {
     $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.job-engine-debug.yml)
     $compose_files+="-f"
     $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.rest-debug.yml)
+}
+
+# JMX Mode
+If ($jmx) {
+    Write-Host "JMX mode enabled!"
+    $compose_files+="-f"
+    $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.broker-jmx.yml)
+    $compose_files+="-f"
+    $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.console-jmx.yml)
+    $compose_files+="-f"
+    $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.consumer-lifecycle-jmx.yml)
+    $compose_files+="-f"
+    $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.consumer-telemetry-jmx.yml)
+    $compose_files+="-f"
+    $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.service-authentication-jmx.yml)
+    $compose_files+="-f"
+    $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.job-engine-jmx.yml)
+    $compose_files+="-f"
+    $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.rest-jmx.yml)
 }
 
 # Dev Mode

--- a/deployment/docker/win/docker-deploy.ps1
+++ b/deployment/docker/win/docker-deploy.ps1
@@ -40,6 +40,8 @@ If ($debug) {
     $compose_files+="-f"
     $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.consumer-telemetry-debug.yml)
     $compose_files+="-f"
+    $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.service-authentication-debug.yml)
+    $compose_files+="-f"
     $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.job-engine-debug.yml)
     $compose_files+="-f"
     $compose_files+=$(Join-Path $script_dir .. compose extras docker-compose.rest-debug.yml)

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -813,7 +813,7 @@ public class DockerSteps {
         envVars.add("BROKER_HOST=message-broker");
         envVars.add("CRYPTO_SECRET_KEY=kapuaTestsKey!!!");
         if (debug) {
-            envVars.add(String.format("DEBUG_OPTIONS=-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:%s", debugPort));
+            envVars.add(String.format("DEBUG_OPTS=-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:%s", debugPort));
         }
 
         return ContainerConfig.builder()


### PR DESCRIPTION
This PR adds the mapping of `JMX_OPTS` env variable to enable JMX on containers

**Related Issue**
_None_

**Description of the solution adopted**
Added mapping for env variable for containers to allow JMX connection.

- JMX_OPTS  for consumers and service authentication
- JETTY_JMX_OPTS for Console, Job Engine and REST API
- JAVA_ARGS_APPEND for Message Broker

Default port mappings are:

| Port | Component               |
|------|-------------------------|
| 9875 | Message Broker          |
| 9876 | Consumer Lifecycle      |
| 9877 | Consumer Telemetry      |
| 9880 | Service Authentication  |
| 9881 | Rest API                |
| 9882 | Console                 |
| 9883 | Job Engine              |

**Screenshots**
None

**Any side note on the changes made**
- `DEBUG_OPTIONS` has been renamed `DEBUG_OPTS` to be more uniform with other classic `OPTS` env variable (like `JAVA_OPTS`, `JETTY_DEBUG_OPTS`, `MAVEN_OPTS`)
- Added Service Authentication debug profile in Powershell scripts that was not added in https://github.com/eclipse/kapua/pull/3704