### PR TITLE
chng(deviceConnection): moved DeviceConnectionServiceConfigurationManager into dedicated module

### DIFF
--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceConnectionServiceConfigurationModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceConnectionServiceConfigurationModule.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry;
+
+import com.google.inject.Provides;
+import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableServiceCache;
+import org.eclipse.kapua.commons.configuration.CachingServiceConfigRepository;
+import org.eclipse.kapua.commons.configuration.RootUserTester;
+import org.eclipse.kapua.commons.configuration.ServiceConfigImplJpaRepository;
+import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
+import org.eclipse.kapua.commons.configuration.ServiceConfigurationManagerCachingWrapper;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
+import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
+import org.eclipse.kapua.service.device.authentication.api.DeviceConnectionCredentialAdapter;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionServiceConfigurationManager;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Map;
+
+/**
+ * {@link DeviceConnectionServiceConfigurationManager}'s {@link AbstractKapuaModule}.
+ *
+ * @since 2.0.0
+ */
+public class DeviceConnectionServiceConfigurationModule extends AbstractKapuaModule {
+
+    @Override
+    protected void configureModule() {
+        // Nothing to bind here
+    }
+
+    @Provides
+    @Singleton
+    @Named("DeviceConnectionServiceConfigurationManager")
+    ServiceConfigurationManager deviceConnectionServiceConfigurationManager(
+            RootUserTester rootUserTester,
+            KapuaJpaRepositoryConfiguration jpaRepoConfig,
+            Map<String, DeviceConnectionCredentialAdapter> availableDeviceConnectionAdapters,
+            KapuaMetatypeFactory kapuaMetatypeFactory) {
+        return new ServiceConfigurationManagerCachingWrapper(
+                new DeviceConnectionServiceConfigurationManager(
+                        new CachingServiceConfigRepository(
+                                new ServiceConfigImplJpaRepository(jpaRepoConfig),
+                                new AbstractKapuaConfigurableServiceCache().createCache()
+                        ),
+                        rootUserTester,
+                        availableDeviceConnectionAdapters,
+                        kapuaMetatypeFactory)
+        );
+    }
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
@@ -44,7 +44,6 @@ import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionServ
 import org.eclipse.kapua.service.device.registry.connection.internal.CachingDeviceConnectionRepository;
 import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionFactoryImpl;
 import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionImplJpaRepository;
-import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionServiceConfigurationManager;
 import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionServiceImpl;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionRepository;
@@ -71,7 +70,13 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Map;
 
+/**
+ * kapua-device-registry-internal's {@link AbstractKapuaModule}
+ *
+ * @since 2.0.0
+ */
 public class DeviceRegistryModule extends AbstractKapuaModule {
+
     @Override
     protected void configureModule() {
         bind(DeviceRegistryCacheFactory.class).toInstance(new DeviceRegistryCacheFactory());
@@ -183,23 +188,6 @@ public class DeviceRegistryModule extends AbstractKapuaModule {
                 jpaTxManagerFactory.create("kapua-device"),
                 repository,
                 availableDeviceConnectionAdapters);
-    }
-
-    @Provides
-    @Singleton
-    @Named("DeviceConnectionServiceConfigurationManager")
-    ServiceConfigurationManager deviceConnectionServiceConfigurationManager(
-            RootUserTester rootUserTester,
-            KapuaJpaRepositoryConfiguration jpaRepoConfig,
-            Map<String, DeviceConnectionCredentialAdapter> availableDeviceConnectionAdapters,
-            KapuaMetatypeFactory kapuaMetatypeFactory) {
-        return new ServiceConfigurationManagerCachingWrapper(
-                new DeviceConnectionServiceConfigurationManager(
-                        new CachingServiceConfigRepository(
-                                new ServiceConfigImplJpaRepository(jpaRepoConfig),
-                                new AbstractKapuaConfigurableServiceCache().createCache()
-                        ),
-                        rootUserTester, availableDeviceConnectionAdapters, kapuaMetatypeFactory));
     }
 
     @Provides

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceConfigurationManager.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceConfigurationManager.java
@@ -83,11 +83,7 @@ public class DeviceConnectionServiceConfigurationManager extends ServiceConfigur
         KapuaTocd deviceConnectionServiceConfigDefinition = super.getConfigMetadata(txContext, scopeId, excludeDisabled);
 
         // Find the 'deviceConnectionAuthenticationType' KapuaTad
-        Optional<KapuaTad> authenticationTypeConfigDefinition = deviceConnectionServiceConfigDefinition
-                .getAD()
-                .stream()
-                .filter(kapuaTad -> "deviceConnectionAuthenticationType".equals(kapuaTad.getId()))
-                .findFirst();
+        Optional<KapuaTad> authenticationTypeConfigDefinition = findAuthenticationTypeTad(deviceConnectionServiceConfigDefinition);
 
         // Add the KapuaToption to the KapuaTad
         authenticationTypeConfigDefinition.ifPresent(tad -> {
@@ -110,5 +106,20 @@ public class DeviceConnectionServiceConfigurationManager extends ServiceConfigur
         });
 
         return deviceConnectionServiceConfigDefinition;
+    }
+
+    /**
+     * Looks for the {@link KapuaTad} with 'deviceConnectionAuthenticationType' {@link KapuaTad#getId()}.
+     *
+     * @param deviceConnectionServiceConfigDefinition The {@link DeviceConnectionService} {@link KapuaTad}.
+     * @return The {@link Optional} {@link KapuaTad}
+     * @since 2.0.0
+     */
+    protected Optional<KapuaTad> findAuthenticationTypeTad(KapuaTocd deviceConnectionServiceConfigDefinition) {
+        return deviceConnectionServiceConfigDefinition
+                .getAD()
+                .stream()
+                .filter(kapuaTad -> "deviceConnectionAuthenticationType".equals(kapuaTad.getId()))
+                .findFirst();
     }
 }

--- a/service/device/registry/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService.xml
+++ b/service/device/registry/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService.xml
@@ -35,7 +35,7 @@
             cardinality="0"
             required="true"
             allowSelfEdit="true"
-            description="Default device connection authentication type. The selected strategy to use when a new device connection performs a login">
+            description="Default device authentication type. The type of authentication to apply by default when a new device performs a connection. Allowed value is USER_PASS (username and password). Check the device is configured to support the desired authentication type.">
             <!-- 'options' and 'default' value are programmatically defined by the DeviceConnectionServiceConfigurationManager.getConfigMetadata-->
         </AD>
 


### PR DESCRIPTION
Moved the `DeviceConnectionServiceConfigurationManager` to a dedicated module to able to customise the `DeviceConnectionService` `ServiceConfiguration` `deviceConnectionAuthenticationType` property and others, without requiring the user to override the full `DeviceRegistryModule`.

**Related Issue**
_None_

**Description of the solution adopted**
Created a new module dedicated to the `DeviceConnectionServiceConfigurationManager`.

**Screenshots**
_None_

**Any side note on the changes made**
_None_