### PR TITLE
fix(jobEngine): added missing mappings in JobEngine locator.xml for DeviceConnectionService and DeviceConnectionFactory

### DIFF
--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -55,6 +55,9 @@
         <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
         <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
 
+        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
+        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
+
         <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
         <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
 


### PR DESCRIPTION
This PR fixes mapping of Job Engine `locator.xml`.

`DeviceConnectionService` and `DeviceConnectionFactory` were not added when backporting https://github.com/eclipse/kapua/pull/3697

**Related Issue**
This PR fixes backport issue on https://github.com/eclipse/kapua/pull/3697

**Description of the solution adopted**
Added missing mappings to the Job Engine `locator.xml`.

**Screenshots**
_None_

**Any side note on the changes made**
_None_