### PR TITLE
FIX - Fix offset limit datastore api

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
@@ -210,6 +210,22 @@ public class ArgumentValidator {
     }
 
     /**
+     * Throws an KapuaIllegalArgumentException if the value for the specified argument is higher (&gt;) than the maxValue given
+     *
+     * @param value
+     * @param maxValue
+     * @param argumentName
+     * @throws KapuaIllegalArgumentException
+     */
+    public static void numLessThenOrEqual(long value, long maxValue, String argumentName)
+            throws KapuaIllegalArgumentException {
+
+        if (value > maxValue) {
+            throw new KapuaIllegalArgumentException(argumentName, "Value over than allowed max value. Max value is " + maxValue);
+        }
+    }
+
+    /**
      * Throws a {@link KapuaIllegalArgumentException} if the {@link String} given has {@link String#length()} less than the #minLength given or greater than the #maxLength given.
      *
      * @param value        The {@link String} to check

--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -1401,6 +1401,32 @@ Feature: Datastore tests
     Then The message list "MessageInfo" have limitExceed value false
     And I delete all indices
 
+  Scenario: Create some messages, query all messages with not allowed offset and limit values
+  Check if value of limitExceed is false.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-client-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
+      | clientId      | topic               | count | startDate                | endDate                  |
+      | test-client-1 | delete/by/date/test | 2     | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
+    When I query for the current account messages with limit -1 and offset 3 and store them as "MessageInfo"
+    Then An exception was thrown
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
+    When I query for the current account messages with limit 5 and offset -3 and store them as "MessageInfo"
+    Then An exception was thrown
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I query for the current account messages with limit 9999 and offset 3 and store them as "MessageInfo"
+    Then An exception was thrown
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I query for the current account messages with limit 3 and offset 9999 and store them as "MessageInfo"
+    Then An exception was thrown
+    And I delete all indices
+
   Scenario: Create 10k messages and more, test if limitExceeded parameter is right when doing queries
 
     Given I login as user with name "kapua-sys" and password "kapua-password"

--- a/qa/integration/src/test/resources/kapua-datastore-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-setting.properties
@@ -31,5 +31,5 @@ datastore.cache.local.size.maximum=1000
 datastore.cache.metadata.local.size.maximum=1000
 
 #
-#maximum value for limit parameter
-datastore.query.limit.max=10000
+#value of the "index.max_result_window" configured in ES, by default = 10k (this parameter pose a limit to the offset + limit value on queries to ES)
+datastore.max_result_window=10000

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/ExceptionConfigurationProviderImpl.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/ExceptionConfigurationProviderImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.rest.errors.ExceptionConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -24,6 +25,7 @@ public class ExceptionConfigurationProviderImpl implements ExceptionConfiguratio
     private final boolean showStackTrace;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    @Inject
     public ExceptionConfigurationProviderImpl(@Named("showStackTrace") Boolean showStackTrace) {
         this.showStackTrace = showStackTrace;
         logger.debug("Initialized with showStackTrace={}", showStackTrace);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
@@ -64,6 +64,7 @@ public class ChannelInfoRegistryServiceImpl implements ChannelInfoRegistryServic
     private static final Logger LOG = LoggerFactory.getLogger(ChannelInfoRegistryServiceImpl.class);
 
     private final DatastorePredicateFactory datastorePredicateFactory;
+    private Integer MAX_RESULT_WINDOW_VALUE;
     private final AccountService accountService;
     private final AuthorizationService authorizationService;
     private final PermissionFactory permissionFactory;
@@ -95,6 +96,7 @@ public class ChannelInfoRegistryServiceImpl implements ChannelInfoRegistryServic
         this.messageRepository = messageStoreService;
         this.channelInfoRegistryFacade = channelInfoRegistryFacade;
         this.datastoreSettings = datastoreSettings;
+        this.MAX_RESULT_WINDOW_VALUE = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
     }
 
     @Override
@@ -136,6 +138,12 @@ public class ChannelInfoRegistryServiceImpl implements ChannelInfoRegistryServic
         ArgumentValidator.notNull(query.getScopeId(), QUERY_SCOPE_ID);
 
         checkDataAccess(query.getScopeId(), Actions.read);
+        if (query.getLimit() != null && query.getOffset() != null) {
+            ArgumentValidator.notNegative(query.getLimit(), "limit");
+            ArgumentValidator.notNegative(query.getOffset(), "offset");
+            ArgumentValidator.numRange(query.getLimit() + query.getOffset(), 0, MAX_RESULT_WINDOW_VALUE, "limit + offset");
+        }
+
         try {
             ChannelInfoListResult result = channelInfoRegistryFacade.query(query);
             if (result != null && query.getFetchAttributes().contains(ChannelInfoField.TIMESTAMP.field())) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
@@ -62,16 +62,14 @@ import java.util.Optional;
 public class ChannelInfoRegistryServiceImpl implements ChannelInfoRegistryService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ChannelInfoRegistryServiceImpl.class);
-
     private final DatastorePredicateFactory datastorePredicateFactory;
-    private Integer MAX_RESULT_WINDOW_VALUE;
+    protected final Integer maxResultWindowValue;
     private final AccountService accountService;
     private final AuthorizationService authorizationService;
     private final PermissionFactory permissionFactory;
     private final ChannelInfoRegistryFacade channelInfoRegistryFacade;
     private final MessageRepository messageRepository;
     private final DatastoreSettings datastoreSettings;
-
     private static final String QUERY = "query";
     private static final String QUERY_SCOPE_ID = "query.scopeId";
 
@@ -90,13 +88,13 @@ public class ChannelInfoRegistryServiceImpl implements ChannelInfoRegistryServic
             ChannelInfoRegistryFacade channelInfoRegistryFacade,
             DatastoreSettings datastoreSettings) {
         this.datastorePredicateFactory = datastorePredicateFactory;
-        this.accountService = accountService;
         this.authorizationService = authorizationService;
         this.permissionFactory = permissionFactory;
         this.messageRepository = messageStoreService;
         this.channelInfoRegistryFacade = channelInfoRegistryFacade;
         this.datastoreSettings = datastoreSettings;
-        this.MAX_RESULT_WINDOW_VALUE = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
+        this.accountService = accountService;
+        this.maxResultWindowValue = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
     }
 
     @Override
@@ -140,7 +138,7 @@ public class ChannelInfoRegistryServiceImpl implements ChannelInfoRegistryServic
         if (query.getLimit() != null && query.getOffset() != null) {
             ArgumentValidator.notNegative(query.getLimit(), "limit");
             ArgumentValidator.notNegative(query.getOffset(), "offset");
-            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), MAX_RESULT_WINDOW_VALUE, "limit + offset");
+            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), maxResultWindowValue, "limit + offset");
         }
 
         try {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
@@ -136,12 +136,11 @@ public class ChannelInfoRegistryServiceImpl implements ChannelInfoRegistryServic
 
         ArgumentValidator.notNull(query, QUERY);
         ArgumentValidator.notNull(query.getScopeId(), QUERY_SCOPE_ID);
-
         checkDataAccess(query.getScopeId(), Actions.read);
         if (query.getLimit() != null && query.getOffset() != null) {
             ArgumentValidator.notNegative(query.getLimit(), "limit");
             ArgumentValidator.notNegative(query.getOffset(), "offset");
-            ArgumentValidator.numRange(query.getLimit() + query.getOffset(), 0, MAX_RESULT_WINDOW_VALUE, "limit + offset");
+            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), MAX_RESULT_WINDOW_VALUE, "limit + offset");
         }
 
         try {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
@@ -63,7 +63,8 @@ import java.util.Optional;
 public class ClientInfoRegistryServiceImpl implements ClientInfoRegistryService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientInfoRegistryServiceImpl.class);
-
+    
+    private  Integer MAX_RESULT_WINDOW_VALUE;
     private final StorablePredicateFactory storablePredicateFactory;
     private final AccountService accountService;
     private final AuthorizationService authorizationService;
@@ -97,6 +98,7 @@ public class ClientInfoRegistryServiceImpl implements ClientInfoRegistryService 
         this.clientInfoRegistryFacade = clientInfoRegistryFacade;
         this.messageRepository = messageRepository;
         this.datastoreSettings = datastoreSettings;
+        this.MAX_RESULT_WINDOW_VALUE = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
     }
 
     @Override
@@ -135,7 +137,11 @@ public class ClientInfoRegistryServiceImpl implements ClientInfoRegistryService 
 
         ArgumentValidator.notNull(query, QUERY);
         ArgumentValidator.notNull(query.getScopeId(), QUERY_SCOPE_ID);
-
+        if (query.getLimit() != null && query.getOffset() != null) {
+            ArgumentValidator.notNegative(query.getLimit(), "limit");
+            ArgumentValidator.notNegative(query.getOffset(), "offset");
+            ArgumentValidator.numRange(query.getLimit() + query.getOffset(), 0, MAX_RESULT_WINDOW_VALUE, "limit + offset");
+        }
         checkAccess(query.getScopeId(), Actions.read);
         try {
             ClientInfoListResult result = clientInfoRegistryFacade.query(query);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
@@ -63,8 +63,7 @@ import java.util.Optional;
 public class ClientInfoRegistryServiceImpl implements ClientInfoRegistryService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientInfoRegistryServiceImpl.class);
-    
-    private  Integer MAX_RESULT_WINDOW_VALUE;
+    protected final Integer maxResultWindowValue;
     private final StorablePredicateFactory storablePredicateFactory;
     private final AccountService accountService;
     private final AuthorizationService authorizationService;
@@ -98,7 +97,7 @@ public class ClientInfoRegistryServiceImpl implements ClientInfoRegistryService 
         this.clientInfoRegistryFacade = clientInfoRegistryFacade;
         this.messageRepository = messageRepository;
         this.datastoreSettings = datastoreSettings;
-        this.MAX_RESULT_WINDOW_VALUE = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
+        this.maxResultWindowValue = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
     }
 
     @Override
@@ -140,7 +139,7 @@ public class ClientInfoRegistryServiceImpl implements ClientInfoRegistryService 
         if (query.getLimit() != null && query.getOffset() != null) {
             ArgumentValidator.notNegative(query.getLimit(), "limit");
             ArgumentValidator.notNegative(query.getOffset(), "offset");
-            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), MAX_RESULT_WINDOW_VALUE, "limit + offset");
+            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), maxResultWindowValue, "limit + offset");
         }
         checkAccess(query.getScopeId(), Actions.read);
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
@@ -140,9 +140,10 @@ public class ClientInfoRegistryServiceImpl implements ClientInfoRegistryService 
         if (query.getLimit() != null && query.getOffset() != null) {
             ArgumentValidator.notNegative(query.getLimit(), "limit");
             ArgumentValidator.notNegative(query.getOffset(), "offset");
-            ArgumentValidator.numRange(query.getLimit() + query.getOffset(), 0, MAX_RESULT_WINDOW_VALUE, "limit + offset");
+            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), MAX_RESULT_WINDOW_VALUE, "limit + offset");
         }
         checkAccess(query.getScopeId(), Actions.read);
+
         try {
             ClientInfoListResult result = clientInfoRegistryFacade.query(query);
             if (result != null && query.getFetchAttributes().contains(ClientInfoField.TIMESTAMP.field())) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -23,7 +23,6 @@ import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
@@ -59,12 +58,11 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
     private static final Logger logger = LoggerFactory.getLogger(MessageStoreServiceImpl.class);
 
     private MetricsDatastore metrics;
-    protected AccountService accountService;
     protected AuthorizationService authorizationService;
     protected PermissionFactory permissionFactory;
 
     protected final Integer maxEntriesOnDelete;
-    protected Integer MAX_RESULT_WINDOW_VALUE;
+    protected final Integer maxResultWindowValue;
     protected final MessageStoreFacade messageStoreFacade;
 
     @Inject
@@ -83,7 +81,7 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
         this.metrics = metricsDatastore;
         this.messageStoreFacade = messageStoreFacade;
         maxEntriesOnDelete = datastoreSettings.getInt(DatastoreSettingsKey.CONFIG_MAX_ENTRIES_ON_DELETE);
-        MAX_RESULT_WINDOW_VALUE = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
+        maxResultWindowValue = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
     }
 
     @Override
@@ -163,7 +161,7 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
         if (query.getLimit() != null && query.getOffset() != null) {
             ArgumentValidator.notNegative(query.getLimit(), "limit");
             ArgumentValidator.notNegative(query.getOffset(), "offset");
-            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), MAX_RESULT_WINDOW_VALUE, "limit + offset");
+            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), maxResultWindowValue, "limit + offset");
         }
         try {
             return messageStoreFacade.query(query);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -163,7 +163,7 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
         if (query.getLimit() != null && query.getOffset() != null) {
             ArgumentValidator.notNegative(query.getLimit(), "limit");
             ArgumentValidator.notNegative(query.getOffset(), "offset");
-            ArgumentValidator.numRange(query.getLimit() + query.getOffset(), 0, MAX_RESULT_WINDOW_VALUE, "limit + offset");
+            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), MAX_RESULT_WINDOW_VALUE, "limit + offset");
         }
         try {
             return messageStoreFacade.query(query);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
@@ -138,7 +138,7 @@ public class MetricInfoRegistryServiceImpl implements MetricInfoRegistryService 
         if (query.getLimit() != null && query.getOffset() != null) {
             ArgumentValidator.notNegative(query.getLimit(), "limit");
             ArgumentValidator.notNegative(query.getOffset(), "offset");
-            ArgumentValidator.numRange(query.getLimit() + query.getOffset(), 0, MAX_RESULT_WINDOW_VALUE, "limit + offset");
+            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), MAX_RESULT_WINDOW_VALUE, "limit + offset");
         }
 
         try {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
@@ -72,7 +72,7 @@ public class MetricInfoRegistryServiceImpl implements MetricInfoRegistryService 
     private final DatastorePredicateFactory datastorePredicateFactory;
     private final MessageRepository messageRepository;
     private final DatastoreSettings datastoreSettings;
-    protected final Integer MAX_RESULT_WINDOW_VALUE;
+    protected final Integer maxResultWindowValue;
 
     private static final String QUERY = "query";
     private static final String QUERY_SCOPE_ID = "query.scopeId";
@@ -93,7 +93,7 @@ public class MetricInfoRegistryServiceImpl implements MetricInfoRegistryService 
         this.metricInfoRegistryFacade = metricInfoRegistryFacade;
         this.messageRepository = messageRepository;
         this.datastoreSettings = datastoreSettings;
-        MAX_RESULT_WINDOW_VALUE = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
+        maxResultWindowValue = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
     }
 
     @Override
@@ -138,7 +138,7 @@ public class MetricInfoRegistryServiceImpl implements MetricInfoRegistryService 
         if (query.getLimit() != null && query.getOffset() != null) {
             ArgumentValidator.notNegative(query.getLimit(), "limit");
             ArgumentValidator.notNegative(query.getOffset(), "offset");
-            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), MAX_RESULT_WINDOW_VALUE, "limit + offset");
+            ArgumentValidator.numLessThenOrEqual(query.getLimit() + query.getOffset(), maxResultWindowValue, "limit + offset");
         }
 
         try {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
@@ -65,12 +65,14 @@ public class MetricInfoRegistryServiceImpl implements MetricInfoRegistryService 
     private static final Logger LOG = LoggerFactory.getLogger(MetricInfoRegistryServiceImpl.class);
 
     private final StorablePredicateFactory storablePredicateFactory;
+
     private final AuthorizationService authorizationService;
     private final PermissionFactory permissionFactory;
     private final MetricInfoRegistryFacade metricInfoRegistryFacade;
     private final DatastorePredicateFactory datastorePredicateFactory;
     private final MessageRepository messageRepository;
     private final DatastoreSettings datastoreSettings;
+    protected final Integer MAX_RESULT_WINDOW_VALUE;
 
     private static final String QUERY = "query";
     private static final String QUERY_SCOPE_ID = "query.scopeId";
@@ -91,6 +93,7 @@ public class MetricInfoRegistryServiceImpl implements MetricInfoRegistryService 
         this.metricInfoRegistryFacade = metricInfoRegistryFacade;
         this.messageRepository = messageRepository;
         this.datastoreSettings = datastoreSettings;
+        MAX_RESULT_WINDOW_VALUE = datastoreSettings.getInt(DatastoreSettingsKey.MAX_RESULT_WINDOW_VALUE);
     }
 
     @Override
@@ -132,6 +135,12 @@ public class MetricInfoRegistryServiceImpl implements MetricInfoRegistryService 
         ArgumentValidator.notNull(query.getScopeId(), QUERY_SCOPE_ID);
 
         checkDataAccess(query.getScopeId(), Actions.read);
+        if (query.getLimit() != null && query.getOffset() != null) {
+            ArgumentValidator.notNegative(query.getLimit(), "limit");
+            ArgumentValidator.notNegative(query.getOffset(), "offset");
+            ArgumentValidator.numRange(query.getLimit() + query.getOffset(), 0, MAX_RESULT_WINDOW_VALUE, "limit + offset");
+        }
+
         try {
             MetricInfoListResult result = metricInfoRegistryFacade.query(query);
             if (result != null && query.getFetchAttributes().contains(MetricInfoField.TIMESTAMP_FULL.field())) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
@@ -71,9 +71,9 @@ public enum DatastoreSettingsKey implements SettingKey {
      */
     DISABLE_DATASTORE("datastore.disable"),
     /**
-     * Elasticsearch limit maximum value
+     * Elasticsearch limit+offset maximum value
      */
-    MAX_LIMIT_VALUE("datastore.query.limit.max");
+    MAX_RESULT_WINDOW_VALUE("datastore.max_result_window");
 
     private String key;
 

--- a/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
@@ -34,5 +34,5 @@ datastore.cache.metadata.local.size.maximum=1000
 datastore.index.prefix=
 
 #
-#maximum value for limit parameter
-datastore.query.limit.max=10000
+#value of the "index.max_result_window" configured in ES, by default = 10k (this parameter pose a limit to the offset + limit value on queries to ES)
+datastore.max_result_window=10000

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -886,13 +886,18 @@ public class DatastoreSteps extends TestBase {
     }
 
     @When("I query for the current account messages with limit {int} and offset {int} and store them as {string}")
-    public void queryMessageWithOffsetAndLimit(int limit, int offset, String lstKey) throws KapuaException {
+    public void queryMessageWithOffsetAndLimit(int limit, int offset, String lstKey) throws Exception {
         Account account = (Account) stepData.get(LAST_ACCOUNT);
         MessageQuery tmpQuery = createBaseMessageQuery(account.getId(), limit);
         tmpQuery.setOffset(offset);
         tmpQuery.addFetchAttributes(ChannelInfoField.TIMESTAMP.field());
-        MessageListResult tmpList = messageStoreService.query(tmpQuery);
-        stepData.put(lstKey, tmpList);
+        primeException();
+        try {
+            MessageListResult tmpList = messageStoreService.query(tmpQuery);
+            stepData.put(lstKey, tmpList);
+        } catch (KapuaException e) {
+            verifyException(e);
+        }
     }
 
     @When("I query for the current account clients with limit {int} and offset {int} and store them as {string}")

--- a/service/datastore/test/src/test/resources/kapua-datastore-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-setting.properties
@@ -34,5 +34,5 @@ datastore.cache.metadata.local.size.maximum=1000
 datastore.index.window=week
 
 #
-#maximum value for limit parameter
-datastore.query.limit.max=10000
+#value of the "index.max_result_window" configured in ES, by default = 10k (this parameter pose a limit to the offset + limit value on queries to ES)
+datastore.max_result_window=10000


### PR DESCRIPTION
**Brief description of the PR**
For a technical limit imposed by ES, the maximum number of hits for a query is 10k, even when in the store there are more than 10k documents. Currently, the only check performed in our back end regarding the values offset & limit of our rest APIs regarding queries to ES is that the limit value must be <= to 10k. This is not wrong but it's not complete, in fact the real limit imposed by ES is that the values limit + offset must not be more than 10k. 

**Description of the solution adopted**
This pr introduce this new check on the back-end, along with a test for the feature. This has been done augmenting the check on the max limit value of 10k with the new more "strict" check on the sum offset,limit

