### PR TITLE
fix(jobEngine): Changed 'jbtc_job_status.obj' type to longblob to support changes made in eclipse/kapua#3828

### DIFF
--- a/job-engine/jbatch/src/main/resources/liquibase/2.0.0/changelog-job-engine-2.0.0.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/2.0.0/changelog-job-engine-2.0.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./job_engine_jbatch-job_status.xml"/>
+
+</databaseChangeLog>

--- a/job-engine/jbatch/src/main/resources/liquibase/2.0.0/job_engine_jbatch-job_status.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/2.0.0/job_engine_jbatch-job_status.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job_engine_jbatch-2.0.0.xml">
+
+    <changeSet id="changelog-job_engine_jbatch-2.0.0-job_status_obj_longtext" author="eurotech">
+        <modifyDataType
+                tableName="jbtc_job_status"
+                columnName="obj"
+                newDataType="longblob"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/job-engine/jbatch/src/main/resources/liquibase/changelog-job-engine-master.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/changelog-job-engine-master.xml
@@ -20,5 +20,6 @@
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-engine-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-job-engine-1.2.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.5.0/changelog-job-engine-1.5.0.xml"/>
+    <include relativeToChangelogFile="true" file="./2.0.0/changelog-job-engine-2.0.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR fix an issue introduced with eclipse/kapua#3828

The Job Engine jBatch internal tables were not updated to handle big values.

**Related Issue**
This PR fixes eclipse/kapua#3828

**Description of the solution adopted**
Updated the column type of  `jbtc_job_status.obj` from `text` to `longblob` to handle bigger values that might be stored on it.

**Screenshots**
_None_

**Any side note on the changes made**
_None_