### PR TITLE
feat(job): Increased length of `JobStepProperty.propertyValue` field to allow up to 4GB

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -340,8 +340,21 @@ public class JobStepAddDialog extends EntityAddEditDialog {
 
                 textArea.setData(PROPERTY_TYPE, property.getPropertyType());
                 textArea.setData(PROPERTY_NAME, property.getPropertyName());
-                textArea.setMaxLength(65535);
                 jobStepPropertiesPanel.add(textArea);
+
+                JOB_STEP_SERVICE.getJobStepPropertyLengthMax(new AsyncCallback<Integer>() {
+                    @Override
+                    public void onFailure(Throwable caught) {
+                        textArea.setMaxLength(104857600); // 100MB
+
+                        FailureHandler.handle(caught);
+                    }
+
+                    @Override
+                    public void onSuccess(Integer jobStepPropertyMaxLength) {
+                        textArea.setMaxLength(jobStepPropertyMaxLength);
+                    }
+                });
 
                 if (property.getExampleValue() != null) {
                     final String exampleValue = KapuaSafeHtmlUtils.htmlUnescape(property.getExampleValue());

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
@@ -221,6 +221,15 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
         }
     }
 
+    @Override
+    public int getJobStepPropertyLengthMax() throws GwtKapuaException {
+        try {
+            return JOB_STEP_SERVICE.getJobStepPropertyMaxLength();
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
+        }
+    }
+
     /**
      * Set the {@link GwtJobStepProperty#isEnum()} property.
      * This cannot be performed in *.shared.* packages (entity converters are in that package), since `Class.forName` is not present in the JRE Emulation library.

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobStepService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobStepService.java
@@ -47,6 +47,9 @@ public interface GwtJobStepService extends RemoteService {
     GwtJobStep update(GwtXSRFToken xsrfToken, GwtJobStep gwtJobStep)
             throws GwtKapuaException;
 
+    int getJobStepPropertyLengthMax()
+            throws GwtKapuaException;
+
     /**
      * Just to make Gwt serialize {@link GwtJobStepProperty}
      */

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorServiceImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorServiceImpl.java
@@ -69,4 +69,9 @@ public class JobStepMigratorServiceImpl extends AbstractKapuaService implements 
     public void delete(KapuaId scopeId, KapuaId jobStepId) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public int getJobStepPropertyMaxLength() throws KapuaException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepService.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 
 /**
  * {@link JobStepService} exposes APIs to manage JobStep objects.<br>
@@ -37,5 +38,13 @@ public interface JobStepService extends KapuaEntityService<JobStep, JobStepCreat
      */
     @Override
     JobStepListResult query(KapuaQuery query)
+            throws KapuaException;
+
+    /**
+     * Gets the maximum length that a {@link JobStepProperty#getPropertyValue()} is allowed to have.
+     *
+     * @since 2.0.0
+     */
+    int getJobStepPropertyMaxLength()
             throws KapuaException;
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/settings/JobServiceSettingKeys.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/settings/JobServiceSettingKeys.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.internal.settings;
+
+import org.eclipse.kapua.commons.setting.SettingKey;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
+
+/**
+ * {@link SettingKey}s for {@link JobServiceSettings}.
+ *
+ * @since 2.0.0
+ */
+public enum JobServiceSettingKeys implements SettingKey {
+
+    /**
+     * Max length of {@link JobStepProperty#getPropertyValue()}.
+     *
+     * @since 2.0.0
+     */
+    JOB_STEP_PROPERTY_VALUE_LENGTH_MAX("job.step.property.value.length.max");
+
+    /**
+     * The key value of the {@link SettingKey}.
+     *
+     * @since 120.0
+     */
+    private final String key;
+
+    /**
+     * Constructor.
+     *
+     * @param key The key value of the {@link SettingKey}.
+     * @since 2.0.0
+     */
+    private JobServiceSettingKeys(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+}

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/settings/JobServiceSettings.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/settings/JobServiceSettings.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.internal.settings;
+
+import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+
+/**
+ * {@link AbstractKapuaSetting} for {@code kapua-job-internal} module.
+ *
+ * @see AbstractKapuaSetting
+ * @since 2.0.0
+ */
+public class JobServiceSettings extends AbstractKapuaSetting<JobServiceSettingKeys> {
+
+    /**
+     * Setting filename.
+     *
+     * @since 2.0.0
+     */
+    private static final String JOB_SERVICE_SETTING_RESOURCE = "job-service-settings.properties";
+
+    /**
+     * Singleton instance.
+     *
+     * @since 2.0.0
+     */
+    private static final JobServiceSettings INSTANCE = new JobServiceSettings();
+
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    private JobServiceSettings() {
+        super(JOB_SERVICE_SETTING_RESOURCE);
+    }
+
+    /**
+     * Gets a singleton instance of {@link JobServiceSettings}.
+     *
+     * @return A singleton instance of {@link JobServiceSettings}.
+     * @since 2.0.0
+     */
+    public static JobServiceSettings getInstance() {
+        return INSTANCE;
+    }
+}

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -37,6 +37,8 @@ import org.eclipse.kapua.service.job.execution.JobExecutionFactory;
 import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
 import org.eclipse.kapua.service.job.execution.JobExecutionService;
 import org.eclipse.kapua.service.job.internal.JobEntityManagerFactory;
+import org.eclipse.kapua.service.job.internal.settings.JobServiceSettingKeys;
+import org.eclipse.kapua.service.job.internal.settings.JobServiceSettings;
 import org.eclipse.kapua.service.job.step.JobStep;
 import org.eclipse.kapua.service.job.step.JobStepAttributes;
 import org.eclipse.kapua.service.job.step.JobStepCreator;
@@ -80,6 +82,10 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
     @Inject
     QueryFactory queryFactory;
 
+    private final JobServiceSettings jobServiceSettings = JobServiceSettings.getInstance();
+
+    private final int jobStepPropertyValueLengthMax = jobServiceSettings.getInt(JobServiceSettingKeys.JOB_STEP_PROPERTY_VALUE_LENGTH_MAX);
+
     public JobStepServiceImpl() {
         super(JobEntityManagerFactory.getInstance(), null);
     }
@@ -95,8 +101,8 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
 
         for (JobStepProperty jobStepProperty : jobStepCreator.getStepProperties()) {
             if (jobStepProperty.getPropertyValue() != null) {
-                Integer stepPropertyMaxLength = jobStepProperty.getMaxLength() != null ? jobStepProperty.getMaxLength() : 65535;
-                ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepProperty.getMinLength(), stepPropertyMaxLength, "stepProperties[]." + jobStepProperty.getName());
+                Integer stepPropertyMaxLength = jobStepProperty.getMaxLength() != null ? jobStepProperty.getMaxLength() : jobStepPropertyValueLengthMax;
+                ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepProperty.getMinLength(), stepPropertyMaxLength, "jobStepCreator.stepProperties[]." + jobStepProperty.getName());
             }
         }
 
@@ -186,6 +192,14 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
         ArgumentValidator.notNull(jobStep.getScopeId(), "jobStep.scopeId");
         ArgumentValidator.validateEntityName(jobStep.getName(), "jobStep.name");
         ArgumentValidator.notNull(jobStep.getJobStepDefinitionId(), "jobStep.stepDefinitionId");
+
+        for (JobStepProperty jobStepProperty : jobStep.getStepProperties()) {
+            if (jobStepProperty.getPropertyValue() != null) {
+                Integer stepPropertyMaxLength = jobStepProperty.getMaxLength() != null ? jobStepProperty.getMaxLength() : jobStepPropertyValueLengthMax;
+                ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepProperty.getMinLength(), stepPropertyMaxLength, "jobStep.stepProperties[]." + jobStepProperty.getName());
+            }
+        }
+
         if (jobStep.getDescription() != null) {
             ArgumentValidator.numRange(jobStep.getDescription().length(), 0, 8192, "jobStep.description");
         }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -84,6 +84,11 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
 
     private final JobServiceSettings jobServiceSettings = JobServiceSettings.getInstance();
 
+    /**
+     * The maximum length that a {@link JobStepProperty#getPropertyValue()} is allowed to have
+     *
+     * @since 2.0.0
+     */
     private final int jobStepPropertyValueLengthMax = jobServiceSettings.getInt(JobServiceSettingKeys.JOB_STEP_PROPERTY_VALUE_LENGTH_MAX);
 
     public JobStepServiceImpl() {
@@ -380,6 +385,17 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
             }
             return deletedJobStep;
         });
+    }
+
+    @Override
+    public int getJobStepPropertyMaxLength() throws KapuaException {
+        //
+        // Check access
+        authorizationService.checkPermission(permissionFactory.newPermission(JobDomains.JOB_DOMAIN, Actions.read, KapuaId.ANY));
+
+        //
+        // Return the value
+        return jobStepPropertyValueLengthMax;
     }
 
     //

--- a/service/job/internal/src/main/resources/job-service-settings.properties
+++ b/service/job/internal/src/main/resources/job-service-settings.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+# 100 MB
+job.step.property.value.length.max=104857600

--- a/service/job/internal/src/main/resources/liquibase/2.0.0/changelog-job-2.0.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/2.0.0/changelog-job-2.0.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-2.0.0.xml">
+
+    <include relativeToChangelogFile="true" file="job_job_step_properties-value_length.xml"/>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/2.0.0/job_job_step_properties-value_length.xml
+++ b/service/job/internal/src/main/resources/liquibase/2.0.0/job_job_step_properties-value_length.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+        logicalFilePath="KapuaDB/changelog-job-2.0.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-job_step_properties-2.0.0_valueLength" author="eurotech">
+        <modifyDataType
+                tableName="job_job_step_properties"
+                columnName="property_value"
+                newDataType="longtext"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
@@ -22,5 +22,6 @@
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-job-1.2.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.5.0/changelog-job-1.5.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.6.0/changelog-job-1.6.0.xml"/>
+    <include relativeToChangelogFile="true" file="./2.0.0/changelog-job-2.0.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR increase the maximum length for `JobStepProperty.propertyValue` field, from 65k to 4GB softlimited ad 100MB

**Related Issue**
This PR relates to changes made in https://github.com/eclipse/kapua/pull/3812 and solves https://github.com/eclipse/kapua/issues/3469


**Description of the solution adopted**
Column for the field has been changed from `TEXT` to `LONGTEXT`, which in Maria DB increased the maximum allowed value from 65KB to 4GB. 

A configurable soft limit has been set at 100MB.

**Screenshots**
_None_

**Any side note on the changes made**
_None_