### PR TITLE
Normalize fields containing dots before querying to es 

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
@@ -464,7 +464,7 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
         if (headers != null) {
             OrPredicate metricsPredicate = DATASTORE_PREDICATE_FACTORY.newOrPredicate();
             for (GwtHeader header : headers) {
-                metricsPredicate.getPredicates().add(DATASTORE_PREDICATE_FACTORY.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", header.getName())));
+                metricsPredicate.getPredicates().add(DATASTORE_PREDICATE_FACTORY.newMetricExistsPredicate(header.getName(), null));
             }
             andPredicate.getPredicates().add(metricsPredicate);
         }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/MetricExistsPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/MetricExistsPredicateImpl.java
@@ -67,7 +67,7 @@ public class MetricExistsPredicateImpl extends ExistsPredicateImpl implements Me
 
         fieldNameSb.append(MessageField.METRICS.field())
                 .append(".")
-                .append(getName());
+                .append(DatastoreUtils.normalizeMetricName(getName()));
 
         if (getType() != null) {
             fieldNameSb.append(".")

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/MetricPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/MetricPredicateImpl.java
@@ -86,7 +86,7 @@ public class MetricPredicateImpl extends RangePredicateImpl implements MetricPre
         termNode.set(
                 getField().field()
                         .concat(".")
-                        .concat(getName())
+                        .concat(DatastoreUtils.normalizeMetricName(getName()))
                         .concat(".")
                         .concat(DatastoreUtils.getClientMetricFromAcronym(getType().getSimpleName().toLowerCase())),
                 valuesNode);


### PR DESCRIPTION
This pr introduces the missing normalization to fields containing dots in the context of ES queries. Such fields were already properly escaped with special sequences on the insertion side and retrieval but this king of normalization pre-query was missing