### PR TITLE
Fixed Docker Compose SSL enablement

### DIFF
--- a/assembly/jetty-base/entrypoint/run-jetty
+++ b/assembly/jetty-base/entrypoint/run-jetty
@@ -24,9 +24,9 @@ START_ARGS="$START_ARGS -Djetty.base=${JETTY_BASE}"
 
 # Certificate Options
 
-: ${KAPUA_DISABLE_SSL:="true"}
+: ${KAPUA_SSL_ENABLE:="false"}
 
-if [ "${KAPUA_DISABLE_SSL}" == "false" ]; then
+if [ "${KAPUA_SSL_ENABLE}" == "true" ]; then
     # Keystore configuration
     CERTIFICATES_PATH="tls"
     if [ ! -d "${JETTY_BASE}/${CERTIFICATES_PATH}" ]; then

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -152,7 +152,7 @@ Following ports will be opened
 
 ### Enabling JMX mode
 
-Containers can be accessed via JMX. For example, you can use it to analyse the JVM using jConsole. 
+Containers can be accessed via JMX. For example, you can use it to analyse the JVM using jConsole.
 To enable it, provide the `--jmx` option.
 
 Example:
@@ -209,9 +209,9 @@ By adding this option Kapua will be deployed with an instance of [Keycloak](http
 
 The Keycloack instance can be accessed at the following endpoints:
 
-| Application/Service | Endpoint       | User  | Password | Notes             |
-|---------------------|----------------|-------|----------|-------------------|
-| Keycloak Console    | localhost:9090 | admin | admin    |                   |
+| Application/Service | Endpoint       | User  | Password | Notes |
+|---------------------|----------------|-------|----------|-------|
+| Keycloak Console    | localhost:9090 | admin | admin    |       |
 
 This option is not available on Windows OS at the moment.
 
@@ -219,12 +219,12 @@ This option is not available on Windows OS at the moment.
 
 ### Enabling SSL
 
-To enable SSL in the Jetty (Console and REST API) and Broker containers, set the `KAPUA_DISABLE_SSL` environment
-variable to `false`, and other variables according to the desired behavior, **before** running the `docker-deploy.sh`
+To enable SSL in the Jetty (Console and REST API) and Broker containers, set the `KAPUA_SSL_ENABLE` environment
+variable to `true`, and other variables according to the desired behavior, **before** running the `docker-deploy.sh`
 script:
 
 ```bash
-export KAPUA_DISABLE_SSL=false
+export KAPUA_SSL_ENABLE=true
 ```
 
 Additionally, the SSL can be configured in two ways: providing a certificate, a private key and an optional CA chain, or

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -219,16 +219,18 @@ This option is not available on Windows OS at the moment.
 
 ### Enabling SSL
 
-To enable SSL in the Jetty (Console and REST API) and Broker containers, set the `KAPUA_SSL_ENABLE` environment
-variable to `true`, and other variables according to the desired behavior, **before** running the `docker-deploy.sh`
-script:
+Kapua can be deployed with an SSL enabled. To enable it, provide the `--ssl` option.
 
-```bash
-export KAPUA_SSL_ENABLE=true
-```
+SSL will be enabled for the following services
 
-Additionally, the SSL can be configured in two ways: providing a certificate, a private key and an optional CA chain, or
-providing a keystore.
+| Application/Service | Endpoint          |
+|---------------------|-------------------|
+| Message Broker      | To be implemented |
+| Admin WEB Console   | localhost:8443    |
+| REST API endpoint   | localhost:8444    |
+
+The `--ssl` options configures a self-signed keypair created on the fly.
+If you want to provide your certificates, follow the instruction below.
 
 ##### Providing certificates and private key
 

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -31,7 +31,6 @@ services:
     ports:
       - "1883:1883"
       - "1893:1893"
-      - "8883:8883"
       - "5682:5672"
       - "61616:61616"
     depends_on:
@@ -39,14 +38,7 @@ services:
       - events-broker
     environment:
       - CRYPTO_SECRET_KEY
-      - KAPUA_SSL_ENABLE
       - KAPUA_DISABLE_DATASTORE
-      - KAPUA_CRT
-      - KAPUA_CA
-      - KAPUA_KEY
-      - KAPUA_KEY_PASSWORD
-      - KAPUA_KEYSTORE
-      - KAPUA_KEYSTORE_PASSWORD
       - LOGBACK_LOG_LEVEL
   service-authentication:
     image: kapua/kapua-service-authentication:${IMAGE_VERSION}
@@ -90,7 +82,6 @@ services:
     image: kapua/kapua-console:${IMAGE_VERSION}
     ports:
       - "8080:8080"
-      - "8443:8443"
     depends_on:
       - db
       - es
@@ -99,13 +90,6 @@ services:
     environment:
       - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_DATASTORE
-      - KAPUA_SSL_ENABLE
-      - KAPUA_CA
-      - KAPUA_CRT
-      - KAPUA_KEY
-      - KAPUA_KEY_PASSWORD
-      - KAPUA_KEYSTORE
-      - KAPUA_KEYSTORE_PASSWORD
       - LOGBACK_LOG_LEVEL
       - KAPUA_CONSOLE_URL
       - KAPUA_OPENID_JWT_ISSUER
@@ -133,13 +117,6 @@ services:
       - API_CORS_ORIGINS_ALLOWED
       - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_DATASTORE
-      - KAPUA_SSL_ENABLE
-      - KAPUA_CA
-      - KAPUA_CRT
-      - KAPUA_KEY
-      - KAPUA_KEY_PASSWORD
-      - KAPUA_KEYSTORE
-      - KAPUA_KEYSTORE_PASSWORD
       - LOGBACK_LOG_LEVEL
       - SWAGGER=${KAPUA_SWAGGER_ENABLE:-true}
   job-engine:
@@ -154,11 +131,4 @@ services:
     environment:
       - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_DATASTORE
-      - KAPUA_SSL_ENABLE
-      - KAPUA_CA
-      - KAPUA_CRT
-      - KAPUA_KEY
-      - KAPUA_KEY_PASSWORD
-      - KAPUA_KEYSTORE
-      - KAPUA_KEYSTORE_PASSWORD
       - LOGBACK_LOG_LEVEL

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - events-broker
     environment:
       - CRYPTO_SECRET_KEY
-      - KAPUA_DISABLE_SSL
+      - KAPUA_SSL_ENABLE
       - KAPUA_DISABLE_DATASTORE
       - KAPUA_CRT
       - KAPUA_CA
@@ -98,8 +98,8 @@ services:
       - message-broker
     environment:
       - CRYPTO_SECRET_KEY
-      - KAPUA_DISABLE_SSL
       - KAPUA_DISABLE_DATASTORE
+      - KAPUA_SSL_ENABLE
       - KAPUA_CA
       - KAPUA_CRT
       - KAPUA_KEY
@@ -132,8 +132,8 @@ services:
     environment:
       - API_CORS_ORIGINS_ALLOWED
       - CRYPTO_SECRET_KEY
-      - KAPUA_DISABLE_SSL
       - KAPUA_DISABLE_DATASTORE
+      - KAPUA_SSL_ENABLE
       - KAPUA_CA
       - KAPUA_CRT
       - KAPUA_KEY
@@ -153,8 +153,8 @@ services:
       - message-broker
     environment:
       - CRYPTO_SECRET_KEY
-      - KAPUA_DISABLE_SSL
       - KAPUA_DISABLE_DATASTORE
+      - KAPUA_SSL_ENABLE
       - KAPUA_CA
       - KAPUA_CRT
       - KAPUA_KEY

--- a/deployment/docker/compose/extras/docker-compose.broker-ssl.yml
+++ b/deployment/docker/compose/extras/docker-compose.broker-ssl.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+
+services:
+  message-broker:
+    ports:
+      - "8883:8883"
+    environment:
+      - KAPUA_SSL_ENABLE=true
+      - KAPUA_CA
+      - KAPUA_CRT
+      - KAPUA_KEY
+      - KAPUA_KEY_PASSWORD
+      - KAPUA_KEYSTORE
+      - KAPUA_KEYSTORE_PASSWORD

--- a/deployment/docker/compose/extras/docker-compose.console-ssl.yml
+++ b/deployment/docker/compose/extras/docker-compose.console-ssl.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+
+services:
+  kapua-console:
+    ports:
+      - "8443:8443"
+    environment:
+      - KAPUA_SSL_ENABLE=true
+      - KAPUA_CA
+      - KAPUA_CRT
+      - KAPUA_KEY
+      - KAPUA_KEY_PASSWORD
+      - KAPUA_KEYSTORE
+      - KAPUA_KEYSTORE_PASSWORD

--- a/deployment/docker/compose/extras/docker-compose.rest-ssl.yml
+++ b/deployment/docker/compose/extras/docker-compose.rest-ssl.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+
+services:
+  kapua-api:
+    ports:
+      - "8444:8443"
+    environment:
+      - KAPUA_SSL_ENABLE=true
+      - KAPUA_CA
+      - KAPUA_CRT
+      - KAPUA_KEY
+      - KAPUA_KEY_PASSWORD
+      - KAPUA_KEYSTORE
+      - KAPUA_KEYSTORE_PASSWORD

--- a/deployment/docker/unix/configure-certificates.sh
+++ b/deployment/docker/unix/configure-certificates.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+###############################################################################
+# Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech
+###############################################################################
+
+set -eo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+docker_common() {
+    . "${SCRIPT_DIR}"/docker-common.sh
+}
+
+create_certificates() {
+    if [[ ! -f "${KAPUA_CRT_DIR}/${KAPUA_CERT_FILE}" ]]; then
+        openssl req -x509 -newkey rsa:4096 -keyout "${KAPUA_CRT_DIR}/${KAPUA_KEY_FILE}" -out "${KAPUA_CRT_DIR}/${KAPUA_CERT_FILE}" -days 365 -nodes -subj "/CN=Kapua"
+    fi
+
+    export KAPUA_CRT="${KAPUA_CRT:=$(cat "${KAPUA_CRT_DIR}"/"${KAPUA_CERT_FILE}")}"
+    export KAPUA_KEY="${KAPUA_KEY:=$(cat "${KAPUA_CRT_DIR}"/"${KAPUA_KEY_FILE}")}"
+    export KAPUA_CA="${KAPUA_CA:=$(cat "${KAPUA_CRT_DIR}"/"${KAPUA_CA_FILE}")}"
+}
+
+docker_common
+
+echo "Creating Certificates..."
+create_certificates || {
+  echo "Creating Certificates... ERROR!";
+  exit 1;
+}
+echo "Creating Certificates... DONE!"

--- a/deployment/docker/unix/docker-common.sh
+++ b/deployment/docker/unix/docker-common.sh
@@ -17,3 +17,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export IMAGE_VERSION=${IMAGE_VERSION:=2.0.0-SNAPSHOT}
 export CRYPTO_SECRET_KEY="${CRYPTO_SECRET_KEY:=dockerSecretKey!}"
+
+# Certificates
+export KAPUA_CRT_DIR="${KAPUA_CRT_DIR:=$(mktemp -d)}"
+export KAPUA_CERT_FILE="${KAPUA_CERT_FILE:=cert.pem}"
+export KAPUA_KEY_FILE="${KAPUA_KEY_FILE:=key.pem}"
+export KAPUA_CA_FILE="${KAPUA_CA_FILE:=cert.pem}"

--- a/deployment/docker/unix/docker-deploy.sh
+++ b/deployment/docker/unix/docker-deploy.sh
@@ -55,8 +55,14 @@ docker_compose() {
       COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.db-dev.yml")
     fi
 
-    # SSO Mode
+    # SSL
     if [[ "$4" == true ]]; then
+      echo "SSL enabled!"
+    fi
+    export KAPUA_SSL_ENABLE=$4
+
+    # SSO Mode
+    if [[ "$5" == true ]]; then
       echo "SSO enabled!"
       . "${SCRIPT_DIR}/sso/docker-sso-config.sh"
 
@@ -65,22 +71,23 @@ docker_compose() {
     fi
 
     # Swagger UI
-    if [[ "$5" == false ]]; then
+    if [[ "$6" == false ]]; then
       echo "Swagger disabled!"
     fi
-    export KAPUA_SWAGGER_ENABLE=$5
+    export KAPUA_SWAGGER_ENABLE=$6
 
     docker-compose -f "${SCRIPT_DIR}/../compose/docker-compose.yml" "${COMPOSE_FILES[@]}" up -d
 }
 
 print_usage_deploy() {
-    echo "Usage: $(basename "$0") [-h|--help] [--dev] [--debug] [--jmx] [--logs] [--sso] [--no-swagger]" >&2
+    echo "Usage: $(basename "$0") [-h|--help] [--dev] [--debug] [--jmx] [--logs] [--ssl] [--sso] [--no-swagger]" >&2
 }
 
 DEBUG_MODE=false
 DEV_MODE=false
 OPEN_LOGS=false
 JMX_MODE=false
+SSL_MODE=false
 SSO_MODE=false
 SWAGGER=true
 for option in "$@"; do
@@ -101,6 +108,9 @@ for option in "$@"; do
     --jmx)
       JMX_MODE=true
       ;;
+    --ssl)
+      SSL_MODE=true
+        ;;
     --sso)
       SSO_MODE=true
       ;;
@@ -119,8 +129,13 @@ done
 
 docker_common
 
+# Configure certificates if required
+if [[ ${SSL_MODE} == true ]]; then
+    . "${SCRIPT_DIR}/configure-certificates.sh"
+fi
+
 echo "Deploying Eclipse Kapua version $IMAGE_VERSION..."
-docker_compose ${DEBUG_MODE} ${JMX_MODE} ${DEV_MODE} ${SSO_MODE} ${SWAGGER} || {
+docker_compose ${DEBUG_MODE} ${JMX_MODE} ${DEV_MODE} ${SSL_MODE} ${SSO_MODE} ${SWAGGER} || {
     echo "Deploying Eclipse Kapua... ERROR!"
     exit 1
 }

--- a/deployment/docker/unix/docker-deploy.sh
+++ b/deployment/docker/unix/docker-deploy.sh
@@ -58,8 +58,10 @@ docker_compose() {
     # SSL
     if [[ "$4" == true ]]; then
       echo "SSL enabled!"
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.broker-ssl.yml")
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.console-ssl.yml")
+      COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.rest-ssl.yml")
     fi
-    export KAPUA_SSL_ENABLE=$4
 
     # SSO Mode
     if [[ "$5" == true ]]; then


### PR DESCRIPTION
Fixed the enablement of the SSL for deployed components in Docker Compose.

**Related Issue**
_None_

**Description of the solution adopted**

- Renamed `KAPUA_DISABLE_SSL` to `KAPUA_SSL_ENABLE` for the sake of simplicity and clearness
- Added on-the-fly creation of keypair
- Updated documentation

**Screenshots**
_None_

**Any side note on the changes made**
MessageBroker component does not currently support SSL enablement