### PR TITLE
fix(datastore): improve performances on messages store

### DIFF
--- a/qa/integration/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/integration/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -47,7 +47,7 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", messageUniquenessCheck "FULL"
     And System property "datastore.index.window" with value "day"
     When I delete all indices
     And I select account "kapua-sys"
@@ -66,7 +66,7 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", messageUniquenessCheck "FULL"
     And System property "datastore.index.window" with value "hour"
     When I delete all indices
     And I select account "kapua-sys"
@@ -84,7 +84,7 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", messageUniquenessCheck "FULL"
     And System property "datastore.index.window" with value "week"
     When I delete all indices
     And I select account "kapua-sys"
@@ -105,7 +105,7 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", messageUniquenessCheck "FULL"
     And System property "datastore.index.window" with value "day"
     When I delete all indices
     And I select account "kapua-sys"
@@ -126,7 +126,7 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", messageUniquenessCheck "FULL"
     And System property "datastore.index.window" with value "hour"
     When I delete all indices
     And I select account "kapua-sys"
@@ -146,7 +146,7 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", messageUniquenessCheck "FULL"
     And System property "datastore.index.window" with value "week"
     And I configure account service
       | type    | name                   | value |

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
@@ -15,6 +15,7 @@ package org.eclipse.kapua.service.datastore.internal.mediator;
 
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.service.datastore.internal.model.DataIndexBy;
+import org.eclipse.kapua.service.datastore.internal.model.MessageUniquenessCheck;
 import org.eclipse.kapua.service.datastore.internal.model.metric.MetricsIndexBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +71,12 @@ public class MessageStoreConfiguration {
     public static final String CONFIGURATION_METRICS_INDEX_BY_KEY = "metricsIndexBy";
 
     /**
+     * Message Uniqueness Check key (available options are in MessageUniquenessCheck enumeration).<br>
+     * <b>The key must be aligned with the key used in org.eclipse.kapua.service.datastore.MessageStoreService.xml meta data configuration file).</b>
+     */
+    public static final String CONFIGURATION_MESSAGE_UNIQUENESS_CHECK = "messageUniquenessCheck";
+
+    /**
      * Defines a value in service plan as unlimited resource
      */
     public static final int UNLIMITED = -1;
@@ -87,6 +94,7 @@ public class MessageStoreConfiguration {
     private long rxByteLimit = 1000000;
     private DataIndexBy dataIndexBy = DataIndexBy.SERVER_TIMESTAMP;
     private MetricsIndexBy metricsIndexBy = MetricsIndexBy.TIMESTAMP;
+    private MessageUniquenessCheck messageUniquenessCheck;
 
     private Map<String, Object> values;
 
@@ -119,6 +127,9 @@ public class MessageStoreConfiguration {
             }
             if (this.values.get(CONFIGURATION_METRICS_INDEX_BY_KEY) != null) {
                 setMetricsIndexBy(MetricsIndexBy.valueOf((String) this.values.get(CONFIGURATION_METRICS_INDEX_BY_KEY)));
+            }
+            if (this.values.get(CONFIGURATION_MESSAGE_UNIQUENESS_CHECK) != null) {
+                setMessageUniquenessCheck(MessageUniquenessCheck.valueOf((String) this.values.get(CONFIGURATION_MESSAGE_UNIQUENESS_CHECK)));
             }
         }
     }
@@ -231,4 +242,20 @@ public class MessageStoreConfiguration {
     public void setMetricsIndexBy(MetricsIndexBy metricsIndexBy) {
         this.metricsIndexBy = metricsIndexBy;
     }
+
+    /**
+     * Get the message uniqueness check parameter ({@link MessageStoreConfiguration#CONFIGURATION_MESSAGE_UNIQUENESS_CHECK}
+     * @return
+     */
+    public MessageUniquenessCheck getMessageUniquenessCheck() {
+        return messageUniquenessCheck;
+    }
+
+    /**
+     * Set the message uniqueness check parameter ({@link MessageStoreConfiguration#CONFIGURATION_MESSAGE_UNIQUENESS_CHECK}
+     */
+    public void setMessageUniquenessCheck(MessageUniquenessCheck messageUniquenessCheck) {
+        this.messageUniquenessCheck = messageUniquenessCheck;
+    }
+
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MessageUniquenessCheck.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MessageUniquenessCheck.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal.model;
+
+/**
+ * Once a message is going to be stored to datastore the store call can terminate with error on client side (due to timeout for example) but performed on server side.
+ * The store call is then retried and the message could be inserted twice.
+ * To avoid that, the current implementation does a query looking for a message with a specific id (the one from the message) in all the indexes belonging to the account.
+ * This is safer since changes in the message indexing by or the settings of the datastore (index by week/day/hour) can affect the index where the message should be stored to and then the effectivness of the check.
+ * But this has a performance drawback. The number of queries to be performed are linear with the indexes available so, if there are a lot of indexes, the query will need more time and resources to be executed.
+ * This enum define a new parameter to change the search behavior by account.
+ */
+public enum MessageUniquenessCheck {
+
+    /**
+     * No check
+     */
+    NONE,
+    /**
+     * The search is done only to the index where the message is expected to be, based on current configuration.
+     */
+    BOUND,
+    /**
+     * Will check in all the indexes defined for the account
+     */
+    FULL
+}

--- a/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
@@ -56,6 +56,18 @@
             <Option label="SERVER_TIMESTAMP" value="SERVER_TIMESTAMP" />
         </AD>
 
+        <AD id="messageUniquenessCheck"
+            name="messageUniquenessCheck"
+            type="String"
+            cardinality="0"
+            required="true"
+            default="FULL"
+            description="Message uniqueness check type (on telemetry message datastore insert)">
+            <Option label="NONE" value="NONE" />
+            <Option label="BOUND" value="BOUND" />
+            <Option label="FULL" value="FULL" />
+        </AD>
+
     </OCD>
 
     <Designate pid="org.eclipse.kapua.service.datastore.MessageStoreService">

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -1560,13 +1560,14 @@ public class DatastoreSteps extends TestBase {
         checkListOrder(metLst, getNamedMetricOrdering());
     }
 
-    @Given("Dataservice config enabled {string}, dataTTL {int}, rxByteLimit {int}, dataIndexBy {string}")
-    public void configureDatastoreService(String enabled, int dataTTL, int rxByteLimit, String dataIndexBy) throws Exception {
-        Map<String, Object> settings = new HashMap<>();
+    @Given("Dataservice config enabled {string}, dataTTL {int}, rxByteLimit {int}, dataIndexBy {string}, messageUniquenessCheck {string}")
+    public void configureDatastoreService(String enabled, int dataTTL, int rxByteLimit, String dataIndexBy, String messageUniquenessCheck) throws Exception {
+        Map<String, Object> settings = messageStoreService.getConfigValues(KapuaId.ONE);
         settings.put("enabled", enabled.equalsIgnoreCase("TRUE"));
         settings.put("dataTTL", dataTTL);
         settings.put("rxByteLimit", rxByteLimit);
         settings.put("dataIndexBy", dataIndexBy);
+        settings.put("messageUniquenessCheck", messageUniquenessCheck);
         messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
     }
 


### PR DESCRIPTION
Brief description of the PR.
This pr introduces a parameter to tune the datastore driver behaviour on message storing.

**Related Issue**
none

**Description of the solution adopted**
A new parameter allows to set the type of check the datastore does about the message uniqueness on message storing.

- NONE no checks are made
- BOUND check is made only in the index of the account where the message should be stored based on the current indexing policy
- FULL check is made in all the indices of the account (current and default)

Depepending on the use case this parameter enhance the flexibility.

**Screenshots**
none

**Any side note on the changes made**
none (the default value for this parameter let the datastore to work as before so no changes in the datastore behaviour using the default value
