### PR TITLE
FIX - LimitExceeded value on Data Metric/Message/Client/Channel GET APIs when more than 10k documents stored

### DIFF
--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -1401,6 +1401,20 @@ Feature: Datastore tests
     Then The message list "MessageInfo" have limitExceed value false
     And I delete all indices
 
+  Scenario: Create 10k messages and more, test if limitExceeded parameter is right when doing queries
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I store 10000 messages in bulk mode to the index "1-data-message-2023-1"
+    And I refresh all indices
+    When I query for the current account messages with limit 10000 and offset 0 and store them as "MessageInfo"
+    Then The message list "MessageInfo" have limitExceed value false
+    When I store 1 messages in bulk mode to the index "1-data-message-2023-1"
+    And I refresh all indices
+    When I query for the current account messages with limit 10000 and offset 0 and store them as "MessageInfo"
+    Then The message list "MessageInfo" have limitExceed value true
+    And I delete all indices
+
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/model/ResultList.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/model/ResultList.java
@@ -25,6 +25,7 @@ public class ResultList<T> {
 
     private final List<T> result;
     private final long totalCount;
+    private boolean totalHitsExceedsCount; //true iff in ES there are actually more than 10k hits
 
     /**
      * Constructor.
@@ -46,6 +47,14 @@ public class ResultList<T> {
      */
     public void add(T object) {
         result.add(object);
+    }
+
+    public void setTotalHitsExceedsCount(boolean value) {
+        this.totalHitsExceedsCount=value;
+    }
+
+    public boolean getTotalHitsExceedsCount() {
+        return this.totalHitsExceedsCount;
     }
 
     /**

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/ElasticsearchKeywords.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/ElasticsearchKeywords.java
@@ -38,4 +38,5 @@ public class ElasticsearchKeywords {
     static final String KEY_HITS = "hits";
     static final String KEY_TOTAL = "total";
     static final String KEY_VALUE = "value";
+    static final String KEY_RELATION = "relation";
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/AbstractRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/AbstractRegistryFacade.java
@@ -49,10 +49,13 @@ public abstract class AbstractRegistryFacade {
         return DatastoreClientFactory.getElasticsearchClient();
     }
 
-    protected <T extends Storable> void setLimitExceed(StorableQuery query, StorableListResult<T> list) {
+    protected <T extends Storable> void setLimitExceed(StorableQuery query, boolean hitsExceedsTotalCount, StorableListResult<T> list) {
         int offset = query.getOffset() != null ? query.getOffset() : 0;
-        if (query.getLimit() != null && list.getTotalCount() > offset + query.getLimit()) {
-            list.setLimitExceeded(true);
+        if (query.getLimit() != null) {
+            if (hitsExceedsTotalCount || //pre-condition: there are more than 10k documents in ES && query limit is <= 10k
+                    list.getTotalCount() > offset + query.getLimit()) {
+                list.setLimitExceeded(true);
+            }
         }
     }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -28,6 +28,7 @@ import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
 import org.eclipse.kapua.service.elasticsearch.client.exception.ClientException;
+import org.eclipse.kapua.service.elasticsearch.client.model.ResultList;
 import org.eclipse.kapua.service.elasticsearch.client.model.TypeDescriptor;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateRequest;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateResponse;
@@ -193,8 +194,9 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
 
         String indexName = SchemaUtil.getChannelIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ChannelInfoSchema.CHANNEL_TYPE_NAME);
-        ChannelInfoListResult result = new ChannelInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, ChannelInfo.class));
-        setLimitExceed(query, result);
+        ResultList<ChannelInfo> rl = getElasticsearchClient().query(typeDescriptor, query, ChannelInfo.class);
+        ChannelInfoListResult result = new ChannelInfoListResultImpl(rl);
+        setLimitExceed(query, rl.getTotalHitsExceedsCount(), result);
         return result;
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
@@ -28,6 +28,7 @@ import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.datastore.model.ClientInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 import org.eclipse.kapua.service.elasticsearch.client.exception.ClientException;
+import org.eclipse.kapua.service.elasticsearch.client.model.ResultList;
 import org.eclipse.kapua.service.elasticsearch.client.model.TypeDescriptor;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateRequest;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateResponse;
@@ -188,8 +189,9 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
 
         String indexName = SchemaUtil.getClientIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ClientInfoSchema.CLIENT_TYPE_NAME);
-        ClientInfoListResultImpl result = new ClientInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, ClientInfo.class));
-        setLimitExceed(query, result);
+        ResultList<ClientInfo> rl = getElasticsearchClient().query(typeDescriptor, query, ClientInfo.class);
+        ClientInfoListResult result = new ClientInfoListResultImpl(rl);
+        setLimitExceed(query, rl.getTotalHitsExceedsCount(), result);
         return result;
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -305,8 +305,9 @@ public final class MessageStoreFacade extends AbstractRegistryFacade {
 
         String dataIndexName = SchemaUtil.getDataIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(dataIndexName, MessageSchema.MESSAGE_TYPE_NAME);
-        MessageListResult result = new MessageListResultImpl(getElasticsearchClient().query(typeDescriptor, query, DatastoreMessage.class));
-        setLimitExceed(query, result);
+        ResultList<DatastoreMessage> rl = getElasticsearchClient().query(typeDescriptor, query, DatastoreMessage.class);
+        MessageListResult result = new MessageListResultImpl(rl);
+        setLimitExceed(query, rl.getTotalHitsExceedsCount(), result);
         return result;
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
@@ -30,6 +30,7 @@ import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 import org.eclipse.kapua.service.elasticsearch.client.exception.ClientException;
 import org.eclipse.kapua.service.elasticsearch.client.model.BulkUpdateRequest;
 import org.eclipse.kapua.service.elasticsearch.client.model.BulkUpdateResponse;
+import org.eclipse.kapua.service.elasticsearch.client.model.ResultList;
 import org.eclipse.kapua.service.elasticsearch.client.model.TypeDescriptor;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateRequest;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateResponse;
@@ -257,8 +258,9 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
 
         String indexNme = SchemaUtil.getMetricIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexNme, MetricInfoSchema.METRIC_TYPE_NAME);
-        MetricInfoListResult result = new MetricInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, MetricInfo.class));
-        setLimitExceed(query, result);
+        ResultList<MetricInfo> rl = getElasticsearchClient().query(typeDescriptor, query, MetricInfo.class);
+        MetricInfoListResult result = new MetricInfoListResultImpl(rl);
+        setLimitExceed(query, rl.getTotalHitsExceedsCount(), result);
         return result;
     }
 

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -95,6 +95,7 @@ import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 import org.eclipse.kapua.service.elasticsearch.client.ElasticsearchClient;
 import org.eclipse.kapua.service.elasticsearch.client.exception.ClientException;
 import org.eclipse.kapua.service.elasticsearch.client.model.IndexRequest;
+import org.eclipse.kapua.service.elasticsearch.client.rest.ElasticsearchResourcePaths;
 import org.eclipse.kapua.service.storable.model.StorableListResult;
 import org.eclipse.kapua.service.storable.model.id.StorableId;
 import org.eclipse.kapua.service.storable.model.id.StorableIdFactory;
@@ -104,11 +105,14 @@ import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
 import org.eclipse.kapua.service.storable.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.service.storable.model.query.predicate.RangePredicate;
 import org.eclipse.kapua.service.storable.model.query.predicate.TermPredicate;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.text.DateFormat;
@@ -685,6 +689,21 @@ public class DatastoreSteps extends TestBase {
         }
         stepData.put(idListKey, tmpList);
     }
+
+    //with this method I insert in bulk mode an hard-coded message, in order to speed up the insertion process
+    @When("I store {int} messages in bulk mode to the index {string}")
+    public void bulkInsert(int nMessages, String index) throws IOException {
+        StringBuilder body = new StringBuilder();
+        for (int i=0; i<nMessages; i++) {
+            body.append("{ \"index\":{}}\n");
+            body.append("{\"device_id\":\"6782593496741240747\",\"channel_parts\":[\"genericMetric\"],\"scope_id\":\"1\",\"channel\":\"genericMetric\",\"received_on\":\"2018-10-01T16:43:04.115Z\",\"ip_address\":\"127.0.0.1\",\"metrics\":{\"metric\":{\"int\":2}},\"sent_on\":null,\"body\":null,\"captured_on\":null,\"client_id\":\"samSulekBulkingHeavy\",\"timestamp\":\"2018-10-01T13:48:36.946Z\",\"sort\":[1701784116946]}\n");
+        }
+        Request request = new Request("POST", index + ElasticsearchResourcePaths.getBulkPath());
+        request.setJsonEntity(body.toString());
+        RestClient cl = (RestClient)elasticsearchClient.getClient();
+        cl.performRequest(request);
+    }
+
 
     @Given("I set the database to device timestamp indexing")
     public void setDatabaseToDeviceTimestampIndexing() throws KapuaException {


### PR DESCRIPTION
**Brief description of the PR**
For a technical limit imposed by ES, the maximum number of hits for a query is 10k, even when in the store there are more than 10k documents. Not knowing this, we were calculating the _limitExceeded_ parameter in the GET apis in the title using the totalCount parameter returned by ES queries, which is wrong in such corner cases (for example, when in the store there are 10k+1 documents and you query using the _limit_ parameter=10k). To be compliant with the contract of our API, it would be correct to return a right _limitExceeded_ parameter even in such corner cases, but taking into consideration that the _limit_ parameter cannot be more than 10k in value. 

**Description of the solution adopted**
Considering what is explained here [See the second sub-section of the paragraph here](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/search-your-data.html#track-total-hits) I leveraged the "total.relation" returned in the "total" object that is already inside the json Response we receive from ES upon such queries. Using it, I refactored the way we derive the _limitExceeded_ parameter in the response of our APIs. More precisely, I augmented the ResultList class inserting a boolean that reflects the value of such "total.relation" parameter, in this way then the different *Facade classes know how to derive the _limitExceeded_ parameter in the correct way.
Finally, I added a new scenario to test the fix.

**Any side note on the changes made**
Currently, it is still possible to query using, for example, an offset value = 9999 and limit = 3. This is wrong because it doesn't take into consideration the same technical limit explained in the start of this description. I could have inserted also this fix in this PR but I'll do in a separated PR instead
