### PR TITLE
Fix - Fixed retrieval of metrics with same name and different types from Console GWT

### DIFF
--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -907,6 +907,115 @@ Feature: Datastore tests
     And No assertion error was thrown
     And I logout
 
+  Scenario: Dotted metrics
+  Checking of the number of messages that are associated with the correct metrics which contains dots (special chars parsed to other set of chars).
+  Searching for messages is done by all metrics.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I start the Kura Mock
+    When Device is connected within 10 seconds
+    Then Device status is "CONNECTED" within 10 seconds
+    And I select account "kapua-sys"
+    And I get the KuraMock device after 5 seconds
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+    And I set the following metrics with messages from the list "TestMessages"
+      | message | metric       | type   | value |
+      | 0       | dotted.metric.first | double | 123   |
+      | 1       | dotted.metric.second | double | 123   |
+      | 2       | dotted.metric.third | bool | true   |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics and store them as "AccountMetrics"
+    Then There are exactly 3 metrics in the list "AccountMetrics"
+    When I create message query for following metrics
+      | dotted.metric.first  |
+      | dotted.metric.second |
+      | dotted.metric.third  |
+    And I count data messages for more metrics
+    Then I count 3 data messages
+    And No assertion error was thrown
+    And I logout
+
+  Scenario: Dotted metrics considering different types
+  Checking of the number of messages that are associated with the correct metrics which contains dots (special chars parsed to other set of chars).
+  Searching for messages is done by all metrics and considering the particular type.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I start the Kura Mock
+    When Device is connected within 10 seconds
+    Then Device status is "CONNECTED" within 10 seconds
+    And I select account "kapua-sys"
+    And I get the KuraMock device after 5 seconds
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+    And I set the following metrics with messages from the list "TestMessages"
+      | message | metric       | type   | value |
+      | 0       | dotted.metric.first | double | 123   |
+      | 1       | dotted.metric.second | double | 123   |
+      | 2       | dotted.metric.third | bool | true   |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics and store them as "AccountMetrics"
+    Then There are exactly 3 metrics in the list "AccountMetrics"
+    When I create message query for metric type "double" for following metrics
+      | dotted.metric.first  |
+      | dotted.metric.second |
+      | dotted.metric.third  |
+    And I count data messages for more metrics
+    Then I count 2 data messages
+    And No assertion error was thrown
+    When I create message query for metric type "boolean" for following metrics
+      | dotted.metric.first  |
+      | dotted.metric.second |
+      | dotted.metric.third  |
+    And I count data messages for more metrics
+    Then I count 1 data messages
+    And No assertion error was thrown
+    And I logout
+
+  Scenario: Metrics containing combination of special chars
+  Checking of the number of messages that are associated with the correct metrics which contains dots and dollars (special chars parsed to other set of chars for the insertion to DB).
+  Searching for messages is done by all metrics.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I start the Kura Mock
+    When Device is connected within 10 seconds
+    Then Device status is "CONNECTED" within 10 seconds
+    And I select account "kapua-sys"
+    And I get the KuraMock device after 5 seconds
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+    And I set the following metrics with messages from the list "TestMessages"
+      | message | metric       | type   | value |
+      | 0       | dotted.$metric$.first  | double | 123   |
+      | 1       | dotted.metric$$.second | double | 123   |
+      | 2       | dotted.$$$metric.third | bool | true   |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics and store them as "AccountMetrics"
+    Then There are exactly 3 metrics in the list "AccountMetrics"
+    When I create message query for following metrics
+      | dotted.$metric$.first  |
+      | dotted.metric$$.second |
+      | dotted.$$$metric.third  |
+    And I count data messages for more metrics
+    Then I count 3 data messages
+    And No assertion error was thrown
+    And I logout
+
   Scenario: Finding messages with incorrect metric parameters
   Checking of the number of messages that are associated with the incorrect metrics.
   Searching for messages is done by one metric.

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -33,6 +33,7 @@ import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.message.device.data.KapuaDataMessageFactory;
 import org.eclipse.kapua.message.device.data.KapuaDataPayload;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.type.ObjectTypeConverter;
 import org.eclipse.kapua.qa.common.Session;
 import org.eclipse.kapua.qa.common.SimulatedDevice;
 import org.eclipse.kapua.qa.common.SimulatedDeviceApplication;
@@ -190,13 +191,18 @@ public class DatastoreSteps extends TestBase {
 
     @When("I create message query for following metrics")
     public void iCreateMessageQueryForMetrics(List<String> metricList) throws Exception {
+        iCreateMessageQueryForMetrics(null, metricList);
+    }
+
+    @When("I create message query for metric type {string} for following metrics")
+    public void iCreateMessageQueryForMetrics(String type, List<String> metricList) throws Exception {
         Account account = (Account) stepData.get(LAST_ACCOUNT);
         List<MessageQuery> listOfMessageQueries = new ArrayList<>();
 
         try {
             for (String metricName : metricList) {
                 MessageQuery messageQuery = createBaseMessageQuery(account.getId(), 100);
-                messageQuery.setPredicate(datastorePredicateFactory.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", metricName)));
+                messageQuery.setPredicate(datastorePredicateFactory.newMetricExistsPredicate(metricName, (Class<? extends Comparable>) ObjectTypeConverter.fromString(type)));
 
                 stepData.put(MESSAGE_QUERY, messageQuery);
                 listOfMessageQueries.add(messageQuery);


### PR DESCRIPTION
This pr fixes the retrieval of metrics with the same name and different types, that were treated as the same metric. This bug was introduced while working on this https://github.com/eclipse/kapua/pull/3825