### PR TITLE
FIX - scopeID definition in openapi file

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -457,7 +457,7 @@ components:
       schema:
         allOf:
           - $ref: '#/components/schemas/kapuaId'
-          - default: _
+        default: _
       required: true
     limit:
       name: limit


### PR DESCRIPTION
On swaggerUI sometimes it happens that if you open a certain path/operation you can see, for example, that the scopeID field is not shown with the “_” default value. Furthermore, trying to call the operation inside swagger fails in an infinite loop. Refreshing the page the thing is fixed. This error can be emulated in this swagger UI https://api-qat-1.dev.everyware.io/doc/#/.

Initially, I thought this was a problem regarding the swaggerUI version we use but in the end, after trying to update it to the latest version, I started to realize that maybe there was a problem with the definition of the scopeID in the openAPI.yaml file.

Syntactically, the definition should not be wrong (in fact, for example, is not signaled in the various warnings that swagger shows regarding syntactic problems) but at the same time if I change it as I've done in this PR the problem I exposed above is fixed. I suppose this problem is caused by the fact the the "allOf" operator (https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#allof) expects schemas in input, and the "default" operator is not technically a schema. But at the same time, I've seen in other parts of the API definition a similar thing done with other operators that are not "schemas" and the result is not wrong. 

In the end, the mod. I've done is AT WORST equivalent to the previous scopeID definition BUT with this mod. the problem I exposed is solved.