### PR TITLE
FIX - introduction of sonarCloud scans for pullrequests coming from external forks

### DIFF
--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -1,4 +1,4 @@
-name: kapua-ci
+name: kapua ci
 on: [ push, pull_request ] # Triggers the workflow on push or pull request events
 
 env: #the last 2 env variables defines respectively the maven projects were cucumber tests resides and maven projects were consumers applications needed for docker images building resides.
@@ -26,15 +26,6 @@ jobs:
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
-      - name: Save PR number to file for the sonarCloud scan
-        if: github.event_name == 'pull_request'
-        run: echo ${{ github.event.number }} > PR_NUMBER.txt
-      - name: Archive PR number
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
-        with:
-          name: PR_NUMBER
-          path: PR_NUMBER.txt
       - run: bash <(curl -s https://codecov.io/bash)
   test-brokerAcl:
     needs: build

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -1,4 +1,4 @@
-name: Kapua CI
+name: kapua-ci
 on: [ push, pull_request ] # Triggers the workflow on push or pull request events
 
 env: #the last 2 env variables defines respectively the maven projects were cucumber tests resides and maven projects were consumers applications needed for docker images building resides.
@@ -26,6 +26,15 @@ jobs:
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
+      - name: Save PR number to file for the sonarCloud scan
+        if: github.event_name == 'pull_request'
+        run: echo ${{ github.event.number }} > PR_NUMBER.txt
+      - name: Archive PR number
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: PR_NUMBER
+          path: PR_NUMBER.txt
       - run: bash <(curl -s https://codecov.io/bash)
   test-brokerAcl:
     needs: build

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -1,4 +1,4 @@
-name: kapua ci
+name: Kapua CI
 on: [ push, pull_request ] # Triggers the workflow on push or pull request events
 
 env: #the last 2 env variables defines respectively the maven projects were cucumber tests resides and maven projects were consumers applications needed for docker images building resides.

--- a/.github/workflows/prNumberUploader.yaml
+++ b/.github/workflows/prNumberUploader.yaml
@@ -1,0 +1,19 @@
+name: pr-number-uploader
+on: [pull_request] # Triggers the workflow on pull request events
+
+#this workflow is used for the sonarCloud scan.
+#It saves into an artifact the pull request number.
+#In this way, then, the sonarCloud workflow (which is executed externally with respect to the context of the pr) retrieves it and performs the scan
+
+jobs:
+  uploader:
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      steps:
+      - name: Save PR number to file for the sonarCloud scan
+        run: echo ${{ github.event.number }} > PR_NUMBER.txt
+      - name: Archive PR number
+        uses: actions/upload-artifact@v3
+        with:
+          name: PR_NUMBER
+          path: PR_NUMBER.txt

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -1,34 +1,62 @@
-name: SonarCloud
-on:
-  push:
-    branches:
-      - 'develop'
-      - 'release-**'
-  pull_request:
-    types: [opened, synchronize, reopened]
+name: Sonar
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+on:
+  workflow_run:
+    workflows: [kapua-ci]
+    types: [completed]
 
 jobs:
-  scan:
+  sonar:
     name: Scan code with sonarCould
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Download PR number artifact
+        uses: dawidd6/action-download-artifact@v2
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+          workflow: kapua-ci.yaml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: PR_NUMBER
+      - name: Read PR_NUMBER.txt
+        id: pr_number
+        uses: juliangruber/read-file-action@v1
         with:
-          java-version: 11
+          path: ./PR_NUMBER.txt
+      - name: Request GitHub API for PR data
+        uses: octokit/request-action@v2.x
+        id: get_pr_data
+        with:
+          route: GET /repos/{full_name}/pulls/{number}
+          number: ${{ steps.pr_number.outputs.content }}
+          full_name: ${{ github.event.repository.full_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout into the pr's branch
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Fetch base branch from upstream #step needed to calculate the "new lines of code metric" for the scan. Basically, the idea is to synch. with the base branch on the upstream because the fork could be not synched with it
+        run: |
+          git remote add upstream ${{ github.event.repository.clone_url }}
+          git fetch upstream
+          git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+          git checkout ${{ github.event.workflow_run.head_branch }}
+          git clean -ffdx && git reset --hard HEAD
+      - uses: actions/setup-java@v3
+        with:
           distribution: 'zulu'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: SonarCloud scan
-        run: mvn -B compile org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=org.eclipse_kapua -Dsonar.organization=eclipse
+          java-version: 11
+      - name: SonarCloud Scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B compile org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          -Dsonar.projectKey=org.eclipse_kapua
+          -Dsonar.organization=eclipse
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+          -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }}
+          -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
+          -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -2,19 +2,19 @@ name: Sonar
 
 on:
   workflow_run:
-    workflows: [kapua-ci]
+    workflows: [pr-number-uploader]
     types: [completed]
 
 jobs:
   sonar:
     name: Scan code with sonarCould
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download PR number artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: kapua-ci.yaml
+          workflow: prNumberUploader.yaml
           run_id: ${{ github.event.workflow_run.id }}
           name: PR_NUMBER
       - name: Read PR_NUMBER.txt


### PR DESCRIPTION
This PR changes both the Kapua-ci and sonarCloud workflows in order to allow sonarCloud scans for pull-requests opened from different forks. In fact, for those PRs, there was a problem reading the SONAR_TOKEN secret configured inside this repo and this PR fixes this, implementing a solution proposed here: https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/32.

**Description of the solution adopted**
The idea is to leverage the GitHub actions Workflow_run event https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run. Basically, With this construct, it's possible to launch a workflow triggered by another one... considering that the triggered workflow resides in the default branch, it can read secrets, and here comes the solution to the before-mentioned problem. Considering that this triggered workflow is not "born" from the opened PR it doesn't have the commits of the PR, for this reason, the data from the PR (practically, the code) must be retrieved using other techniques. 

**How I tested this fix**
I tested this solution on my fork. First of all, I inserted in my develop branch the workflows here modified. Then, asking a contributor to open an external PR from his fork and seeing that his commits on the PR were triggering this sonarCloud scan, I concluded that the solution was working and that similar behavior will be expected for the eclipse/kapua repo and external forks.

**Any side note on the changes made**
for now, the scan works only for pull requests and is not working for push events on the default branch or release branches (as was before). This because I just would like to test the work done and the re-introduce this behavior
