### PR TITLE
Bumped `protobuf-java` version from 3.21.9 to 3.23.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <owasp-encoder.version>1.2.3</owasp-encoder.version>
         <opencsv.version>3.7</opencsv.version>
         <paho.version>1.2.1</paho.version>
-        <protobuf.version>3.21.9</protobuf.version>
+        <protobuf.version>3.23.2</protobuf.version>
         <qpid-jms-client.version>0.59.0</qpid-jms-client.version>
         <qpid-amqp-1-0-client-jms.version>0.32</qpid-amqp-1-0-client-jms.version>
         <qpid-proton.version>0.31.0</qpid-proton.version>


### PR DESCRIPTION
**Brief description of the PR**
This PR is to upgrade the `com.google.protobuf:protobuf-java` library from the current `3.21.9` to the most recent `3.23.2`.

**Related Issue**
This PR fixes #3802.

**Any side note on the changes made**
This PR is to merge after #3801, otherwise `Unsupported platform` error is thrown at compile time.