### PR TITLE
Feature - Bump liquibase to 4.18

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
@@ -240,7 +240,7 @@ public class KapuaLiquibaseClient {
             if (!Strings.isNullOrEmpty(schema)) {
                 database.setDefaultSchemaName(schema);
             }
-            Liquibase liquibase = new Liquibase(masterChangelog.getAbsolutePath(), new FileSystemResourceAccessor(), database);
+            Liquibase liquibase = new Liquibase(masterChangelog.getAbsolutePath(), new FileSystemResourceAccessor("/"), database);
             liquibase.update(ctx);
 
             LOG.debug("\t\tExecuting liquibase script: {}... DONE!", masterChangelog.getAbsolutePath());

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.10</jose4j.version>
         <junit.version>4.13.2</junit.version>
-        <liquibase.version>3.6.3</liquibase.version>
+        <liquibase.version>4.13.0</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
         <logback.version>1.2.11</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
@@ -2646,7 +2646,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-jpamodelgen</artifactId>
-                <version>5.5.4.Final</version>
+                <version>5.6.5.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.10</jose4j.version>
         <junit.version>4.13.2</junit.version>
-        <liquibase.version>4.13.0</liquibase.version>
+        <liquibase.version>4.18.0</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
         <logback.version>1.2.11</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
@@ -1713,10 +1713,10 @@
                 <artifactId>liquibase-core</artifactId>
                 <version>${liquibase.version}</version>
                 <exclusions>
-                    <!-- This is not required. The implementation of SLF4J will be by the application assembly-->
+                    <!-- Already in dependencies-->
                     <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -2229,7 +2229,6 @@
                 <artifactId>log4j-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-
             <!-- -->
             <!-- Jetty-->
             <dependency>
@@ -2646,7 +2645,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-jpamodelgen</artifactId>
-                <version>5.6.5.Final</version>
+                <version>5.5.4.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Here I upgraded liquibase core up to 4.18 version. I did not upgrade it to a more late release for changes in the checksum of changelogs https://contribute.liquibase.com/extensions-integrations/extensions-overview/upgrade-guides/lb-4.23-upgrade-guide/ that could interfere with the upgrade. by the way, this version I have chosen doesn't have any CVE. 

Modifications to the liquibase java client were necessary following this guide https://contribute.liquibase.com/extensions-integrations/extensions-overview/upgrade-guides/lb-4.0-upgrade-guide/ 