### PR TITLE
dependency: bumped version of Apache Commons Compress from 1.22 to 1.24.0 - CVE-2023-42503

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-configuration2.version>2.9.0</commons-configuration2.version>
-        <commons-compress.version>1.22</commons-compress.version>
+        <commons-compress.version>1.24.0</commons-compress.version>
         <commons-fileupload.versison>1.5</commons-fileupload.versison>
         <commons-imaging.version>1.0-alpha3</commons-imaging.version>
         <commons-io.version>2.11.0</commons-io.version>


### PR DESCRIPTION
This PR bump the version of Apache Commons Compress from 1.22 to 1.24.0 solving following CVEs:

- CVE-2023-42503

**Related Issue**
_None_

**Description of the solution adopted**
Changed to the latest version

**Screenshots**
_None_

**Any side note on the changes made**
_None_