### PR TITLE
feat(docker): set jvm 11 to reference latest version

### DIFF
--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -16,7 +16,7 @@ FROM @docker.base.image@
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-openjdk
 
-RUN yum install -y java-11-openjdk-11.0.19.0.7-4.el8 && \
+RUN yum install -y java-11-openjdk && \
     yum install -y curl && \
     yum install -y openssl && \
     mkdir -p /opt/jolokia && \


### PR DESCRIPTION
This PR set back to `java-11-openjdk` the version of the JDK installed on the `java-base` Docker image
It was modified in https://github.com/eclipse/kapua/pull/3831

**Related Issue**
https://github.com/eclipse/kapua/pull/3831

**Description of the solution adopted**
Set back the original value

**Screenshots**
_None_

**Any side note on the changes made**
_None_