### PR TITLE
Fix enable Swagger UI feature incorrectly bounded to the `--sso` parameter

### DIFF
--- a/deployment/docker/unix/docker-deploy.sh
+++ b/deployment/docker/unix/docker-deploy.sh
@@ -68,7 +68,7 @@ docker_compose() {
     if [[ "$5" == false ]]; then
       echo "Swagger disabled!"
     fi
-    export KAPUA_SWAGGER_ENABLE=$4
+    export KAPUA_SWAGGER_ENABLE=$5
 
     docker-compose -f "${SCRIPT_DIR}/../compose/docker-compose.yml" "${COMPOSE_FILES[@]}" up -d
 }


### PR DESCRIPTION
**Brief description of the PR**
This PR bound the disable swagger feature to the correct parameter (`--no-swagger`).

**Related Issue**
This PR fixes #3818.