### PR TITLE
Feature - Bump swagger-ui from 3.52.4 to 4.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <slf4j.version>1.7.33</slf4j.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
-        <swagger-ui.version>3.52.5</swagger-ui.version>
+        <swagger-ui.version>4.19.1</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>
 
         <cucumber.version>6.11.0</cucumber.version>


### PR DESCRIPTION
This is meant to be back-ported to Kapua 1.x