### PR TITLE
dependency: bumped Google Guava version from 30.1-jre to 32.1.2-jre - CVE-2020-8908 CVE-2023-2976

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <elasticsearch.version>7.8.1</elasticsearch.version>
         <googleauth.version>1.5.0</googleauth.version>
         <gson.version>2.10</gson.version>
-        <guava.version>30.1-jre</guava.version>
+        <guava.version>32.1.2-jre</guava.version>
         <guava-failureaccess.version>1.0.1</guava-failureaccess.version>
         <guava-listenablefuture.version>9999.0-empty-to-avoid-conflict-with-guava</guava-listenablefuture.version>
         <guice.version>5.1.0</guice.version>


### PR DESCRIPTION
This PR bumps the version of Google Guava from 30.1-jre to 32.1.2-jre solving following CVEs:

- CVE-2020-8908 
- CVE-2023-2976

**Related Issue**
_None_

**Description of the solution adopted**
Updated the version of the dependency

**Screenshots**
_None_

**Any side note on the changes made**
_None_