### PR TITLE
FIX - Foreign keys liquibase scripts correctly imported and executed

### DIFF
--- a/assembly/api/descriptors/kapua-api-jetty.xml
+++ b/assembly/api/descriptors/kapua-api-jetty.xml
@@ -34,7 +34,6 @@
 
             <includes>
                 <include>${pom.groupId}:kapua-rest-api-web:war</include>
-                <include>${pom.groupId}:kapua-foreignkeys</include>
             </includes>
 
         </dependencySet>

--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -141,10 +141,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-foreignkeys</artifactId>
-        </dependency>
-        <dependency>
             <!-- Google protobuf for message encoding -->
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>

--- a/assembly/console/descriptors/kapua-console-jetty.xml
+++ b/assembly/console/descriptors/kapua-console-jetty.xml
@@ -42,7 +42,6 @@
 
             <includes>
                 <include>${pom.groupId}:kapua-console-web:war</include>
-                <include>${pom.groupId}:kapua-foreignkeys</include>
             </includes>
 
         </dependencySet>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -134,10 +134,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-foreignkeys</artifactId>
-        </dependency>
-        <dependency>
             <!-- Google protobuf for message encoding -->
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>

--- a/assembly/job-engine/descriptors/kapua-job-engine-jetty.xml
+++ b/assembly/job-engine/descriptors/kapua-job-engine-jetty.xml
@@ -34,7 +34,6 @@
 
             <includes>
                 <include>${pom.groupId}:kapua-job-engine-app-web:war</include>
-                <include>${pom.groupId}:kapua-foreignkeys</include>
             </includes>
 
         </dependencySet>

--- a/assembly/job-engine/pom.xml
+++ b/assembly/job-engine/pom.xml
@@ -33,10 +33,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-foreignkeys</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-job-engine-app-web</artifactId>
             <type>war</type>
         </dependency>

--- a/job-engine/app/web/pom.xml
+++ b/job-engine/app/web/pom.xml
@@ -223,6 +223,10 @@
             <artifactId>kapua-endpoint-internal</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-foreignkeys</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-web</artifactId>
         </dependency>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -164,6 +164,10 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-user-internal</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-foreignkeys</artifactId>
+        </dependency>
 
         <!-- Jersey -->
         <dependency>


### PR DESCRIPTION
Brief description of the PR.
I noticed that there were a problems in the project related to the liquibase scripts for the foreign keys (namely, the ones inside the "extra" module):

The way of including those liquibase scripts through the configuration of the assembly descriptors:
![Screenshot 2023-10-09 at 14 49 59](https://github.com/eclipse/kapua/assets/39708353/805f60b9-9388-4401-8576-b832e4f554de)
was wrong because, in order to have in the final container the scripts to run, the right "output directory" should be _var/opt/jetty/webapps/root/WEB-INF/lib_ (the classpath) and not the one present on the screen. This wrong configuration led to the missing of FKs liquibase scripts in some containers (for example, the rest-API container)

**Description of the solution adopted**
For some containers, for example, the console, the FK scripts were imported not through the configuration of the XML descriptor but with a dependency on the FK module, included inside the POM file of the "web application" module, like this: 
![Screenshot 2023-10-09 at 15 09 19](https://github.com/eclipse/kapua/assets/39708353/3f5439aa-8aa4-413b-ad38-67895a9b9c47)
To solve the problem, I decided to uniform this way of importing the scripts in the other containers...also, I think that this is the simpler way to include in the classpath the scripts


