### PR TITLE
chng(job): Changeg max length for JobStepProperty.value from 100MB to 10MB

### DIFF
--- a/service/job/internal/src/main/resources/job-service-settings.properties
+++ b/service/job/internal/src/main/resources/job-service-settings.properties
@@ -11,5 +11,5 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-# 100 MB
-job.step.property.value.length.max=104857600
+# 10 MB
+job.step.property.value.length.max=10485760


### PR DESCRIPTION
This PR lowers the default value of a soft limit introduced with https://github.com/eclipse/kapua/pull/3828

**Related Issue**
This PR changes a limit introduced in https://github.com/eclipse/kapua/pull/3828

**Description of the solution adopted**
Lowered the limit int the Settings files

**Screenshots**
_None_

**Any side note on the changes made**
_None_