### PR TITLE
Feature - Bump H2 Database from  1.4.199 to 1.4.200

### DIFF
--- a/assembly/sql/docker/Dockerfile
+++ b/assembly/sql/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd -u 1001 -g 0 -d '/var/opt/h2' -s '/sbin/nologin' h2 && \
     mkdir -p /var/opt/h2/data && chmod -R a+rw /var/opt/h2 && \
     mkdir -p /opt/h2 && chmod a+r /opt/h2 && \
     cd /opt/h2 && \
-    curl -s https://repo1.maven.org/maven2/com/h2database/h2/1.4.193/h2-1.4.193.jar -o h2.jar
+    curl -s https://repo1.maven.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar -o h2.jar
 
 VOLUME /var/opt/h2/data
 

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntity.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntity.java
@@ -23,6 +23,7 @@ import javax.persistence.Table;
 
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
 
 @Entity(name = "CollisionEntity")
 @Table(name = "collision_entity_test")
@@ -60,7 +61,8 @@ public class CollisionEntity extends AbstractKapuaNamedEntity {
     @Override
     protected void prePersistsAction() {
         setId(new KapuaEid(collisionIdGenerator.generate()));
-
+        setScopeId(KapuaId.ONE);
+        setName("foo");
         setCreatedBy(new KapuaEid(BigInteger.ONE));
         setCreatedOn(new Date());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <guice.version>5.1.0</guice.version>
         <guice-multibindings.version>4.2.3</guice-multibindings.version>
         <hamcrest-core.version>2.2</hamcrest-core.version>
-        <h2.version>1.4.199</h2.version>
+        <h2.version>1.4.200</h2.version>
         <hikaricp.version>4.0.3</hikaricp.version>
         <hk2-api.version>2.6.1</hk2-api.version>
         <httpcomponents-asyncclient.version>4.1.5</httpcomponents-asyncclient.version>

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/DBHelper.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/DBHelper.java
@@ -107,7 +107,7 @@ public class DBHelper {
             ResultSet sqlResults = connection.getMetaData().getTables(null, null, "%", types);
 
             while (sqlResults.next()) {
-                String sqlStatement = String.format("DROP TABLE %s", sqlResults.getString("TABLE_NAME").toUpperCase());
+                String sqlStatement = String.format("DROP TABLE %s CASCADE", sqlResults.getString("TABLE_NAME").toUpperCase());
                 try (PreparedStatement preparedStatement = connection.prepareStatement(sqlStatement)) {
                     preparedStatement.execute();
                 }

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestDomain.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestDomain.java
@@ -30,6 +30,7 @@ public class TestDomain extends AbstractKapuaEntity implements Domain, org.eclip
     private static final long serialVersionUID = 3782336558657796495L;
 
     private String name = "test";
+    private String serviceName = "test";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
     private boolean groupable;
 
@@ -45,9 +46,20 @@ public class TestDomain extends AbstractKapuaEntity implements Domain, org.eclip
     }
 
     @Override
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    @Override
     public String getName() {
         return name;
     }
+
+    @Override
+    public String getServiceName() {
+        return serviceName;
+    }
+
 
     @Override
     public void setActions(Set<Actions> actions) {

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucDomain.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucDomain.java
@@ -27,6 +27,9 @@ public class CucDomain {
     public CucDomain(String name, String serviceName, String actions) {
         this.name = name;
         this.serviceName = serviceName;
+        if (this.serviceName == null) {
+            this.serviceName= "test";
+        }
         this.actions = actions;
     }
 
@@ -63,6 +66,14 @@ public class CucDomain {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
     }
 
     public void setActionSet(Set<Actions> actionSet) {

--- a/qa/common/src/main/resources/sql/all_delete.sql
+++ b/qa/common/src/main/resources/sql/all_delete.sql
@@ -11,6 +11,8 @@
  *     Eurotech - initial API and implementation
  *******************************************************************************/
 
+UPDATE act_account SET scope_id = null;
+
 DELETE
 FROM act_account
 WHERE id NOT IN (1);

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -58,6 +58,8 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      */
     void setName(String name);
 
+    void setServiceName(String serviceName);
+
     /**
      * Gets the {@link Domain} name.
      *
@@ -66,6 +68,8 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      */
     @XmlElement(name = "name")
     String getName();
+
+    String getServiceName();
 
     /**
      * Sets the set of {@link Actions} available in this {@link Domain}.<br>

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -58,6 +58,12 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      */
     void setName(String name);
 
+    /**
+     * Sets the {@link Domain} service Name.<br>
+     *
+     * @param serviceName The service name of the {@link Domain}
+     * @since 6.0.0
+     */
     void setServiceName(String serviceName);
 
     /**
@@ -69,6 +75,13 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
     @XmlElement(name = "name")
     String getName();
 
+    /**
+     * Gets the {@link Domain} service name.
+     *
+     * @return The {@link Domain} service name.
+     * @since 6.0.0
+     */
+    @XmlTransient
     String getServiceName();
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
@@ -48,6 +48,12 @@ public interface DomainCreator extends KapuaEntityCreator<Domain> { // org.eclip
      */
     void setName(String name);
 
+    /**
+     * Sets the {@link Domain} service name.
+     *
+     * @param serviceName The {@link Domain} name.
+     * @since 1.0.0
+     */
     void setServiceName(String serviceName);
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
@@ -34,6 +34,8 @@ public interface DomainCreator extends KapuaEntityCreator<Domain> { // org.eclip
 
     String getName();
 
+    String getServiceName();
+
     Set<Actions> getActions();
 
     boolean getGroupable();
@@ -45,6 +47,8 @@ public interface DomainCreator extends KapuaEntityCreator<Domain> { // org.eclip
      * @since 1.0.0
      */
     void setName(String name);
+
+    void setServiceName(String serviceName);
 
     /**
      * Sets the set of {@link Actions} available in the {@link Domain}.<br>

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImpl.java
@@ -30,6 +30,8 @@ public class DomainCreatorImpl extends AbstractKapuaEntityCreator<Domain> implem
     private static final long serialVersionUID = -4676187845961673421L;
 
     private String name;
+
+    private String serviceName;
     private Set<Actions> actions;
     private boolean groupable;
 
@@ -50,9 +52,18 @@ public class DomainCreatorImpl extends AbstractKapuaEntityCreator<Domain> implem
         this.name = name;
     }
 
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String getServiceName() {
+        return serviceName;
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
@@ -44,6 +44,10 @@ public class DomainImpl extends AbstractKapuaEntity implements Domain {
     @Column(name = "name", nullable = false, updatable = false)
     private String name;
 
+    @Basic
+    @Column(name = "serviceName", nullable = false, updatable = false)
+    private String serviceName;
+
     @ElementCollection
     @CollectionTable(name = "athz_domain_actions", joinColumns = @JoinColumn(name = "domain_id", referencedColumnName = "id"))
     @Column(name = "action", nullable = false)
@@ -93,8 +97,18 @@ public class DomainImpl extends AbstractKapuaEntity implements Domain {
     }
 
     @Override
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String getServiceName() {
+        return this.serviceName;
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
@@ -70,11 +70,13 @@ public class DomainRegistryServiceImpl implements DomainRegistryService {
         ArgumentValidator.notNull(domainCreator, "domainCreator");
         ArgumentValidator.notEmptyOrNull(domainCreator.getName(), "domainCreator.name");
         ArgumentValidator.notNull(domainCreator.getActions(), "domainCreator.actions");
+        ArgumentValidator.notEmptyOrNull(domainCreator.getServiceName(), "domainCreator.serviceName");
         // Check Access
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.DOMAIN_DOMAIN, Actions.write, null));
         Domain domain = new DomainImpl();
 
         domain.setName(domainCreator.getName());
+        domain.setServiceName(domainCreator.getServiceName());
         domain.setGroupable(domainCreator.getGroupable());
 
         if (domainCreator.getActions() != null) {

--- a/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/AuthorizationServiceSteps.java
+++ b/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/AuthorizationServiceSteps.java
@@ -611,6 +611,7 @@ public class AuthorizationServiceSteps extends TestBase {
             if (tmpDom.getActionSet() != null) {
                 domainCreator.setActions(tmpDom.getActionSet());
             }
+            domainCreator.setServiceName(tmpDom.getServiceName());
             stepData.put(DOMAIN_CREATOR, domainCreator);
             try {
                 domain = domainRegistryService.create(domainCreator);
@@ -721,6 +722,7 @@ public class AuthorizationServiceSteps extends TestBase {
     public void checkDomainComparison() throws KapuaException {
         KapuaSecurityUtils.doPrivileged(() -> {
             DomainCreator tmpCreator = domainFactory.newCreator("name_1");
+            tmpCreator.setServiceName("test");
             HashSet<Actions> tmpAct = new HashSet<>();
             tmpAct.add(Actions.read);
             tmpAct.add(Actions.write);


### PR DESCRIPTION
H2 has been upgraded to the latest 1.x. Namely the 1.4.200.

Two main modifications were needed for this new H2 version

1. This version is more rigid with respect to the deletion of tables that have a foreign key to other tables with the "on delete restrict" rule: when trying to delete them the DB blocks the operation. For this reason, I had to modify the scripts used to clear tables of the DB in the test code.
2. We connect to h2 using the "MySql" mode :
![Screenshot 2023-09-12 at 14 21 41](https://github.com/eclipse/kapua/assets/39708353/3f78937d-0c09-4b75-b0f8-120018185d29)
Suppose to have a table that defines some fields as NOT-NULLABLE. With this mode and with the previous version of h2, when trying to insert some records on that table with some NULL fields it was actually possible to try to insert those fields as NULL because the h2 engine was converting those NULLs to the default type of the field (for example, a 0 for integers). In the tests, there were cases where we were unknowingly exploiting this feature. This was caused by not setting, in the code, some fields for certain entities that, consequently, were inserted with the default value. 

This rule has been changed and the engine now complains if you try to set NOT-NULLABLE fields as NULL. Consequently, the mentioned tests were failing. I had to modify these tests defining a value for such fields