### PR TITLE
User/password login cache

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -341,6 +341,14 @@ public enum SystemSettingKey implements SettingKey {
      */
     CACHE_TTL("commons.cache.config.ttl"),
     /**
+     * Provide the Authentication Cache TTL
+     */
+    AUTHENTICATION_CACHE_TTL("commons.authentication-cache.config.ttl"),
+    /**
+     * Provide the Authentication Cache Size
+     */
+    AUTHENTICATION_CACHE_SIZE("commons.authentication-cache.config.size"),
+    /**
      * Provide the JCache Expiry Policy. Allowed values: MODIFIED, TOUCHED
      */
     JCACHE_EXPIRY_POLICY("commons.cache.config.expiryPolicy");

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -120,6 +120,10 @@ commons.cache.provider.classname=org.eclipse.kapua.commons.service.internal.cach
 #
 commons.cache.local.tmetadata.maxsize=100
 
+commons.authentication-cache.config.size=1000
+#authentication cache ttl (in seconds)
+commons.authentication-cache.config.ttl=60
+
 deployment.name=default-deployment
 
 cluster.name=default-cluster

--- a/qa/integration/src/test/resources/features/authentication/UserCredentialServiceUnitTests.feature
+++ b/qa/integration/src/test/resources/features/authentication/UserCredentialServiceUnitTests.feature
@@ -21,6 +21,14 @@ Feature: User Credential
     Given Init Jaxb Context
     And Init Security Context
 
+  Scenario: test password caching performances
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create default test-user
+    And I create a new PASSWORD credential for the default user with password "Welcome12345!"
+    And I logout
+    When I do a login loop of 100 iterations with user "test-user" and password "Welcome12345!"
+    Then No exception was thrown
+
   Scenario: Change the PASSWORD credential, providing a correct current password, with a new password meeting the standard requirements.
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I create default test-user

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
@@ -34,6 +34,7 @@ public enum KapuaAuthenticationSettingKeys implements SettingKey {
 
     AUTHENTICATION_CREDENTIAL_USERPASS_CACHE_ENABLE("authentication.credential.userpass.cache.enabled"), //
     AUTHENTICATION_CREDENTIAL_USERPASS_CACHE_CACHE_TTL("authentication.credential.userpass.cache.ttl"), //
+    AUTHENTICATION_CREDENTIAL_USERPASS_CACHE_CACHE_SIZE("authentication.credential.userpass.cache.size"), //
     AUTHENTICATION_CREDENTIAL_USERPASS_PASSWORD_MINLENGTH("authentication.credential.userpass.password.minlength"), //
 
     AUTHENTICATION_CREDENTIAL_AUDIENCE_ALLOWED("authentication.credential.jwt.audience.allowed"), //

--- a/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
@@ -24,6 +24,7 @@ authentication.session.jwt.certificate=
 
 authentication.credential.userpass.cache.enabled=true
 authentication.credential.userpass.cache.ttl=300000
+authentication.credential.userpass.cache.size=1000
 authentication.credential.userpass.password.minlength=12
 
 authentication.credential.jwt.audience.allowed=console


### PR DESCRIPTION
Brief description of the PR.
This pr enable the bcrypt caching for user/password authentication. This caching will have performance impact only when multiple login attempts using the same credentials are performed in a short time

**Related Issue**
none

**Description of the solution adopted**
Used local cache to store password and hash.

**Screenshots**
none

**Any side note on the changes made**
none
