### PR TITLE
Feature - Bump OpenApi from 3.0.2 to version 3.0.3 to all openApi yaml files

### DIFF
--- a/job-engine/app/resources/src/main/resources/openapi/jobEngine-scopeId-jobId-executionId.yaml
+++ b/job-engine/app/resources/src/main/resources/openapi/jobEngine-scopeId-jobId-executionId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Job Engine

--- a/job-engine/app/resources/src/main/resources/openapi/jobEngine-scopeId-jobId.yaml
+++ b/job-engine/app/resources/src/main/resources/openapi/jobEngine-scopeId-jobId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Job Engine

--- a/job-engine/app/resources/src/main/resources/openapi/jobEngine-scopeId.yaml
+++ b/job-engine/app/resources/src/main/resources/openapi/jobEngine-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Job Engine

--- a/job-engine/app/resources/src/main/resources/openapi/jobEngine.yaml
+++ b/job-engine/app/resources/src/main/resources/openapi/jobEngine.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Job Engine

--- a/job-engine/app/resources/src/main/resources/openapi/openapi.yaml
+++ b/job-engine/app/resources/src/main/resources/openapi/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua Job Engine REST API

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Infos

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Infos

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Infos

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Infos

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-accessPermissionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-accessPermissionId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Info

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Info

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Infos

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Infos

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-accessRoleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-accessRoleId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Info

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Info

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Info

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Infos

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Access Infos

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Accounts

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Accounts

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId-accountId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId-accountId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Accounts

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Accounts

--- a/rest-api/resources/src/main/resources/openapi/account/account.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Accounts

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-apikey.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-apikey.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Authentication

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-info.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-info.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Authentication

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-jwt.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-jwt.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Authentication

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-logout.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-logout.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Authentication

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-mfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-mfa.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Authentication

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-refresh.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-refresh.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Authentication

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Authentication

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Authentication

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Credentials

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Credentials

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId-unlock.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId-unlock.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Credential

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Credentials

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Credential

--- a/rest-api/resources/src/main/resources/openapi/credential/credential.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Credentials

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Channel

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-channelInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-channelInfoId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Channel

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Channel

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Channel

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Client

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-clientInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-clientInfoId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Client

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Client

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Client

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Message

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-datastoreMessageId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-datastoreMessageId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Message

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Message

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Metric

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Metric

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-metricInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-metricInfoId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Metric

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Metric

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Data Metric

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Devices

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Devices

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Devices

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Devices

--- a/rest-api/resources/src/main/resources/openapi/device/device.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Devices

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_read.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_read.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Asset

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Asset

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_write.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_write.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Asset

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Asset

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Asset

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_start.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_start.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Bundle

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_stop.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_stop.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Bundle

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Bundle

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Bundle

--- a/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand-scopeId-deviceId-_execute.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand-scopeId-deviceId-_execute.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Command

--- a/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Command

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Configurations

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Configuration

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Configuration

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Configuration

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Connection

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Connection

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-options.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-options.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Connection

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Connection

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Connection

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Connection

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Event

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Event

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-deviceEventId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-deviceEventId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Event

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Event

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Event

--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Inventory

--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Inventory

--- a/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Keystore

--- a/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Keystore

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Notifications

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Notifications

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-notificationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-notificationId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Notifications

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Notifications

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Notifications

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Operations

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Operations

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-operationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-operationId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Operations

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Operations

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Operations

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Package

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Package

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Package

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Package

--- a/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Request

--- a/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Request

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId-_rollback.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId-_rollback.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Snapshot

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Snapshot

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Snapshot

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Device Management - Snapshot

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Domains

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Domains

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-domainId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-domainId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Domains

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Domains

--- a/rest-api/resources/src/main/resources/openapi/domain/domain.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Domains

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Endpoint Infos

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Endpoint Infos

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - EndpointInfos

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - EndpointInfos

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - EndpointInfos

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Groups

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Groups

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId-groupId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId-groupId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Groups

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Groups

--- a/rest-api/resources/src/main/resources/openapi/group/group.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Groups

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId-jobId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId-jobId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs

--- a/rest-api/resources/src/main/resources/openapi/job/job.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId-executionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId-executionId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Job Engine

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Job Engine

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Job Engine

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Job Engine

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Executions

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Executions

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId-targets.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Executions

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Executions

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Executions

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/jobExecution.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/jobExecution.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Executions

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Steps

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Steps

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-stepId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-stepId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Steps

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Steps

--- a/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Steps

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Step Definitions

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Step Definitions

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-jobStepDefinitionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-jobStepDefinitionId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Step Definitions

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Step Definitions

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Step Definitions

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Targets

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Targets

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId-executions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId-executions.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Targets

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Targets

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Targets

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/jobTarget.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/jobTarget.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Targets

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Triggers

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Triggers

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-triggerId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-triggerId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Triggers

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Triggers

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/jobTrigger.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/jobTrigger.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs Triggers

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Trigger Fired

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Trigger Fired

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Trigger Fired

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/jobTriggerFired.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/jobTriggerFired.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Trigger Fired

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Roles

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Roles

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId-users.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId-users.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Roles

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Roles

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Roles

--- a/rest-api/resources/src/main/resources/openapi/role/role.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Roles

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - RolePermissions

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - RolePermissions

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-permissionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-permissionId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - RolePermissions

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Roles

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Service Configuration

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Service Configuration

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Service Configuration

--- a/rest-api/resources/src/main/resources/openapi/stream/stream-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/stream/stream-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Streams

--- a/rest-api/resources/src/main/resources/openapi/systemInfo/systemInfo.yaml
+++ b/rest-api/resources/src/main/resources/openapi/systemInfo/systemInfo.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Version

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Tags

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Tags

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-tagId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-tagId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Tags

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Tags

--- a/rest-api/resources/src/main/resources/openapi/tag/tag.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Tags

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Trigger Definitions

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Trigger Definitions

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-triggerDefinitionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-triggerDefinitionId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Jobs - Trigger Definitions

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Trigger Definitions

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Trigger Definitions

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Users

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-_query.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Users

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId-mfa-disableTrust.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId-mfa-disableTrust.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - MfaOptions

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId-mfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId-mfa.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - MfaOptions

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Users

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Users

--- a/rest-api/resources/src/main/resources/openapi/user/user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Users

--- a/rest-api/resources/src/main/resources/openapi/userCredentials/userCredentials-scopeId-credentialId-_reset.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userCredentials/userCredentials-scopeId-credentialId-_reset.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - Credential

--- a/rest-api/resources/src/main/resources/openapi/userCredentials/userCredentials-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userCredentials/userCredentials-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Everyware Cloud REST API - User Credentials

--- a/rest-api/resources/src/main/resources/openapi/userCredentials/userCredentials.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userCredentials/userCredentials.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Everyware Cloud REST API - User Credentials

--- a/rest-api/resources/src/main/resources/openapi/userCredentialsFiltered/credential-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userCredentialsFiltered/credential-scopeId-_count.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - User Credentials Filtered

--- a/rest-api/resources/src/main/resources/openapi/userCredentialsFiltered/credential-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userCredentialsFiltered/credential-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Eclipse Kapua REST API - User Credentials Filtered

--- a/rest-api/resources/src/main/resources/openapi/userProfile/userProfile-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userProfile/userProfile-scopeId.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Everyware Cloud REST API - User Profile

--- a/rest-api/resources/src/main/resources/openapi/userProfile/userProfile.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userProfile/userProfile.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 
 info:
   title: Everyware Cloud REST API - User Profile


### PR DESCRIPTION
Basically this is an extension of this PR https://github.com/eclipse/kapua/pull/3843

In that PR I missed to update the openApi version reference in all the openApi yaml files except for the main one