### PR TITLE
dependency: bumped Netty versions from 4.1.87.Final to 4.1.97.Final - CVE-2023-34462

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
         <logback.version>1.2.11</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.87.Final</netty.version>
+        <netty.version>4.1.97.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <ow2-asm.version>9.4</ow2-asm.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>


### PR DESCRIPTION
This PR bumps the version of Netty dependencies from 4.1.87.Final to 4.1.97.Final solving following CVEs:

- CVE-2023-34462

**Related Issue**
_None_

**Description of the solution adopted**
Updated dependency version

**Screenshots**
_None_

**Any side note on the changes made**
_None_