### PR TITLE
FIX - re-introduced console building in the gitAction configuration

### DIFF
--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -27,6 +27,26 @@ jobs:
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
       - run: bash <(curl -s https://codecov.io/bash)
+  build-Console:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3 # Checks out a copy of the repository on the ubuntu-latest machine
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: |
+            11
+            8
+      - name: Cache Maven repository #retrieve maven artifacts for the console building
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
+      - run: mvn -v
+      - run: mvn clean install -f console/pom.xml -Pdev -DskipTests && mvn clean install -Pdocker,console -DskipTests -pl :kapua-assembly-java-base,:kapua-assembly-jetty-base,:kapua-assembly-console
+      - run: bash <(curl -s https://codecov.io/bash)
   test-brokerAcl:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
In the last optimization that I made in the ci configuration files I noticed that I missed to build the console at all in one of the jobs.

It is true that it's not used as a docker image in the tests but at the same time we don't want to miss possible compilation errors on the code for the console.

Considering that the docker console image is not a dependency for the tests I decided to insert a separate job that builds it (i.e. it's not built in the first "Build" job). In this way the tests execution is not delayed for its build
