### PR TITLE
Fix missing unit test for `MappingException`

### DIFF
--- a/service/commons/storable/api/pom.xml
+++ b/service/commons/storable/api/pom.xml
@@ -36,6 +36,16 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-commons</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service/commons/storable/api/src/main/java/org/eclipse/kapua/service/storable/exception/UnsupportedTypeMappingException.java
+++ b/service/commons/storable/api/src/main/java/org/eclipse/kapua/service/storable/exception/UnsupportedTypeMappingException.java
@@ -30,7 +30,7 @@ public class UnsupportedTypeMappingException extends MappingException {
      * @since 1.3.0
      */
     public UnsupportedTypeMappingException(String name, Object value) {
-        super(StorableErrorCodes.UNSUPPORTED_TYPE, name, value, value != null ? value.getClass().getName() : "null");
+        super(StorableErrorCodes.UNSUPPORTED_TYPE, name, value, value != null ? value.getClass().getSimpleName() : "null");
 
         this.name = name;
         this.value = value;

--- a/service/commons/storable/api/src/test/java/org/eclipse/kapua/service/storable/exception/InvalidValueMappingExceptionTest.java
+++ b/service/commons/storable/api/src/test/java/org/eclipse/kapua/service/storable/exception/InvalidValueMappingExceptionTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.storable.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category(JUnitTests.class)
+public class InvalidValueMappingExceptionTest {
+
+    @Test
+    public void newInstanceHardcodesUnsupportedTypeCode() {
+        final InvalidValueMappingException instance = new InvalidValueMappingException("arg0", new Object(), Object.class);
+
+        Assert.assertEquals(StorableErrorCodes.INVALID_VALUE, instance.getCode());
+    }
+
+
+    @Test
+    public void newInstanceFirstsClassArgumentIsUsedInExceptionMessage() {
+        final String arg0 = "argName";
+        final InvalidValueMappingException mappingException = new InvalidValueMappingException(arg0, arg0.getClass(), null);
+
+        final String expected = "The value of mapping " + arg0 + " of value";
+        Assert.assertTrue(mappingException.getMessage().startsWith(expected));
+    }
+
+
+    @Test
+    public void newInstanceNotNullThirdArgumentClassIsUsedInExceptionMessage() {
+        final String arg1 = "arg1Value";
+        final InvalidValueMappingException mappingException = new InvalidValueMappingException(new Throwable("foo"), "argName", arg1, arg1.getClass());
+
+        final String expected = "of value " + arg1 + " is not compatible with type " + arg1.getClass() + ".";
+        Assert.assertTrue(mappingException.getMessage().endsWith(expected));
+    }
+
+
+    @Test
+    public void newInstanceNullSecondsArgumentLeadsToNullType() {
+        final String arg1 = null;
+        final InvalidValueMappingException mappingException = new InvalidValueMappingException(new Throwable("foo"), "argName", arg1, null);
+
+        Assert.assertNull(mappingException.getType());
+    }
+}

--- a/service/commons/storable/api/src/test/java/org/eclipse/kapua/service/storable/exception/UnsupportedTypeMappingExceptionTest.java
+++ b/service/commons/storable/api/src/test/java/org/eclipse/kapua/service/storable/exception/UnsupportedTypeMappingExceptionTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.storable.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class UnsupportedTypeMappingExceptionTest {
+
+    @Test
+    public void newInstanceHardcodesUnsupportedTypeCode() {
+        final UnsupportedTypeMappingException instance = new UnsupportedTypeMappingException("nameArg", "valueArg");
+
+        Assert.assertEquals(StorableErrorCodes.UNSUPPORTED_TYPE, instance.getCode());
+    }
+
+
+    @Test
+    public void newInstanceFirstsClassArgumentIsUsedInExceptionMessage() {
+        final String arg0 = "argName";
+        final UnsupportedTypeMappingException mappingException = new UnsupportedTypeMappingException(arg0, null);
+
+        final String expected = "The conversion of mapping " + arg0 + " of value";
+        Assert.assertTrue(mappingException.getMessage().startsWith(expected));
+    }
+
+
+    @Test
+    public void newInstanceNotNullSecondsArgumentClassIsUsedInExceptionMessage() {
+        final String arg1 = "arg1Value";
+        final UnsupportedTypeMappingException mappingException = new UnsupportedTypeMappingException("argName", arg1);
+
+        final String expected = "of value " + arg1 + " of type " + arg1.getClass().getSimpleName() + " with is not supported!";
+        Assert.assertTrue(mappingException.getMessage().endsWith(expected));
+    }
+
+
+    @Test
+    public void newInstanceNullSecondsArgumentClassIsReplacedByPlaceholderInExceptionMessage() {
+        final String arg1 = null;
+        final UnsupportedTypeMappingException mappingException = new UnsupportedTypeMappingException("argName", arg1);
+
+        final String expected = "of value " + arg1 + " of type " + "null" + " with is not supported!";
+        Assert.assertTrue(mappingException.getMessage().endsWith(expected));
+    }
+
+    @Test
+    public void newInstanceNotNullSecondsArgumentClassIsAssignedToType() {
+        final String arg1 = "arg1Value";
+        final UnsupportedTypeMappingException mappingException = new UnsupportedTypeMappingException("argName", arg1);
+
+        Assert.assertEquals(arg1.getClass(), mappingException.getType());
+    }
+
+
+    @Test
+    public void newInstanceNullSecondsArgumentLeadsToNullType() {
+        final String arg1 = null;
+        final UnsupportedTypeMappingException mappingException = new UnsupportedTypeMappingException("argName", arg1);
+
+        Assert.assertNull(mappingException.getType());
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for the `MappingException` child classes.

**Related Issue**
This PR fixes #3841.