### PR TITLE
FIX - Added missing findByExternalUsername method

### DIFF
--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserRepository.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserRepository.java
@@ -21,4 +21,7 @@ public interface UserRepository extends
         KapuaNamedEntityRepository<User, UserListResult> {
 
     Optional<User> findByExternalId(TxContext txContext, final String externalId);
+
+    Optional<User> findByExternalUsername(TxContext txContext, final String externalUsername);
+
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCachedRepository.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCachedRepository.java
@@ -37,4 +37,13 @@ public class UserCachedRepository
         found.ifPresent(entityCache::put);
         return found;
     }
+
+    @Override
+    public Optional<User> findByExternalUsername(TxContext txContext, String externalUsername) {
+        final Optional<User> found = wrapped.findByExternalUsername(txContext, externalUsername);
+        found.ifPresent(entityCache::put);
+        return found;
+    }
+
+
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserImplJpaRepository.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserImplJpaRepository.java
@@ -34,4 +34,10 @@ public class UserImplJpaRepository
     public Optional<User> findByExternalId(TxContext txContext, String externalId) {
         return doFindByField(txContext, KapuaId.ANY, UserAttributes.EXTERNAL_ID, externalId);
     }
+
+    @Override
+    public Optional<User> findByExternalUsername(TxContext txContext, String externalUsername) {
+        return doFindByField(txContext, KapuaId.ANY, UserAttributes.EXTERNAL_USERNAME, externalUsername);
+    }
+
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -303,7 +303,7 @@ public class UserServiceImpl extends KapuaConfigurableServiceBase implements Use
         // Validation of the fields
         ArgumentValidator.notEmptyOrNull(externalUsername, "externalUsername");
         // Do the find
-        return checkReadAccess(txManager.execute(tx -> userRepository.findByExternalId(tx, externalUsername)))
+        return checkReadAccess(txManager.execute(tx -> userRepository.findByExternalUsername(tx, externalUsername)))
                 .orElse(null);
     }
 


### PR DESCRIPTION
Brief description of the PR.
The _findByExternalUsername_ method inside the UserServiceImpl was calling erroneously the _findByExternalId_ method of the UserRepository interface instead of the _findByExternalUsername_ method, which was not present at all in it. 
With this PR the missing method has been inserted into the repository interface and into all the implementation classes