### PR TITLE
fix(openapi): fixes SetResult documentation

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection.yaml
@@ -166,7 +166,7 @@ components:
         - 'NULL'
     connectionAuthAdapters:
       allOf:
-        - $ref: '../openapi.yaml#/components/schemas/kapuaSetResult'
+        - $ref: '../openapi.yaml#/components/schemas/setResult'
       example:
         items:
           - USER_PASS

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -633,12 +633,13 @@ components:
         count:
           type: integer
           description: The total count of the Entities available in the Scope
-    kapuaSetResult:
+    setResult:
       type: object
       properties:
-        elements:
+        items:
           type: array
-          description: A set of values
+          items:
+            type: string
     ### Schema used in different yaml definitions, placed here for problems with swagger reference resolution ###
     action:
       type: string
@@ -1011,7 +1012,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/kapuaSetResult'
+            $ref: '#/components/schemas/setResult'
     ### Errors ###
     kapuaError:
       description: An error occurred while performing the request


### PR DESCRIPTION
This PR fixes the OpenAPI documentation of the `SetResult` class which was introduced in https://github.com/eclipse/kapua/pull/3889

**Related Issue**
This PR fixes an issue introduced in https://github.com/eclipse/kapua/pull/3889

**Description of the solution adopted**
Mapped correctly the class

**Screenshots**
_None_

**Any side note on the changes made**
_None_