### PR TITLE
feat(openapi): Added OpenAPI mappings for deviceConfigurationStoreService DeviceApplicationSettings

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
@@ -28,7 +28,6 @@ import org.eclipse.kapua.service.device.registry.Device;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -155,7 +154,7 @@ public class DeviceManagementConfigurations extends AbstractKapuaResource {
         return deviceConfigurationStoreService.getApplicationSettings(scopeId, deviceId);
     }
 
-    @POST
+    @PUT
     @Path("_settings")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public Response postSettings(

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.2
+
+info:
+  title: Eclipse Kapua REST API - Configurations
+  version: '1.0'
+  contact:
+    name: Eclipse Kapua Dev Team
+    url: https://eclipse.org/kapua
+    email: kapua-dev@eclipse.org
+  license:
+    name: Eclipse Public License 2.0
+    url: https://www.eclipse.org/legal/epl-2.0
+
+paths:
+  /{scopeId}/devices/{deviceId}/configurations/_settings:
+    get:
+      tags:
+        - Device Management - Configuration
+      summary: Gets the settings of the Device Configurations Store settings of this Device
+      operationId: getDeviceConfigurationsStoreSettings
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+      responses:
+        200:
+          description: The Device Management Settings retrieved
+          content:
+            application/json:
+              schema:
+                $ref: './deviceConfiguration.yaml#/components/schemas/deviceConfigurationStoreSettings'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
+    put:
+      tags:
+        - Device Management - Configuration
+      summary: Applies the given settings to the Device Configurations Store settings of this Device
+      operationId: putDeviceConfigurationsStoreSettings
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+      requestBody:
+        description: The Device Configurations Store Settings for this Device
+        content:
+          application/json:
+            schema:
+              $ref: './deviceConfiguration.yaml#/components/schemas/deviceConfigurationStoreSettings'
+        required: true
+      responses:
+        204:
+          description: The Device Management Settings have been applied
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration.yaml
@@ -11,7 +11,7 @@ info:
     name: Eclipse Public License 2.0
     url: https://www.eclipse.org/legal/epl-2.0
 
-paths: {}
+paths: { }
 
 components:
   parameters:
@@ -55,7 +55,7 @@ components:
         name: WireGraph
         required: true
         type: String
-        Option: []
+        Option: [ ]
     propertyDefinition:
       type: object
       properties:
@@ -120,8 +120,8 @@ components:
               name: WireGraph
               required: true
               type: String
-              Option: []
-          Icon: []
+              Option: [ ]
+          Icon: [ ]
         properties:
           property:
             - name: WireGraph
@@ -176,8 +176,8 @@ components:
                   name: WireGraph
                   required: true
                   type: String
-                  Option: []
-              Icon: []
+                  Option: [ ]
+              Icon: [ ]
             properties:
               property:
                 - name: WireGraph
@@ -230,3 +230,20 @@ components:
           type: string
         value:
           type: string
+    deviceConfigurationStoreEnablementPolicy:
+      description: The policy for which the Device Configuration Store Application is enabled or not for this device. 'INHERITED' means that it inherits the setting from the Account-wide Configuration Store Service Configuration
+      enum:
+        - ENABLED
+        - DISABLED
+        - INHERITED
+    deviceConfigurationStoreSettings:
+      allOf:
+        - $ref: '../openapi.yaml#/components/schemas/byDeviceAppManagementSettings'
+        - type: object
+          properties:
+            enablementPolicy:
+              $ref: '#/components/schemas/deviceConfigurationStoreEnablementPolicy'
+          example:
+            scopeId: AQ
+            deviceId: dIVxI5QpFUI
+            enablementPolicy: ENABLED

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -171,6 +171,9 @@ paths:
     $ref: './deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1configurations'
   /{scopeId}/devices/{deviceId}/configurations/{componentId}:
     $ref: './deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1configurations~1{componentId}'
+  ### Device Configuration Store ###
+  /{scopeId}/devices/{deviceId}/configurations/_settings:
+    $ref: './deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1configurations~1_settings'
   ### Device Inventory ###
   /{scopeId}/devices/{deviceId}/inventory:
     $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory'


### PR DESCRIPTION
This PR adds the Openapi mappings for the following resources:

- DeviceConfigurationStoreService.getApplicationSettings()
- DeviceConfigurationStoreService.setApplicationSettings(...) 

**Related Issue**
This PR adds a missing part of https://github.com/eclipse/kapua/pull/3601
This PR depends on https://github.com/eclipse/kapua/pull/3832

**Description of the solution adopted**
Added mappings of new resources

**Screenshots**
_None_

**Any side note on the changes made**
Since it has been never released I've changed `POST` in `PUT` while applying settings. This is not a breaking changed though
