### PR TITLE
FIX - CI configuration improvements

### DIFF
--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -20,8 +20,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - run: mvn -v
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
       - run: bash <(curl -s https://codecov.io/bash)
@@ -38,8 +36,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -60,8 +56,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -82,8 +76,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -104,8 +96,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -126,8 +116,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -148,8 +136,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -170,8 +156,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -192,8 +176,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -214,8 +196,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -236,8 +216,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -258,8 +236,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -280,8 +256,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -302,8 +276,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -324,8 +296,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -346,8 +316,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -368,8 +336,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -390,8 +356,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -412,8 +376,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -434,8 +396,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -456,8 +416,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
         with:
           timeout_minutes: 30
@@ -478,7 +436,5 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - run: mvn -B -DskipTests install javadoc:jar
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -16,7 +16,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository
@@ -35,7 +34,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -58,7 +56,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -81,7 +78,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -104,7 +100,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -127,7 +122,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -150,7 +144,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -173,7 +166,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -196,7 +188,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -219,7 +210,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -242,7 +232,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -265,7 +254,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -288,7 +276,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -311,7 +298,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -334,7 +320,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -357,7 +342,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -380,7 +364,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -403,7 +386,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -426,7 +408,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -449,7 +430,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -472,7 +452,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -495,7 +474,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - run: mvn -v
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -191,7 +191,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -213,7 +213,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -235,7 +235,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -279,7 +279,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -301,7 +301,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -323,7 +323,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -345,7 +345,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -367,7 +367,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -389,7 +389,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -411,7 +411,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -433,7 +433,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -455,7 +455,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: nick-fields/retry@v2.8.1
@@ -477,7 +477,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
           restore-keys: |
             ${{ runner.os }}-maven-
       - run: mvn -B -DskipTests install javadoc:jar


### PR DESCRIPTION
Basically, this PR is a "partial" port of this previous PR merged in develop https://github.com/eclipse/kapua/pull/3785 that involved a lot of optimizations in the ci configuration.

Here, I changed these aspects of the configuration:

1. The caching mechanism was redundant between the _actions/setup-java@v3_ and _actions/cache@v3_ gitActions. I removed the caching in the first one to only have it in the second one.
2. The key used for the caching was wrong, for the same reason explained in point 4 of the pr https://github.com/eclipse/kapua/pull/3785. I corrected it in the same way introducing the same "pr-commit-unique" key. 
3. removed the restore-key parameter that was afflitected by the same problem of the point 3.