### PR TITLE
fix(docker): temporarily set specific JVM 11 version to '11.0.19.07-4.el8' to fix start issue

### DIFF
--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -16,7 +16,7 @@ FROM @docker.base.image@
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-openjdk
 
-RUN yum install -y java-11-openjdk && \
+RUN yum install -y java-11-openjdk-11.0.19.0.7-4.el8 && \
     yum install -y curl && \
     yum install -y openssl && \
     mkdir -p /opt/jolokia && \


### PR DESCRIPTION
This PR sets a specific version of JVM installed in `java-base` Docker image to fix the following issue while starting all java-based containers

```
2023-07-26 16:02:52 java.lang.Error: java.io.FileNotFoundException: /usr/lib/jvm/java-11-openjdk-11.0.20.0.8-2.el8.aarch64/lib/tzdb.dat (No such file or directory)
2023-07-26 16:02:52     at java.base/sun.util.calendar.ZoneInfoFile$1.run(ZoneInfoFile.java:261)
2023-07-26 16:02:52     at java.base/sun.util.calendar.ZoneInfoFile$1.run(ZoneInfoFile.java:251)
2023-07-26 16:02:52     at java.base/java.security.AccessController.doPrivileged(Native Method)
2023-07-26 16:02:52     at java.base/sun.util.calendar.ZoneInfoFile.<clinit>(ZoneInfoFile.java:251)
2023-07-26 16:02:52     at java.base/sun.util.calendar.ZoneInfo.getTimeZone(ZoneInfo.java:588)
2023-07-26 16:02:52     at java.base/java.util.TimeZone.getTimeZone(TimeZone.java:577)
2023-07-26 16:02:52     at java.base/java.util.TimeZone.setDefaultZone(TimeZone.java:682)
2023-07-26 16:02:52     at java.base/java.util.TimeZone.getDefaultRef(TimeZone.java:653)
2023-07-26 16:02:52     at java.base/java.util.Date.normalize(Date.java:1198)
2023-07-26 16:02:52     at java.base/java.util.Date.toString(Date.java:1031)
2023-07-26 16:02:52     at java.base/java.util.Properties.store0(Properties.java:932)
2023-07-26 16:02:52     at java.base/java.util.Properties.store(Properties.java:921)
2023-07-26 16:02:52     at org.eclipse.jetty.start.Props.store(Props.java:356)
2023-07-26 16:02:52     at org.eclipse.jetty.start.StartArgs.getMainArgs(StartArgs.java:812)
2023-07-26 16:02:52     at org.eclipse.jetty.start.Main.start(Main.java:457)
2023-07-26 16:02:52     at org.eclipse.jetty.start.Main.main(Main.java:77)
2023-07-26 16:02:52 Caused by: java.io.FileNotFoundException: /usr/lib/jvm/java-11-openjdk-11.0.20.0.8-2.el8.aarch64/lib/tzdb.dat (No such file or directory)
2023-07-26 16:02:52     at java.base/java.io.FileInputStream.open0(Native Method)
2023-07-26 16:02:52     at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
2023-07-26 16:02:52     at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
2023-07-26 16:02:52     at java.base/sun.util.calendar.ZoneInfoFile$1.run(ZoneInfoFile.java:255)
2023-07-26 16:02:52     ... 15 more
2023-07-26 16:02:52 
2023-07-26 16:02:52 Usage: java -jar $JETTY_HOME/start.jar [options] [properties] [configs]
2023-07-26 16:02:52        java -jar $JETTY_HOME/start.jar --help  # for more information
```

This error is occurring with the lastest release JVM 11 version, which is `11.0.20.0.8-2.el8`

This fix is temporary to allow other PRs build and being merged

**Related Issue**
_None_

**Description of the solution adopted**
Set fixed version when installing JVM on rockylinux 8

**Screenshots**
_None_

**Any side note on the changes made**
_None_