### PR TITLE
Set fixed version of `commons-configuration2` dependency to `2.9.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-configuration.version>1.9</commons-configuration.version>
+        <commons-configuration2.version>2.9.0</commons-configuration2.version>
         <commons-compress.version>1.22</commons-compress.version>
         <commons-fileupload.versison>1.4</commons-fileupload.versison>
         <commons-imaging.version>1.0-alpha3</commons-imaging.version>
@@ -1373,6 +1374,17 @@
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
                 <version>${commons-configuration.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${commons-configuration2.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>


### PR DESCRIPTION
Set fixed version of `commons-configuration2` to `2.9.0`.

**Related Issue**
This PR originates from #3853.