### PR TITLE
Fix - Inserted device package fields limits 

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/PackageInstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/PackageInstallDialog.java
@@ -116,7 +116,7 @@ public class PackageInstallDialog extends TabbedDialog {
             packageInfoForm.add(dpInfoText);
 
             dpURIField = new KapuaTextField<String>();
-            dpURIField.setMaxLength(125);
+            dpURIField.setMaxLength(2048);
             dpURIField.setName("dpUri");
             dpURIField.setAllowBlank(false);
             dpURIField.setValidator(new TextFieldValidator(dpURIField, FieldType.URL));
@@ -125,7 +125,7 @@ public class PackageInstallDialog extends TabbedDialog {
             packageInfoForm.add(dpURIField, formData);
 
             dpNameField = new KapuaTextField<String>();
-            dpNameField.setMaxLength(125);
+            dpNameField.setMaxLength(256);
             dpNameField.setName("dpName");
             dpNameField.setAllowBlank(false);
             dpNameField.setFieldLabel("* " + DEVICE_MSGS.packageInstallDpDialogName());
@@ -133,7 +133,7 @@ public class PackageInstallDialog extends TabbedDialog {
             packageInfoForm.add(dpNameField, formData);
 
             dpVersionField = new KapuaTextField<String>();
-            dpVersionField.setMaxLength(125);
+            dpVersionField.setMaxLength(256);
             dpVersionField.setName("dpVersion");
             dpVersionField.setValidator(new TextFieldValidator(dpVersionField, FieldType.PACKAGE_VERSION));
             dpVersionField.setAllowBlank(false);

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -151,6 +151,8 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
             throw new KapuaIllegalArgumentException("packageDownloadRequest.uri", packageDownloadRequest.getUri().toString());
         }
 
+        verifyOverflowPackageFields(packageDownloadRequest);
+
         //
         // Generate requestId
         KapuaId operationId = new KapuaEid(IdGenerator.generate());
@@ -574,4 +576,25 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         // Check response
         return checkResponseAcceptedOrThrowError(responseMessage, () -> responseMessage.getPayload().getDevicePackageUninstallOperation());
     }
+
+    private void verifyOverflowPackageFields(DevicePackageDownloadRequest packageDownloadRequest) throws KapuaIllegalArgumentException {
+        int uriLength = packageDownloadRequest.getUri().toString().length();
+        int nameLength = packageDownloadRequest.getName().length();
+        int versionLength = packageDownloadRequest.getVersion().length();
+
+        if (uriLength > 2048) {
+            throw new KapuaIllegalArgumentException("packageDownloadRequest.uri", packageDownloadRequest.getUri().toString());
+        }
+
+        if (nameLength > 256) {
+            throw new KapuaIllegalArgumentException("packageDownloadRequest.name", packageDownloadRequest.getName().toString());
+        }
+
+        if (versionLength > 256) {
+            throw new KapuaIllegalArgumentException("packageDownloadRequest.version", packageDownloadRequest.getVersion().toString());
+        }
+
+    }
+
+
 }

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -141,17 +141,16 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         ArgumentValidator.notNull(packageDownloadRequest.getVersion(), "packageDownloadRequest.version");
         ArgumentValidator.notNull(packageDownloadOptions, "packageDownloadOptions");
 
-        //
-        // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
-
         try {
             packageDownloadRequest.getUri().toURL();
         } catch (MalformedURLException | IllegalArgumentException ignored) {
             throw new KapuaIllegalArgumentException("packageDownloadRequest.uri", packageDownloadRequest.getUri().toString());
         }
-
         verifyOverflowPackageFields(packageDownloadRequest);
+
+        //
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Generate requestId
@@ -578,22 +577,9 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
     }
 
     private void verifyOverflowPackageFields(DevicePackageDownloadRequest packageDownloadRequest) throws KapuaIllegalArgumentException {
-        int uriLength = packageDownloadRequest.getUri().toString().length();
-        int nameLength = packageDownloadRequest.getName().length();
-        int versionLength = packageDownloadRequest.getVersion().length();
-
-        if (uriLength > 2048) {
-            throw new KapuaIllegalArgumentException("packageDownloadRequest.uri", packageDownloadRequest.getUri().toString());
-        }
-
-        if (nameLength > 256) {
-            throw new KapuaIllegalArgumentException("packageDownloadRequest.name", packageDownloadRequest.getName().toString());
-        }
-
-        if (versionLength > 256) {
-            throw new KapuaIllegalArgumentException("packageDownloadRequest.version", packageDownloadRequest.getVersion().toString());
-        }
-
+        ArgumentValidator.lengthRange(packageDownloadRequest.getUri().toString(), null, 2048, "packageDownloadRequest.uri");
+        ArgumentValidator.lengthRange(packageDownloadRequest.getName(), null, 256, "packageDownloadRequest.name");
+        ArgumentValidator.lengthRange(packageDownloadRequest.getVersion(), null, 256, "packageDownloadRequest.version");
     }
 
 


### PR DESCRIPTION
This PR adds limits for some fields used in the device management packages service. In this way, a reasonable upper-bound is set in order to allow clients to set the needed fields and discourage a buffer overflow attack. 