### PR TITLE
Fix `broker` crash on `1.7.x` due to missing dependency 

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -170,6 +170,7 @@
                 <include>commons-collections:commons-collections</include>
                 <include>commons-configuration:commons-configuration</include>
                 <include>commons-io:commons-io</include>
+                <include>commons-lang:commons-lang</include>
 
                 <include>io.dropwizard.metrics:metrics-core</include>
                 <include>io.netty:netty</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -392,6 +392,11 @@
             <artifactId>javax.annotation-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>


### PR DESCRIPTION
This PR adds the missing dependency `commons-lang:commons-lang` into the broker.
In the codebase both `commons-lang:commons-lang` and `org.apache.commons:commons-lang3` are used, but the first were missing from the dependency.
In a future PR it might be useful to port all the code to `org.apache.commons:commons-lang3`.