### PR TITLE
fix KapuaPrincipal name

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -214,7 +214,6 @@ public class ServerPlugin implements ActiveMQServerPlugin {
             message.putBooleanProperty(MessageConstants.HEADER_KAPUA_BROKER_CONTEXT, true);
         }
         message.putStringProperty(MessageConstants.PROPERTY_ORIGINAL_TOPIC, address);
-        publishMetric.getAllowedMessages().inc();
         publishMetric.getMessageSizeAllowed().update(messageSize);
         logger.info("Published message on address {} from clientId: {} - clientIp: {}", address, sessionContext.getClientId(), sessionContext.getClientIp());
         ActiveMQServerPlugin.super.beforeSend(session, tx, message, direct, noAutoCreateQueue);

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/bean/KapuaPrincipalImpl.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/bean/KapuaPrincipalImpl.java
@@ -45,7 +45,7 @@ public class KapuaPrincipalImpl implements KapuaPrincipal {
      * @param authResponse
      */
     public KapuaPrincipalImpl(AuthResponse authResponse) {
-        name = authResponse.getUsername();
+        name = authResponse.getUsername() + "@" + authResponse.getClientId();
         clientId = authResponse.getClientId();
         accessTokenId = authResponse.getAccessTokenId();
         userId = KapuaEid.parseCompactId(authResponse.getUserId());
@@ -60,10 +60,11 @@ public class KapuaPrincipalImpl implements KapuaPrincipal {
      * @param accountId
      * @param clientId
      */
-    public KapuaPrincipalImpl(KapuaId accountId, String clientId) {
+    public KapuaPrincipalImpl(KapuaId accountId, String name, String clientId) {
         internal = true;
-        this.clientId = clientId;
         this.accountId = accountId;
+        this.name = name + "@" + clientId;
+        this.clientId = clientId;
     }
 
     @Override
@@ -108,12 +109,8 @@ public class KapuaPrincipalImpl implements KapuaPrincipal {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result
-                + (accountId == null ? 0 : accountId.hashCode());
-        result = prime * result + (name == null ? 0 : name.hashCode());
-        return result;
+        //name is unique so let's use it for hashing
+        return (name == null ? 0 : name.hashCode());
     }
 
     @Override
@@ -128,13 +125,6 @@ public class KapuaPrincipalImpl implements KapuaPrincipal {
             return false;
         }
         KapuaPrincipalImpl other = (KapuaPrincipalImpl) obj;
-        if (accountId == null) {
-            if (other.accountId != null) {
-                return false;
-            }
-        } else if (!accountId.equals(other.accountId)) {
-            return false;
-        }
         if (name == null) {
             if (other.name != null) {
                 return false;

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/bean/KapuaPrincipalImpl.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/bean/KapuaPrincipalImpl.java
@@ -60,10 +60,10 @@ public class KapuaPrincipalImpl implements KapuaPrincipal {
      * @param accountId
      * @param clientId
      */
-    public KapuaPrincipalImpl(KapuaId accountId, String name, String clientId) {
+    public KapuaPrincipalImpl(KapuaId accountId, String username, String clientId) {
         internal = true;
         this.accountId = accountId;
-        this.name = name + "@" + clientId;
+        name = username + "@" + clientId;
         this.clientId = clientId;
     }
 


### PR DESCRIPTION
Brief description of the PR.
The name of the KapuaPrincipal is not unique now since a user can connect more than one client so potentially more than one device could be connected with the same principal

**Related Issue**
none

**Description of the solution adopted**
Name now is composed by concatenation of username and client id making it unique in the system.

**Screenshots**
none

**Any side note on the changes made**
none