### PR TITLE
Fix OpenID configuration path

### DIFF
--- a/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/OpenIDUtils.java
+++ b/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/OpenIDUtils.java
@@ -129,9 +129,9 @@ public final class OpenIDUtils {
         }
         String openIdConfPath = issuer + "/" + openIDConfPathSuffix;
         try {
-            new URL(openIdConfPath);
-            return openIdConfPath;
-        } catch (MalformedURLException mue) {
+            URL normalizedURL = new URI(openIdConfPath).normalize().toURL();
+            return normalizedURL.toString();
+        } catch (MalformedURLException | URISyntaxException mue) {
             throw new OpenIDIllegalUriException("openIdConfPath", openIdConfPath);
         }
     }


### PR DESCRIPTION
Brief description of the PR.
The OpenIDUtils.java file hardcode the `/` character, but is' already present on `issuer`. To avoid double `/` characters or generating invalid URLs, the Java `.normalize()` function is used.

**Related Issue**
This PR fixes #3797.

**Description of the solution adopted**
Normalized the URL.
