### PR TITLE
Fix Jenkins Javadoc build to do bad Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
         <kapua-client.maven.compiler.target>11</kapua-client.maven.compiler.target>
         <kapua-client.maven.toolchain.jdk.version>11</kapua-client.maven.toolchain.jdk.version>
 
+        <!-- Maven Javadoc Plugin compiler level -->
+        <!-- See: https://bugs.openjdk.org/browse/JDK-8212233 -->
+        <javadoc-plugin.maven.compiler.source>8</javadoc-plugin.maven.compiler.source>
+
         <!-- Console compiler level and JDK -->
         <!-- Console is limited to Java 1.6, so we are using JDK 8 -->
         <console.maven.compiler.source>1.6</console.maven.compiler.source>
@@ -239,6 +243,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven-javadoc-plugin.version}</version>
+                    <configuration>
+                        <source>${javadoc-plugin.maven.compiler.source}</source>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/model/ByteArrayParam.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/model/ByteArrayParam.java
@@ -18,7 +18,7 @@ import javax.validation.constraints.Null;
 import java.util.Base64;
 
 /**
- * This class is used to deserialize a {@link Byte}[] QueryParam from a {@link Base64} encoded {@link String} to a {@link Byte[]}
+ * This class is used to deserialize a {@link Byte}[] QueryParam from a {@link Base64} encoded {@link String} to a {@link Byte}[].
  *
  * @since 1.0.0
  */

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/model/ByteArrayParam.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/model/ByteArrayParam.java
@@ -14,11 +14,11 @@ package org.eclipse.kapua.app.api.core.model;
 
 import org.eclipse.kapua.model.xml.BinaryXmlAdapter;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.validation.constraints.Null;
 import java.util.Base64;
 
 /**
- * This class is used to deserialize a {@link Byte}[] {@link javax.ws.rs.QueryParam} from a {@link Base64} encoded {@link String} to a {@link Byte[]}
+ * This class is used to deserialize a {@link Byte}[] QueryParam from a {@link Base64} encoded {@link String} to a {@link Byte[]}
  *
  * @since 1.0.0
  */
@@ -29,10 +29,10 @@ public class ByteArrayParam extends BinaryXmlAdapter {
     /**
      * This converts a {@link Base64} encoded {@link String} to a {@link Byte}[]
      *
-     * @param base64encoded The {@link Base64} encoded  {@link String} representation of the {@link Byte}[].
+     * @param base64encoded The {@link Base64} encoded {@link String} representation of the {@link Byte}[].
      * @since 1.0.0
      */
-    public ByteArrayParam(@Nullable String base64encoded) {
+    public ByteArrayParam(@Null String base64encoded) {
         value = super.unmarshal(base64encoded);
     }
 


### PR DESCRIPTION
This PR fixes an issue in the Javadoc which makes the Jenkins build of the Javadoc fails

https://ci.eclipse.org/kapua/job/develop-javadoc/14

This is a build with the fix:

https://ci.eclipse.org/kapua/job/develop-javadoc/19/

**Related Issue**
_None_

**Description of the solution adopted**
Fixed bad javadoc and set javadoc source to 8 due to: https://bugs.openjdk.org/browse/JDK-8212233

**Screenshots**
_None_

**Any side note on the changes made**
_None_