### PR TITLE
Bump `jetty` version from `9.4.52.v20230823` to `9.4.53.v20231009` - `CVE-2023-36478`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <jaxb-impl.version>2.3.6</jaxb-impl.version>
         <jbatch.version>1.0.2</jbatch.version>
         <jersey.version>2.38</jersey.version>
-        <jetty.version>9.4.52.v20230823</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.10</jose4j.version>


### PR DESCRIPTION
This PR bumps the version of `Eclipse Jetty` dependencies from `9.4.52.v20230823` to `9.4.53.v20231009` solving CVE-2023-36478.