### PR TITLE
FIX - fixed logging for device command execution error when arguments are null

### DIFF
--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
@@ -111,7 +111,11 @@ public class DeviceCommandManagementServiceImpl extends AbstractDeviceManagement
         try {
             responseMessage = commandDeviceCallBuilder.send();
         } catch (Exception e) {
-            LOG.error("Error while executing DeviceCommand {} with arguments {} for Device {}. Error: {}", commandInput.getCommand(), String.join(" ", commandInput.getArguments()), deviceId, e.getMessage(), e);
+            if (commandInput.getArguments() != null) {
+                LOG.error("Error while executing DeviceCommand {} with arguments {} for Device {}. Error: {}", commandInput.getCommand(), String.join(" ", commandInput.getArguments()), deviceId, e.getMessage(), e);
+            } else {
+                LOG.error("Error while executing DeviceCommand {} for Device {}. Error: {}", commandInput.getCommand(), deviceId, e.getMessage(), e);
+            }
             throw e;
         }
 


### PR DESCRIPTION
Brief description of the PR.
If you tried to send a Command without arguments to a device that was not connected (or it has been just seeded from the UI and therefore not having a DeviceConnection) this caused a NPE when logging the error because no check was performed on the NULL values of the arguments.

I added such check to better handle the logging of the error 

