### PR TITLE
dependency: bumped Snakeyaml from 1.33 to 2.2 - CVE-2022-1471

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.12.0</shiro.version>
         <slf4j.version>1.7.33</slf4j.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <swagger-ui.version>5.3.1</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>


### PR DESCRIPTION
This PR bumps the version of Snakeyaml from 1.33 to 2.2  solving follwing CVEs:

- CVE-2022-1471

**Related Issue**
_None_

**Description of the solution adopted**
Changed the version of the dependency

**Screenshots**
_None_

**Any side note on the changes made**
_None_