### PR TITLE
Fixed handling of jobStepProperty null value when validating length

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -94,8 +94,10 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
         ArgumentValidator.notNull(jobStepCreator.getJobStepDefinitionId(), "jobStepCreator.stepDefinitionId");
 
         for (JobStepProperty jobStepProperty : jobStepCreator.getStepProperties()) {
-            Integer stepPropertyMaxLength = jobStepProperty.getMaxLength() != null ? jobStepProperty.getMaxLength() : 65535;
-            ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepProperty.getMinLength(), stepPropertyMaxLength, "stepProperties[]." + jobStepProperty.getName());
+            if (jobStepProperty.getPropertyValue() != null) {
+                Integer stepPropertyMaxLength = jobStepProperty.getMaxLength() != null ? jobStepProperty.getMaxLength() : 65535;
+                ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepProperty.getMinLength(), stepPropertyMaxLength, "stepProperties[]." + jobStepProperty.getName());
+            }
         }
 
         if (jobStepCreator.getDescription() != null) {


### PR DESCRIPTION
This PR fixes the handling of `null` values when validating `jobStepProperty.propertyValue` length

**Related Issue**
This PR fixes a bug introduced with https://github.com/eclipse/kapua/pull/3812

**Description of the solution adopted**
Added `null` value check

**Screenshots**
_None_

**Any side note on the changes made**
_None_