### PR TITLE
feat(openapi): Added OpenAPI mappings for deviceAssetStoreService DeviceApplicationSettings

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementAssets.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementAssets.java
@@ -26,13 +26,14 @@ import org.eclipse.kapua.service.device.management.asset.store.DeviceAssetStoreS
 import org.eclipse.kapua.service.device.management.asset.store.settings.DeviceAssetStoreSettings;
 import org.eclipse.kapua.service.device.registry.Device;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -136,7 +137,7 @@ public class DeviceManagementAssets extends AbstractKapuaResource {
         return deviceAssetStoreService.getApplicationSettings(scopeId, deviceId);
     }
 
-    @POST
+    @PUT
     @Path("_settings")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public Response postSettings(

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.2
+
+info:
+  title: Eclipse Kapua REST API - Asset
+  version: '1.0'
+  contact:
+    name: Eclipse Kapua Dev Team
+    url: https://eclipse.org/kapua
+    email: kapua-dev@eclipse.org
+  license:
+    name: Eclipse Public License 2.0
+    url: https://www.eclipse.org/legal/epl-2.0
+
+paths:
+  /{scopeId}/devices/{deviceId}/assets/_settings:
+    get:
+      tags:
+        - Device Management - Asset
+      summary: Gets the settings of the Device Asset Store settings of this Device
+      operationId: getDeviceAssetStoreSettings
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+      responses:
+        200:
+          description: The Device Management Settings retrieved
+          content:
+            application/json:
+              schema:
+                $ref: './deviceAsset.yaml#/components/schemas/deviceAssetStoreSettings'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
+    put:
+      tags:
+        - Device Management - Asset
+      summary: Applies the given settings to the Device Asset Store settings of this Device
+      operationId: putDeviceAssetStoreSettings
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+      requestBody:
+        description: The Device Asset Store Settings for this Device
+        content:
+          application/json:
+            schema:
+              $ref: './deviceAsset.yaml#/components/schemas/deviceAssetStoreSettings'
+        required: true
+      responses:
+        204:
+          description: The Device Management Settings have been applied
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset.yaml
@@ -11,7 +11,7 @@ info:
     name: Eclipse Public License 2.0
     url: https://www.eclipse.org/legal/epl-2.0
 
-paths: {}
+paths: { }
 
 components:
   schemas:
@@ -159,3 +159,21 @@ components:
         The Asset uses a specific Driver instance to communicate with the underlying device and it models a generic device resource as a Channel.
         A register in a PLC or a GATT Characteristic in a Bluetooth device are examples of Channels.
         In this way, each Asset has multiple Channels for reading and writing data from/to an Industrial Device.
+    deviceAssetStoreEnablementPolicy:
+      description: The policy for which the Device Asset Store Application is enabled or not for this device. 'INHERITED' means that it inherits the setting from the Account-wide Asset Store Service Configuration
+      enum:
+        - ENABLED
+        - DISABLED
+        - INHERITED
+    deviceAssetStoreSettings:
+      allOf:
+        - $ref: '../openapi.yaml#/components/schemas/byDeviceAppManagementSettings'
+        - type: object
+          properties:
+            enablementPolicy:
+              $ref: '#/components/schemas/deviceAssetStoreEnablementPolicy'
+          example:
+            scopeId: AQ
+            deviceId: dIVxI5QpFUI
+            enablementPolicy: ENABLED
+

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -153,6 +153,9 @@ paths:
     $ref: './deviceAsset/deviceAsset-scopeId-deviceId-_read.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1assets~1_read'
   /{scopeId}/devices/{deviceId}/assets/_write:
     $ref: './deviceAsset/deviceAsset-scopeId-deviceId-_write.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1assets~1_write'
+  ### Device Asset Store ###
+  /{scopeId}/devices/{deviceId}/assets/_settings:
+    $ref: './deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1assets~1_settings'
   ### Device Bundle ###
   /{scopeId}/devices/{deviceId}/bundles:
     $ref: './deviceBundle/deviceBundle-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1bundles'
@@ -636,6 +639,16 @@ components:
         - SUBMIT
         - CANCEL
         - SENT
+    byDeviceAppManagementSettings:
+      description: Base class for Device Management Applications that have per-device settings
+      type: object
+      properties:
+        scopeId:
+          description: The scopeId of the selected device
+          $ref: '#/components/schemas/kapuaId'
+        deviceId:
+          description: The Device id of the selected device
+          $ref: '#/components/schemas/kapuaId'
     ### AccessInfo Entities ###
     accessInfo:
       $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessInfo'


### PR DESCRIPTION
This PR adds the Openapi mappings for the following resources:

- DeviceAssetStoreService.getApplicationSettings()
- DeviceAssetStoreService.setApplicationSettings(...) 

**Related Issue**
This PR adds a missing part of https://github.com/eclipse/kapua/pull/3601

**Description of the solution adopted**
Added mappings of new resources

**Screenshots**
_None_

**Any side note on the changes made**
Since it has been never released I've changed `POST` in `PUT` while applying configurations. This is not a breaking changed though
