### PR TITLE
fix: cve2023-46604

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Dependencies versions -->
-        <activemq.version>5.14.5</activemq.version>
+        <activemq.version>5.16.7</activemq.version>
         <aopalliance.version>1.0</aopalliance.version>
         <artemis.version>2.19.0</artemis.version>
         <assertj.version>3.2.0</assertj.version>


### PR DESCRIPTION
Brief description of the PR.
upgrade ActiveMQ to fix cve2023-46604

**Related Issue**
none

**Description of the solution adopted**
upgrade ActiveMQ to 5.16.7

**Screenshots**
none

**Any side note on the changes made**
backport to 1.6.x and ?
