### PR TITLE
FIX - recently introduced junit tests poorly written

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.10</jose4j.version>
         <junit.version>4.13.2</junit.version>
+        <jupiter.version>5.9.2</jupiter.version>
         <liquibase.version>3.6.3</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
@@ -1808,6 +1809,11 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${jupiter.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenCredentialsHandlerTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenCredentialsHandlerTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
 import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationException;
 import org.eclipse.kapua.service.authentication.shiro.AccessTokenCredentialsImpl;
@@ -21,7 +22,9 @@ import org.eclipse.kapua.service.authentication.shiro.realm.model.NotProcessable
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class AccessTokenCredentialsHandlerTest {
 
     AccessTokenCredentialsHandler instance;

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsHandlerTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsHandlerTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
 import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationException;
 import org.eclipse.kapua.service.authentication.shiro.ApiKeyCredentialsImpl;
@@ -21,7 +22,9 @@ import org.eclipse.kapua.service.authentication.shiro.realm.model.NotProcessable
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class ApiKeyCredentialsHandlerTest {
 
     ApiKeyCredentialsHandler instance;

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsHandlerTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsHandlerTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.eclipse.kapua.service.authentication.JwtCredentials;
 import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationException;
 import org.eclipse.kapua.service.authentication.shiro.JwtCredentialsImpl;
@@ -21,7 +22,9 @@ import org.eclipse.kapua.service.authentication.shiro.realm.model.NotProcessable
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class JwtCredentialsHandlerTest {
 
     JwtCredentialsHandler instance;

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsHandlerTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsHandlerTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationException;
 import org.eclipse.kapua.service.authentication.shiro.UsernamePasswordCredentialsImpl;
@@ -21,7 +22,9 @@ import org.eclipse.kapua.service.authentication.shiro.realm.model.UsernamePasswo
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class UserPassCredentialsHandlerTest {
 
     UserPassCredentialsHandler instance;

--- a/service/tag/internal/pom.xml
+++ b/service/tag/internal/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/service/tag/internal/src/test/java/org/eclipse/kapua/service/tag/internal/TagServiceImplTest.java
+++ b/service/tag/internal/src/test/java/org/eclipse/kapua/service/tag/internal/TagServiceImplTest.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdImpl;
-import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
@@ -27,7 +26,6 @@ import org.eclipse.kapua.service.tag.TagFactory;
 import org.eclipse.kapua.service.tag.TagRepository;
 import org.eclipse.kapua.storage.TxContext;
 import org.eclipse.kapua.storage.TxManager;
-import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +35,7 @@ import org.mockito.Mockito;
 import java.math.BigInteger;
 import java.util.function.BiConsumer;
 
-@Category(JUnitTests.class)
+@org.junit.jupiter.api.Tag("org.eclipse.kapua.qa.markers.junit.JUnitTests")
 public class TagServiceImplTest {
 
     private static final MockSettings FAIL_ON_UNPREDICTED_METHOD_CALL = Mockito.withSettings()


### PR DESCRIPTION
Brief description of the PR.
I found that some recently introduced junit tests were executed even when, on cli, I was specifying their exclusion. (via the -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' command, as decided in our configuration of gitActions for the CI). Some of these tests are made with junit 4 and one of them is made with junit 5.

As a consequence of this problem, it would be annoying to have all the jobs on our CI executing these tests because, other than the little performance penalty, if they fail they will fail all the CI jobs.

**Description of the solution adopted**
I simply added the missing "Category" tag in the junit 4 tests. For the junit 5 test, I needed the new "category" tag used in this version, namely "Tag". Luckily, surefire behaves in the same way of junit 4 tests when you specify on the CLI the -Dgroups setting, so you can include/exclude this test with the same setting. Furthermore, I noticed that the module for this last test was specifying the dependency to Jupiter with an hardcoded version and I changed this to a root-pom-versioning 

**Hopw it has been tested**
I verified locally that these tests are correclty executed when included and when not
