### PR TITLE
Add maximum length to `configuration put` step definition

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -340,6 +340,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
 
                 textArea.setData(PROPERTY_TYPE, property.getPropertyType());
                 textArea.setData(PROPERTY_NAME, property.getPropertyName());
+                textArea.setMaxLength(65535);
                 jobStepPropertiesPanel.add(textArea);
 
                 if (property.getExampleValue() != null) {

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -93,6 +93,11 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
         ArgumentValidator.validateEntityName(jobStepCreator.getName(), "jobStepCreator.name");
         ArgumentValidator.notNull(jobStepCreator.getJobStepDefinitionId(), "jobStepCreator.stepDefinitionId");
 
+        for (JobStepProperty jobStepProperty : jobStepCreator.getStepProperties()) {
+            Integer stepPropertyMaxLength = jobStepProperty.getMaxLength() != null ? jobStepProperty.getMaxLength() : 65535;
+            ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepProperty.getMinLength(), stepPropertyMaxLength, "stepProperties[]." + jobStepProperty.getName());
+        }
+
         if (jobStepCreator.getDescription() != null) {
             ArgumentValidator.numRange(jobStepCreator.getDescription().length(), 0, 8192, "jobStepCreator.description");
         }


### PR DESCRIPTION
**Brief description of the PR**
Due to the fact that the database column `property_value` [is of type](https://github.com/eclipse/kapua/blob/bad8d2946040de44e97aecfd51eca0a764cfd6f3/service/job/internal/src/main/resources/liquibase/0.3.0/job_step_properties.xml#L36) `TEXT`, a configuration cannot have more than 65535 characters.
This because the column type `TEXT` can hold data [up to about 64 Kilobytes size](https://stackoverflow.com/a/13932834/20088695).

This PR adds a validation in the frontend that permits to illegal requests to fail fast without even sending them to the backend.

**Related Issue**
This PR relates to #3469.

**Description of the solution adopted**
A proper maximum length is forced to the textarea.