### PR TITLE
FIX - Fixed some wrong written tests

### DIFF
--- a/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
@@ -335,9 +335,9 @@ Feature: Account Credential Service Integration Tests
     Then I logout
     Given I expect the exception "KapuaAuthenticationException" with the text "*"
     When I login as user with name "user1" and password "wrongpassword"
-    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    Then An exception was thrown
     When I login as user with name "user1" and password "wrongpassword"
-    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    Then An exception was thrown
     When I login as user with name "user1" and password "ToManySecrets123#"
     Then An exception was thrown
     Then I wait 5 seconds
@@ -372,8 +372,9 @@ Feature: Account Credential Service Integration Tests
     Then I logout
     Given I expect the exception "KapuaAuthenticationException" with the text "*"
     When I login as user with name "user1" and password "wrongpassword"
-    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    Then An exception was thrown
     When I login as user with name "user1" and password "wrongpassword"
+    Then An exception was thrown
     When I login as user with name "user1" and password "ToManySecrets123#"
     Then No exception was thrown
     And I logout

--- a/qa/integration/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -373,14 +373,13 @@ Feature: Broker ACL tests
 #      And clients are disconnected
 #      And Mqtt Device is stoped
 
-  Scenario: D13 Device subscribe on ACL_CTRL_ACC_NOTIFY is not allowed
+  Scenario: D13 Device subscribe on ACL_CTRL_ACC_NOTIFY is allowed
     Normal user with device manage profile subscribes to $EDC/{0}/+/+/NOTIFY/{1}/#
-    Subscribe is not allowed.
+    Subscribe is allowed.
     Given Mqtt Device is started
       And device account and user are created
     Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "KeepCalm123." is listening on topic "$EDC/acme/foo/bar/NOTIFY/client-1"
-#    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 #

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -129,7 +129,7 @@ Feature: Trigger service tests
     And I create a job with the name "job0"
     When I find scheduler properties with name "Device Connect"
     And A regular trigger creator with the name "schedule0" is created
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -162,7 +162,7 @@ Feature: Trigger service tests
     When I find scheduler properties with name "Device Connect"
     And A regular trigger creator with the name "" is created
     And The trigger is set to start on "12-12-2020" at "10:10"
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -200,7 +200,7 @@ Feature: Trigger service tests
     When I find scheduler properties with name "Device Connect"
     And A regular trigger creator with the name "" is created
     And The trigger is set to end on "12-12-2020" at "10:10"
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -343,7 +343,7 @@ Feature: Trigger service tests
     And A regular trigger creator with the name "wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww" is created
     And The trigger is set to start today at "10:00"
     And I set retry interval to 1
-    Then I expect the exception "KapuaIllegalArgumentException" with the text " Value over than allowed max length. Max length is: 255."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text " Value over than allowed max length. Max length is: 255."
     And I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -376,7 +376,7 @@ Feature: Trigger service tests
     And I create a job with the name "job0"
     When I find scheduler properties with name "Interval Job"
     And A regular trigger creator with the name "schedule0" is created
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -413,7 +413,7 @@ Feature: Trigger service tests
     And A regular trigger creator with the name "" is created
     And The trigger is set to start on "12-12-2020" at "10:10"
     And I set retry interval to 1
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -454,7 +454,7 @@ Feature: Trigger service tests
     When I find scheduler properties with name "Interval Job"
     And A regular trigger creator with the name "" is created
     And The trigger is set to end on "12-12-2020" at "10:10"
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -598,7 +598,7 @@ Feature: Trigger service tests
     When I find scheduler properties with name "Cron Job"
     And A regular trigger creator with the name "schedule0" is created
     Then I set cron expression to "0 15 10 * * ?"
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -635,7 +635,7 @@ Feature: Trigger service tests
     And A regular trigger creator with the name "" is created
     And The trigger is set to start on "12-12-2020" at "10:10"
     Then I set cron expression to "0 15 15 * * ?"
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -676,7 +676,7 @@ Feature: Trigger service tests
     When I find scheduler properties with name "Cron Job"
     And A regular trigger creator with the name "" is created
     And The trigger is set to end on "12-12-2020" at "10:10"
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout

--- a/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
@@ -113,7 +113,7 @@ Feature: User Permission tests
     And I delete the last permission added to the new User
     And I logout
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I search for user with name "kapua-a"
     And An exception was thrown
     And I logout
@@ -150,7 +150,7 @@ Feature: User Permission tests
     And I delete the last permission added to the new User
     And I logout
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I search for user with name "kapua-a"
     Then An exception was thrown
     And I logout
@@ -465,7 +465,7 @@ Feature: User Permission tests
     And I delete the last permission added to the new User
     And I logout
     When I login as user with name "kapua-b" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I search for user with name "kapua-b"
     And An exception was thrown
     And I logout
@@ -930,19 +930,19 @@ Feature: User Permission tests
       | subAccount0 | 1       |
     And I logout
     When I login as user with name "user0" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I search for the account with the remembered account Id
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I modify the account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I delete account "subAccount0"
     And An exception was thrown
     And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I modify the account "kapua-sys"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I delete account "kapua-sys"
     And An exception was thrown
     And I logout
@@ -969,19 +969,19 @@ Feature: User Permission tests
       | subAccount0 | 1       |
     And I logout
     When I login as user with name "user0" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I search for the account with the remembered account Id
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I modify the account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I delete account "subAccount0"
     And An exception was thrown
     And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I modify the account "kapua-sys"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I delete account "kapua-sys"
     And An exception was thrown
     And I logout
@@ -1079,17 +1079,17 @@ Feature: User Permission tests
       | subAccount0 | 1       |
     And I logout
     When I login as user with name "user0" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I search for the account with the remembered account Id
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I modify the account "subAccount0"
     And An exception was thrown
     When I delete account "subAccount0"
     And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I modify the account "kapua-sys"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I delete account "kapua-sys"
     And An exception was thrown
     And I logout
@@ -1122,7 +1122,7 @@ Feature: User Permission tests
     And I modify the account "subAccount0"
     And I delete account "subAccount0"
     And I modify the account "kapua-sys"
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I delete account "kapua-sys"
     And An exception was thrown
     And I logout
@@ -1162,16 +1162,16 @@ Feature: User Permission tests
     When I login as user with name "user1" and password "ToManySecrets123#"
     Then I search for the account with the remembered account Id
     And Account "subAccount1" has 0 children
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I modify the account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I delete account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I modify the account "kapua-sys"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     When I delete account "kapua-sys"
     And An exception was thrown
     Then Account
@@ -1213,19 +1213,19 @@ Feature: User Permission tests
       | account | write  |
     And I logout
     When I login as user with name "user1" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And Account "subAccount1" has 0 children
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I modify the account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I delete account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I modify the account "subAccount1"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I delete account "subAccount1"
     And An exception was thrown
     Then Account
@@ -1271,19 +1271,19 @@ Feature: User Permission tests
       | subAccount10 |
     And I logout
     When I login as user with name "user1" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And Account "subAccount1" has 1 children
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I modify the account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I delete account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I modify the account "subAccount1"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I delete account "subAccount1"
     And An exception was thrown
     And I delete account "subAccount10"
@@ -1326,13 +1326,13 @@ Feature: User Permission tests
     When I login as user with name "user1" and password "ToManySecrets123#"
     And Account "subAccount01" has 0 children
     And I modify the account "subAccount01"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I delete account "subAccount01"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I modify the account "subAccount1"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I delete account "subAccount1"
     And An exception was thrown
     And I logout
@@ -1380,13 +1380,13 @@ Feature: User Permission tests
       | account | read   |
     And I logout
     When I login as user with name "user1" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I search for user with name "user0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I modify the account "subAccount0"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I delete account "subAccount0"
     And An exception was thrown
     And I logout
@@ -1446,22 +1446,22 @@ Feature: User Permission tests
       | 1       | test_role |
     Then I logout
     When I login as user with name "user1" and password "ToManySecrets123#"
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I search for user with name "user1"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I query for devices with Client Id "test_device"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I find a job with name "test_job"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And Tag with name "test_tag" is searched
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I search for the group with name "test_group"
     And An exception was thrown
-    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    Given I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
     And I find a role with name "test_role"
     And An exception was thrown
     And I logout

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -476,6 +476,7 @@ Feature: User role service integration tests
     And The device "test-device-1"
     And I expect the exception "SubjectUnauthorizedException" with the text "Required permission: datastore:read:"
     And I search for data message with id "fake-id"
+    Then An exception was thrown
     And I logout
     And I login as user with name "kapua-sys" and password "kapua-password"
     And I select the domain "datastore"

--- a/service/job/test/src/test/resources/features/JobService.feature
+++ b/service/job/test/src/test/resources/features/JobService.feature
@@ -110,7 +110,7 @@ Feature: Job service CRUD tests
   Kapua should return an error.
 
     Given I prepare a job with name "" and description ""
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
     When I create a new job entity from the existing creator
     And An exception was thrown
 
@@ -183,7 +183,7 @@ Feature: Job service CRUD tests
   Kapua should not return any errors.
 
     Given I prepare a job with name "JjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description "description"
-    Then I expect the exception "KapuaIllegalArgumentException" with the text " An illegal value was provided for the argument jobCreator.name: Value over than allowed max length. Max length is: 255."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text " An illegal value was provided for the argument jobCreator.name: Value over than allowed max length. Max length is: 255."
     When I create a new job entity from the existing creator
     And An exception was thrown
 
@@ -192,7 +192,7 @@ Feature: Job service CRUD tests
   Kapua should return an error. Name is mandatory.
 
     Given I prepare a job with name "" and description "description"
-    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
     When I create a new job entity from the existing creator
     And An exception was thrown
 
@@ -247,7 +247,7 @@ Feature: Job service CRUD tests
     When I create a new job entity from the existing creator
     Then I prepare a job with name "jobName1" and description "jobDescription"
     And I create a new job entity from the existing creator
-    Then I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name jobName already exists."
+    Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name jobName already exists."
     When I change name of job from "jobName1" to "jobName"
     And An exception was thrown
 
@@ -288,7 +288,7 @@ Feature: Job service CRUD tests
   Kapua should return an error.
 
     Given I prepare a job with name "JjobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejob" and description ""
-    Then I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is: 255."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is: 255."
     When I create a new job entity from the existing creator
     And An exception was thrown
 

--- a/service/tag/test/src/test/resources/features/TagService.feature
+++ b/service/tag/test/src/test/resources/features/TagService.feature
@@ -34,9 +34,10 @@ Feature: Tag Service
   Scenario: Creating Non-unique Tag Without Description
   Create a tag with non-unique name without description. Kapua should return Exception.
 
-    Given A tag with name "Tag123" is created
-    When Tag with name "Tag123" is searched
-    Then I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name Tag123 already exists."
+    Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name Tag123 already exists."
+    When I create tag with name "Tag123"
+    And I create tag with name "Tag123"
+    Then An exception was thrown
 
   Scenario: Creating Tag With Short Name Without Description
   Create a tag with short name without description. Kapua should not return any errors.

--- a/translator/test/src/test/resources/features/TranslatorUnitTests.feature
+++ b/translator/test/src/test/resources/features/TranslatorUnitTests.feature
@@ -258,7 +258,7 @@ Feature: Translator Service
   Invalid channel exception should be thrown.
 
     Given I create jms message with empty payload "" and valid topic "kapua-sys"
-    Then I expect the exception "InvalidChannelException" with the text " Invalid channel: kapua-sys"
+    Given I expect the exception "InvalidChannelException" with the text " Invalid channel: kapua-sys"
     When I try to translate jms message to kura data message
     And An exception was thrown
 
@@ -268,7 +268,7 @@ Feature: Translator Service
   Invalid message exception should be thrown
 
     Given I create jms message with valid payload "response.code" and valid topic "kapua-sys/rpione3/DEPLOY-V2/GET/packages"
-    Then I expect the exception "InvalidMessageException" with the text "Invalid message: null"
+    Given I expect the exception "InvalidMessageException" with the text "Invalid message: null"
     When I try to translate invalid jms message to kura data message
     And An exception was thrown
 
@@ -306,7 +306,7 @@ Feature: Translator Service
   Invalid payload exception should be thrown.
 
     Given I create kura data message with channel with scope "kapua-sys", client id "rpione3" and null payload
-    Then I expect the exception "InvalidPayloadException" with the text "Invalid payload: null"
+    Given I expect the exception "InvalidPayloadException" with the text "Invalid payload: null"
     When I try to translate kura data message to jms message
     And An exception was thrown
 
@@ -315,7 +315,7 @@ Feature: Translator Service
   Invalid channel exception should be thrown.
 
     Given I create kura data message with null channel and payload without body and with metrics
-    Then I expect the exception "InvalidChannelException" with the text "Invalid channel: null"
+    Given I expect the exception "InvalidChannelException" with the text "Invalid channel: null"
     When I try to translate kura data message to jms message
     And An exception was thrown
 
@@ -324,8 +324,9 @@ Feature: Translator Service
   Invalid message exception should be thrown.
 
     Given I create kura data message with channel with scope "kapua-sys", client id "rpione3" and payload with body and metrics
-    Then I expect the exception "InvalidMessageException" with the text "Invalid message: null"
+    Given I expect the exception "InvalidMessageException" with the text "Invalid message: null"
     When I try to translate invalid kura data message to jms message
+    Then An exception was thrown
 
 @teardown
   Scenario: Reset Security Context for all scenarios


### PR DESCRIPTION
Some cucumber tests were wrongly written with steps not mapped to real functions where the cucumber engine was inferring a partial mapping to other functions, and/or were handling exceptions in the wrong way, for example with the possibility to produce some false positives by omitting the statement "Then An exception was thrown".

I refactored these tests to correct this
 