### PR TITLE
Bump `shiro` version from `1.10.0` to `1.12.0` - `CVE-2023-34478`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
         <reflections.version>0.9.12</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
-        <shiro.version>1.10.0</shiro.version>
+        <shiro.version>1.12.0</shiro.version>
         <slf4j.version>1.7.33</slf4j.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>


### PR DESCRIPTION
Bump shiro version from current `1.10.0` to `1.12.0` due to CVE-2023-34478.