### PR TITLE
Fix `GET /messages` api returns empty result if limit set over 10000

### DIFF
--- a/qa/integration/src/test/resources/kapua-datastore-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-setting.properties
@@ -29,3 +29,7 @@ datastore.delete.max_entries_on_delete=100
 datastore.cache.local.expire.after=60
 datastore.cache.local.size.maximum=1000
 datastore.cache.metadata.local.size.maximum=1000
+
+#
+#maximum value for limit parameter
+datastore.query.limit.max=10000

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -67,6 +67,7 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
     protected PermissionFactory permissionFactory;
 
     protected static final Integer MAX_ENTRIES_ON_DELETE = DatastoreSettings.getInstance().getInt(DatastoreSettingsKey.CONFIG_MAX_ENTRIES_ON_DELETE);
+    protected static final Integer MAX_LIMIT_VALUE = DatastoreSettings.getInstance().getInt(DatastoreSettingsKey.MAX_LIMIT_VALUE);
     protected final MessageStoreFacade messageStoreFacade;
 
     /**
@@ -181,6 +182,9 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
     public MessageListResult query(MessageQuery query)
             throws KapuaException {
         checkDataAccess(query.getScopeId(), Actions.read);
+        if (query.getLimit() != null) {
+            ArgumentValidator.numRange(query.getLimit(), 0, MAX_LIMIT_VALUE, "limit");
+        }
         try {
             return messageStoreFacade.query(query);
         } catch (Exception e) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
@@ -69,7 +69,11 @@ public enum DatastoreSettingsKey implements SettingKey {
     /**
      * Disables the entire Datastore feature
      */
-    DISABLE_DATASTORE("datastore.disable");
+    DISABLE_DATASTORE("datastore.disable"),
+    /**
+     * Elasticsearch limit maximum value
+     */
+    MAX_LIMIT_VALUE("datastore.query.limit.max");
 
     private String key;
 

--- a/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
@@ -32,3 +32,7 @@ datastore.cache.metadata.local.size.maximum=1000
 
 # Datastore index prefix
 datastore.index.prefix=
+
+#
+#maximum value for limit parameter
+datastore.query.limit.max=10000

--- a/service/datastore/test/src/test/resources/kapua-datastore-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-setting.properties
@@ -32,3 +32,7 @@ datastore.cache.metadata.local.size.maximum=1000
 
 # Allowed values are "week", "day" or "hour"; any other different value will be treated as "week".
 datastore.index.window=week
+
+#
+#maximum value for limit parameter
+datastore.query.limit.max=10000


### PR DESCRIPTION
**Brief description of the PR**
This PR introduces a check of the `limit` parameter in the `GET /messages` API. If the check fails, an appropriate error message is sent as response.

Consider a platform state with some stored messages.
Result of `GET /messages` with `limit = 10000` before the PR:
```
{
  "type": "storableListResult",
  "limitExceeded": false,
  "size": 0,
  "items": [],
  "totalCount": 0
}
```

Result of `GET /messages` with `limit = 10000` after the PR:
```
{
  "type": "illegalArgumentExceptionInfo",
  "httpErrorCode": 400,
  "message": "An illegal value was provided for the argument limit: Value over than allowed max value. Max value is 10000.",
  "kapuaErrorCode": "ILLEGAL_ARGUMENT",
  "argumentName": "limit",
  "argumentValue": "Value over than allowed max value. Max value is 10000"
}
```

**Related Issue**
This PR fixes #3822.

**Description of the solution adopted**
* Add the property `datastore.query.limit.max` which represents the maximum legal value for the `limit` parameter of the `GET /messages` API
* Check the consistency of the `limit` parameter in the `GET /messages` API