### PR TITLE
Fix - Cache miss CI fall back

### DIFF
--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -18,10 +18,15 @@ runs:
         distribution: 'zulu'
         java-version: 11
     - name: Cache Maven repository
-      uses: actions/cache@v3
+      id: cacheMavenArtifacts
+      uses: actions/cache/restore@v3 #use restore action in order to skip post-action that saves cache
       with:
         path: ~/.m2/repository
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
+    - name: Maven artifacts creation #if for some reason there was a cache miss then create the maven artifacts
+      if: steps.cacheMavenArtifacts.outputs.cache-hit != 'true'
+      run: mvn -B ${BUILD_OPTS} -DskipTests clean install
+      shell: bash
     - name: Docker images creation
       if: ${{ inputs.needs-docker-images == 'true' }}
       run: mvn clean install -pl ${APP_PROJECTS} && mvn clean install -Pdocker --f assembly/pom.xml

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -19,13 +19,20 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-      - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
-        with:
-          path: ~/.m2/repository
-          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
+      - uses: actions/cache/save@v3 # Cache local Maven repository to reuse dependencies
+        with:
+          path: ~/.m2/repository
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
+      - name: Verify maven artifacts cache saving
+        uses: actions/cache/restore@v3 #use restore action just to verify if cache saving did not fail
+        with:
+          fail-on-cache-miss: true
+          lookup-only: true
+          path: ~/.m2/repository
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: bash <(curl -s https://codecov.io/bash)
   test-brokerAcl:
     needs: build


### PR DESCRIPTION
Brief description of the PR.
This PR introduces a fall-back strategy for cache-miss cases found in the CI process. 

**Related Issue**
I've noticed some rare occasions where the jobs, while retrieving the maven artifacts cache, get stuck and did not manage to retrieve it. I found what was the problem here https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout. Basically, sometimes the platform doesn't respond and the Cache gitAction fails to retrieve the cache; to this end, a time-out has been inserted in order to prevent a too-long restore phase. 

**Description of the solution adopted**
I've inserted a new step, in the test jobs, that verifies if the previous cache restore step concluded with a cache miss (when the above-mentioned time-out is reached there is a cache miss as stated in https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout) and in that case, the step builds the maven artifacts. To insert this fall-back strategy I used the _restore_ feature of the Cache gitAction (actions/cache/restore@v3) in order to prevent the cache saving in the post-run phase that is performed by the Cache gitAction. 

Additionally, by thinking that a similar fail could happen when the build job saves the cache, I improved that job in order to insert a failing of the workflow in the (rare) case where it doesn't manage to save the cache. I decided to do so because I thought that It would be more time-efficient to re-run the workflow if this unlucky event happens, and hope that the same failure doesn't happen, instead of wasting time for the rebuild of the artifacts in each test job. I never encountered an event like this in the workflows of eclipse/kapua that I have analyzed but I think it could be possible.
