### PR TITLE
Feature - Add option to disconnect a device from the broker

### DIFF
--- a/assembly/broker-artemis/configurations/locator.xml
+++ b/assembly/broker-artemis/configurations/locator.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<locator-config>
+    <provided>
+        <provide>
+            <interceptor>annotation</interceptor>
+            <with>Impl</with>
+        </provide>
+    </provided>
+
+    <packages>
+        <package>org.eclipse.kapua.commons</package>
+        <package>org.eclipse.kapua.message</package>
+        <package>org.eclipse.kapua.service</package>
+    </packages>
+</locator-config>

--- a/assembly/broker-artemis/descriptors/kapua-broker-artemis.xml
+++ b/assembly/broker-artemis/descriptors/kapua-broker-artemis.xml
@@ -89,13 +89,43 @@
                 <include>org.eclipse.persistence:org.eclipse.persistence.extension</include>
                 <include>org.eclipse.persistence:javax.persistence</include>
 
-                <include>${pom.groupId}:kapua-commons</include>
-                <include>${pom.groupId}:kapua-client-security</include>
+                <!-- additional kapua-locator dependencies -->
+                <include>aopalliance:aopalliance</include>
+                <include>com.google.guava:failureaccess</include>
+                <include>com.google.guava:guava</include>
+                <include>com.google.guava:listenablefuture</include>
+                <include>com.google.inject.extensions:guice-multibindings</include>
+                <include>com.google.inject:guice</include>
+                <include>com.warrenstrange:googleauth</include>
+                <include>javax.cache:cache-api</include>
+                <include>javax.inject:javax.inject</include>
+                <include>org.apache.shiro:shiro-core</include>
+                <include>org.bitbucket.b_c:jose4j</include>
+                <include>org.javassist:javassist</include>
+
+                <include>${pom.groupId}:kapua-account-api</include>
+                <include>${pom.groupId}:kapua-account-internal</include>
                 <include>${pom.groupId}:kapua-broker-artemis-plugin</include>
+                <include>${pom.groupId}:kapua-client-security</include>
                 <include>${pom.groupId}:kapua-commons</include>
+                <include>${pom.groupId}:kapua-device-api</include>
+                <include>${pom.groupId}:kapua-device-authentication</include>
+                <include>${pom.groupId}:kapua-device-registry-api</include>
+                <include>${pom.groupId}:kapua-device-registry-internal</include>
+                <include>${pom.groupId}:kapua-locator-guice</include>
+                <include>${pom.groupId}:kapua-message-api</include>
+                <include>${pom.groupId}:kapua-message-internal</include>
+                <include>${pom.groupId}:kapua-openid-api</include>
                 <include>${pom.groupId}:kapua-service-api</include>
-                <include>${pom.groupId}:kapua-service-client</include>
                 <include>${pom.groupId}:kapua-security-authentication-api</include>
+                <include>${pom.groupId}:kapua-security-authorization-api</include>
+                <include>${pom.groupId}:kapua-security-certificate-api</include>
+                <include>${pom.groupId}:kapua-security-certificate-internal</include>
+                <include>${pom.groupId}:kapua-security-shiro</include>
+                <include>${pom.groupId}:kapua-service-client</include>
+                <include>${pom.groupId}:kapua-tag-api</include>
+                <include>${pom.groupId}:kapua-user-api</include>
+                <include>${pom.groupId}:kapua-user-internal</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/assembly/broker-artemis/pom.xml
+++ b/assembly/broker-artemis/pom.xml
@@ -33,7 +33,11 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-broker-artemis-plugin</artifactId>
+            <artifactId>kapua-account-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
@@ -41,7 +45,27 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-broker-artemis-plugin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-client-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-locator-guice</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
@@ -54,6 +78,26 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-security-authentication-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-certificate-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-shiro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-tag-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-user-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-user-internal</artifactId>
         </dependency>
 
         <dependency>

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/BrokerJAXBContextProvider.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/BrokerJAXBContextProvider.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.broker.artemis.plugin.security;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
+import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+
+public class BrokerJAXBContextProvider implements JAXBContextProvider {
+
+    private JAXBContext context;
+
+    @Override
+    public JAXBContext getJAXBContext() {
+        try {
+            if (context == null) {
+                Map<String, Object> properties = new HashMap<>(1);
+                properties.put(MarshallerProperties.JSON_WRAPPER_AS_ARRAY_NAME, true);
+                context = JAXBContextFactory.createContext(new Class<?>[]{
+                        // KapuaEvent
+                        ServiceEvent.class,
+                }, properties);
+            }
+            return context;
+        } catch (JAXBException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.eclipse.kapua.broker.artemis.plugin.security.connector.AcceptorHandler;
 import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEvent;
 import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEvent.EventType;
-import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEventHanldler;
+import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEventHandler;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.LoginMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.PublishMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.SubscribeMetric;
@@ -110,7 +110,7 @@ public class ServerPlugin implements ActiveMQServerPlugin {
     private PublishMetric publishMetric;
     private SubscribeMetric subscribeMetric;
 
-    protected BrokerEventHanldler brokerEventHanldler;
+    protected BrokerEventHandler brokerEventHanldler;
     protected AcceptorHandler acceptorHandler;
     protected String version;
     protected ServerContext serverContext;
@@ -127,7 +127,7 @@ public class ServerPlugin implements ActiveMQServerPlugin {
         //TODO find a proper way to initialize database
         DatabaseCheckUpdate databaseCheckUpdate = new DatabaseCheckUpdate();
         serverContext = ServerContext.getInstance();
-        brokerEventHanldler = BrokerEventHanldler.getInstance();
+        brokerEventHanldler = BrokerEventHandler.getInstance();
         brokerEventHanldler.registerConsumer((brokerEvent) -> disconnectClient(brokerEvent));
         brokerEventHanldler.start();
 
@@ -361,7 +361,7 @@ public class ServerPlugin implements ActiveMQServerPlugin {
             BrokerEvent disconnectEvent = new BrokerEvent(EventType.disconnectClientByConnectionId, sessionContext, sessionContext);
 
             logger.info("Submitting broker event to disconnect clientId: {}, connectionId: {}", fullClientId, sessionContext.getConnectionId());
-            BrokerEventHanldler.getInstance().enqueueEvent(disconnectEvent);
+            BrokerEventHandler.getInstance().enqueueEvent(disconnectEvent);
         } catch (Exception e) {
             logger.warn("Error processing event: {}", e.getMessage());
         }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -42,10 +42,12 @@ import org.eclipse.kapua.client.security.ServiceClient.SecurityAction;
 import org.eclipse.kapua.client.security.bean.AuthRequest;
 import org.eclipse.kapua.client.security.context.SessionContext;
 import org.eclipse.kapua.client.security.context.Utils;
+import org.eclipse.kapua.commons.core.ServiceModuleBundle;
 import org.eclipse.kapua.commons.metric.CommonsMetric;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -144,6 +146,13 @@ public class ServerPlugin implements ActiveMQServerPlugin {
             acceptorHandler.syncAcceptors();
 
             deviceConnectionEventListenerService.addReceiver(serviceEvent -> processDeviceConnectionEvent(serviceEvent));
+
+            // Setup service events
+            ServiceModuleBundle app = KapuaLocator.getInstance().getService(ServiceModuleBundle.class);
+            app.startup();
+
+            // Setup JAXB Context
+            XmlUtil.setContextProvider(new BrokerJAXBContextProvider());
         } catch (Exception e) {
             logger.error("Error while initializing {} plugin: {}", this.getClass().getName(), e.getMessage(), e);
         }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -358,12 +358,17 @@ public class ServerPlugin implements ActiveMQServerPlugin {
 
             String fullClientId = Utils.getFullClientId(deviceConnection.getScopeId(), deviceConnection.getClientId());
             SessionContext sessionContext = serverContext.getSecurityContext().getSessionContextByClientId(fullClientId);
+            if(sessionContext == null) {
+                logger.info("Did not find any connections to disconnect for clientId: {}", fullClientId);
+                return;
+            }
+
             BrokerEvent disconnectEvent = new BrokerEvent(EventType.disconnectClientByConnectionId, sessionContext, sessionContext);
 
             logger.info("Submitting broker event to disconnect clientId: {}, connectionId: {}", fullClientId, sessionContext.getConnectionId());
             BrokerEventHandler.getInstance().enqueueEvent(disconnectEvent);
         } catch (Exception e) {
-            logger.warn("Error processing event: {}", e.getMessage());
+            logger.warn("Error processing event: {}", e);
         }
     }
 

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/event/BrokerEventHandler.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/event/BrokerEventHandler.java
@@ -14,19 +14,19 @@ package org.eclipse.kapua.broker.artemis.plugin.security.event;
 
 import org.eclipse.kapua.commons.localevent.EventHandler;
 
-public class BrokerEventHanldler extends EventHandler<BrokerEvent> {
+public class BrokerEventHandler extends EventHandler<BrokerEvent> {
 
-    private static BrokerEventHanldler instance;
+    private static BrokerEventHandler instance;
 
-    public static synchronized BrokerEventHanldler getInstance() {
+    public static synchronized BrokerEventHandler getInstance() {
         if (instance==null) {
-            instance = new BrokerEventHanldler();
+            instance = new BrokerEventHandler();
         }
         return instance;
     }
 
-    private BrokerEventHanldler() {
-        super(BrokerEventHanldler.class.getName(), 10, 10);
+    private BrokerEventHandler() {
+        super(BrokerEventHandler.class.getName(), 10, 10);
     }
 
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
@@ -115,8 +115,6 @@ public class ServiceInspector {
         Method matchingMethod = null;
 
         if (methods.length > 0) {
-            List<Class<?>> methodParamTypes = Arrays.asList(method.getParameterTypes());
-
             for (Method candidate : methods) {
                 if (!candidate.getName().equals(method.getName())) {
                     continue;
@@ -124,10 +122,7 @@ public class ServiceInspector {
                 if (!candidate.getReturnType().equals(method.getReturnType())) {
                     continue;
                 }
-
-                List<Class<?>> candidateParamTypes = Arrays.asList(method.getParameterTypes());
-
-                if (candidateParamTypes.size() != methodParamTypes.size() || !candidateParamTypes.containsAll(methodParamTypes)) {
+                if(!Arrays.equals(method.getParameterTypes(), candidate.getParameterTypes())) {
                     continue;
                 }
 

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -38,7 +38,8 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 
-import org.eclipse.kapua.commons.event.ServiceEventBusManager;
+import org.eclipse.kapua.commons.core.ServiceModuleBundle;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.qa.common.BasicSteps;
 import org.eclipse.kapua.qa.common.DBHelper;
 import org.eclipse.kapua.qa.common.StepData;
@@ -239,9 +240,10 @@ public class DockerSteps {
         startBaseDockerEnvironmentInternal();
     }
 
-    @Given("Service event bus is started")
+    @Given("Service events are setup")
     public void startEventBus() throws Exception {
-        ServiceEventBusManager.start();
+        ServiceModuleBundle serviceModuleBundle = KapuaLocator.getInstance().getService(ServiceModuleBundle.class);
+        serviceModuleBundle.startup();
     }
 
     private void startBaseDockerEnvironmentInternal() throws Exception {

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -38,6 +38,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 
+import org.eclipse.kapua.commons.event.ServiceEventBusManager;
 import org.eclipse.kapua.qa.common.BasicSteps;
 import org.eclipse.kapua.qa.common.DBHelper;
 import org.eclipse.kapua.qa.common.StepData;
@@ -236,6 +237,11 @@ public class DockerSteps {
     public void startBaseDockerEnvironment() throws Exception {
         stopBaseDockerEnvironment();
         startBaseDockerEnvironmentInternal();
+    }
+
+    @Given("Service event bus is started")
+    public void startEventBus() throws Exception {
+        ServiceEventBusManager.start();
     }
 
     private void startBaseDockerEnvironmentInternal() throws Exception {

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -52,7 +52,7 @@ Feature: Device Broker Integration
 
   Scenario: Test the forced disconnection of a connected device
 
-    Given Service event bus is started
+    Given Service events are setup
     And Client with name "client-disc-1" with client id "client-disc-1" user "kapua-broker" password "kapua-password" is connected
     Then Device status is "CONNECTED" within 5 seconds for client id "client-disc-1"
     When I Force Disconnect connection with client id "client-disc-1"

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -50,6 +50,15 @@ Feature: Device Broker Integration
     And I connect the pool called "stealing"
     Then Only 1 client of the pool called "stealing" is still connected within 10 seconds
 
+  Scenario: Test the forced disconnection of a connected device
+
+    Given Service event bus is started
+    And Client with name "client-disc-1" with client id "client-disc-1" user "kapua-broker" password "kapua-password" is connected
+    Then Device status is "CONNECTED" within 5 seconds for client id "client-disc-1"
+    When I Force Disconnect connection with client id "client-disc-1"
+    Then Device status is "DISCONNECTED" within 10 seconds for client id "client-disc-1"
+    And Client named "client-disc-1" is not connected
+
 #TODO
 #disable for now. Wait for further investigation.
   Scenario: Test the stealing link handling with 2 clients with same client id but different account (they should be able to connect both)

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnections.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnections.java
@@ -41,6 +41,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("{scopeId}/deviceconnections")
 public class DeviceConnections extends AbstractKapuaResource {
@@ -165,5 +166,24 @@ public class DeviceConnections extends AbstractKapuaResource {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public SetResult getAvailableAuthAdapter() {
         return new SetResult(deviceConnectionService.getAvailableAuthTypes());
+    }
+
+    /**
+     * Request that the DeviceConnection specified by the "deviceConnectionId" is disconnected from the broker.
+     *
+     * @param scopeId            The {@link ScopeId} of the requested {@link DeviceConnection}.
+     * @param deviceConnectionId The id of the requested DeviceConnection.
+     * @return HTTP 200 if operation has completed successfully.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 2.0.0
+     */
+    @POST
+    @Path("{deviceConnectionId}/_disconnect")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public Response disconnect(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("deviceConnectionId") EntityId deviceConnectionId) throws KapuaException {
+        deviceConnectionService.disconnect(scopeId, deviceConnectionId);
+        return returnNoContent();
     }
 }

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-_disconnect.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-_disconnect.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+
+info:
+  title: Eclipse Kapua REST API - Connection
+  version: '1.0'
+  contact:
+    name: Eclipse Kapua Dev Team
+    url: https://eclipse.org/kapua
+    email: kapua-dev@eclipse.org
+  license:
+    name: Eclipse Public License 2.0
+    url: https://www.eclipse.org/legal/epl-2.0
+
+paths:
+  /{scopeId}/deviceconnections/{connectionId}/_disconnect:
+    post:
+      tags:
+        - Device Connection
+      summary: Request that the specified Connection is disconnected from the broker
+      operationId: connectionDisconnect
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: './deviceConnection.yaml#/components/parameters/connectionId'
+      responses:
+        204:
+          description: The disconnection request was sent to the broker
+          content:
+            application/json:
+              schema:
+                $ref: './deviceConnection.yaml#/components/schemas/connectionOptions'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -250,6 +250,8 @@ paths:
     $ref: './deviceConnection/deviceConnection-scopeId.yaml#/paths/~1{scopeId}~1deviceconnections'
   /{scopeId}/deviceconnections/{connectionId}:
     $ref: './deviceConnection/deviceConnection-scopeId-connectionId.yaml#/paths/~1{scopeId}~1deviceconnections~1{connectionId}'
+  /{scopeId}/deviceconnections/{connectionId}/_disconnect:
+    $ref: './deviceConnection/deviceConnection-scopeId-connectionId-_disconnect.yaml#/paths/~1{scopeId}~1deviceconnections~1{connectionId}~1_disconnect'
   /{scopeId}/deviceconnections/{connectionId}/options:
     $ref: './deviceConnection/deviceConnection-scopeId-connectionId-options.yaml#/paths/~1{scopeId}~1deviceconnections~1{connectionId}~1options'
   /{scopeId}/deviceconnections/_count:

--- a/service/authentication/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServiceBackEndCall.java
+++ b/service/authentication/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServiceBackEndCall.java
@@ -12,8 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication;
 
-import com.codahale.metrics.Timer.Context;
-import com.google.common.base.Strings;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+
 import org.apache.shiro.util.ThreadContext;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaErrorCodes;
@@ -48,9 +51,8 @@ import org.eclipse.kapua.service.user.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.validation.constraints.NotNull;
-import java.util.Map;
+import com.codahale.metrics.Timer.Context;
+import com.google.common.base.Strings;
 
 public class AuthenticationServiceBackEndCall {
 
@@ -84,7 +86,7 @@ public class AuthenticationServiceBackEndCall {
 
     public AuthResponse brokerConnect(AuthRequest authRequest) {
         try {
-            logger.info("Login for clientId {} - user: {} - password: {} - client certificates: {}", authRequest.getClientId(), authRequest.getUsername(), Strings.isNullOrEmpty(authRequest.getPassword()) ? "yes" : "no", authRequest.getCertificates() != null ? "yes" : "no");
+            logger.info("Login for clientId {} - user: {} - password: {} - client certificates: {}", authRequest.getClientId(), authRequest.getUsername(), Strings.isNullOrEmpty(authRequest.getPassword()) ? "no" : "yes", authRequest.getCertificates() != null ? "yes" : "no");
             ThreadContext.unbindSubject();
             String deviceConnectionAuthType = extractAuthTypeFromAuthRequest(authRequest);
             LoginCredentials authenticationCredentials = buildLoginCredentialsFromAuthType(authRequest, deviceConnectionAuthType);

--- a/service/authentication/src/main/java/org/eclipse/kapua/service/authentication/authentication/DefaultAuthenticator.java
+++ b/service/authentication/src/main/java/org/eclipse/kapua/service/authentication/authentication/DefaultAuthenticator.java
@@ -111,7 +111,7 @@ public class DefaultAuthenticator implements Authenticator {
             authenticationMetric.getUserLogin().getConnected().inc();
             Context loginRaiseLifecycleEventTimeContext = authenticationMetric.getExtConnectorTime().getRaiseLifecycleEvent().time();
             if (raiseLifecycleEvents) {
-                logger.info("raising connect lifecycle event for clientIs: {}", authContext.getClientId());
+                logger.info("raising connect lifecycle event for clientId: {}", authContext.getClientId());
                 raiseLifecycleEvent(authContext, DeviceConnectionStatus.CONNECTED);
             }
             loginRaiseLifecycleEventTimeContext.stop();
@@ -151,7 +151,7 @@ public class DefaultAuthenticator implements Authenticator {
                 authContext.getConnectionId());
         }
         if (userAuthenticationLogic.disconnect(authContext)) {
-            logger.info("raising disconnect lifecycle event for clientIs: {}", authContext.getClientId());
+            logger.info("raising disconnect lifecycle event for clientId: {}", authContext.getClientId());
             Context loginRaiseLifecycleEventTimeContext = authenticationMetric.getExtConnectorTime().getRaiseLifecycleEvent().time();
             raiseLifecycleEvent(authContext, DeviceConnectionStatus.DISCONNECTED);
             loginRaiseLifecycleEventTimeContext.stop();
@@ -163,7 +163,7 @@ public class DefaultAuthenticator implements Authenticator {
     }
 
     protected void raiseLifecycleEvent(AuthContext authContext, DeviceConnectionStatus deviceConnectionStatus) throws ServiceEventBusException {
-        logger.debug("raising lifecycle events: clientIs: {} - connection status: {}", authContext.getClientId(), deviceConnectionStatus);
+        logger.debug("raising lifecycle events: clientId: {} - connection status: {}", authContext.getClientId(), deviceConnectionStatus);
         //internal connections with not registered user/account shouldn't raise connect/disconnect events
         if (authContext.getUserId()!=null && authContext.getScopeId()!=null) {
             serviceEventBus.publish(lifecycleEventAddress, getServiceEvent(authContext, deviceConnectionStatus));

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/connection/listener/DeviceConnectionEventListenerService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/connection/listener/DeviceConnectionEventListenerService.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.connection.listener;
+
+import org.eclipse.kapua.event.ServiceEventBusListener;
+import org.eclipse.kapua.service.KapuaService;
+
+public interface DeviceConnectionEventListenerService extends KapuaService, ServiceEventBusListener {
+
+    public void addReceiver(DeviceConnectionEventReceiver receiver);
+
+    public void removeReceiver(DeviceConnectionEventReceiver receiver);
+}

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/connection/listener/DeviceConnectionEventReceiver.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/connection/listener/DeviceConnectionEventReceiver.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.connection.listener;
+
+import org.eclipse.kapua.event.ServiceEvent;
+
+public interface DeviceConnectionEventReceiver {
+
+    public void receiveEvent(ServiceEvent event);
+
+}

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
@@ -70,13 +70,23 @@ public interface DeviceConnectionService extends KapuaEntityService<DeviceConnec
      * Register a device message when a client disconnects from the broker
      *
      * @param scopeId  The {@link DeviceConnection#getScopeId()}.
-     * @param clientId TThe {@link DeviceConnection#getClientId()}.
+     * @param clientId The {@link DeviceConnection#getClientId()}.
      * @throws KapuaException In case of errors.
      * @since 1.0.0
      * @deprecated Since 1.6.0. It has never been implemented.
      */
     @Deprecated
     void disconnect(KapuaId scopeId, String clientId) throws KapuaException;
+
+    /**
+     * Disconnect the specified {@link DeviceConnection} from the broker
+     *
+     * @param scopeId  The {@link DeviceConnection#getScopeId()}.
+     * @param id The {@link DeviceConnection#getId()}.
+     * @throws KapuaException In case of errors.
+     * @since 2.0.0
+     */
+    void disconnect(KapuaId scopeId, KapuaId deviceConnectionId) throws KapuaException;
 
     /**
      * Gets the available {@link DeviceConnection#getAuthenticationType()}s.

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerModule.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.connection.listener.internal;
+
+import javax.inject.Named;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.commons.core.ServiceModule;
+import org.eclipse.kapua.commons.event.ServiceEventHouseKeeperFactoryImpl;
+import org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory;
+import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecordRepository;
+import org.eclipse.kapua.commons.service.event.store.internal.EventStoreServiceImpl;
+import org.eclipse.kapua.event.ServiceEventBusException;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.device.connection.listener.DeviceConnectionEventListenerService;
+import org.eclipse.kapua.service.device.registry.KapuaDeviceRegistrySettingKeys;
+import org.eclipse.kapua.service.device.registry.KapuaDeviceRegistrySettings;
+import org.eclipse.kapua.storage.TxManager;
+
+import com.google.inject.Module;
+import com.google.inject.multibindings.ProvidesIntoSet;
+
+/**
+ * {@code kapua-account-internal} {@link Module} implementation.
+ *
+ * @since 2.0.0
+ */
+public class DeviceConnectionEventListenerModule extends AbstractKapuaModule implements Module {
+
+    @Override
+    protected void configureModule() {
+        bind(DeviceConnectionEventListenerService.class).to(DeviceConnectionEventListenerServiceImpl.class);
+    }
+
+    @ProvidesIntoSet
+    protected ServiceModule deviceConnectionEventListenerServiceModule(DeviceConnectionEventListenerService deviceConnectionEventListenerService,
+                                       AuthorizationService authorizationService,
+                                       PermissionFactory permissionFactory,
+                                       @Named("DeviceRegistryTransactionManager") TxManager txManager,
+                                       EventStoreFactory eventStoreFactory,
+                                       EventStoreRecordRepository eventStoreRecordRepository
+    ) throws ServiceEventBusException {
+
+        String address = KapuaDeviceRegistrySettings.getInstance().getString(KapuaDeviceRegistrySettingKeys.DEVICE_EVENT_ADDRESS);
+        return new DeviceConnectionEventListenerServiceModule(
+                deviceConnectionEventListenerService,
+                address,
+                new ServiceEventHouseKeeperFactoryImpl(
+                        new EventStoreServiceImpl(
+                                authorizationService,
+                                permissionFactory,
+                                txManager,
+                                eventStoreFactory,
+                                eventStoreRecordRepository
+                        ),
+                        txManager
+                ));
+    }
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceImpl.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.connection.listener.internal;
+
+import java.util.ArrayList;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.event.ListenServiceEvent;
+import org.eclipse.kapua.event.ServiceEvent;
+import org.eclipse.kapua.service.device.connection.listener.DeviceConnectionEventListenerService;
+import org.eclipse.kapua.service.device.connection.listener.DeviceConnectionEventReceiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class DeviceConnectionEventListenerServiceImpl implements DeviceConnectionEventListenerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeviceConnectionEventListenerServiceImpl.class);
+
+    protected static final String DISCONNECT = "disconnect";
+
+    protected ArrayList<DeviceConnectionEventReceiver> receivers = new ArrayList<>();
+
+    @Inject
+    public DeviceConnectionEventListenerServiceImpl() {
+        LOGGER.info("Initializing {}", DeviceConnectionEventListenerServiceImpl.class);
+    }
+
+    @Override
+    @ListenServiceEvent(fromAddress = "device")
+    public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException {
+        LOGGER.info("Received event: {}", kapuaEvent);
+
+        for(DeviceConnectionEventReceiver receiver : receivers) {
+            LOGGER.debug("Notifying receiver: {}", receiver);
+            receiver.receiveEvent(kapuaEvent);
+        }
+    }
+
+    @Override
+    public void addReceiver(DeviceConnectionEventReceiver receiver) {
+        LOGGER.info("Add receiver: {}", receiver);
+        synchronized(receivers) {
+            receivers.add(receiver);
+        }
+    }
+
+    @Override
+    public void removeReceiver(DeviceConnectionEventReceiver receiver) {
+        LOGGER.info("Rmove receiver: {}", receiver);
+        synchronized(receivers) {
+            receivers.remove(receiver);
+        }
+    }
+
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceModule.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.connection.listener.internal;
+
+import org.eclipse.kapua.commons.core.ServiceModule;
+import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
+import org.eclipse.kapua.commons.event.ServiceEventHouseKeeperFactory;
+import org.eclipse.kapua.commons.event.ServiceEventTransactionalModule;
+import org.eclipse.kapua.commons.event.ServiceInspector;
+import org.eclipse.kapua.service.device.connection.listener.DeviceConnectionEventListenerService;
+
+public class DeviceConnectionEventListenerServiceModule extends ServiceEventTransactionalModule implements ServiceModule {
+
+    public DeviceConnectionEventListenerServiceModule(DeviceConnectionEventListenerService deviceConnectionEventListenerService, String eventAddress, ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory) {
+        super(ServiceInspector.getEventBusClients(deviceConnectionEventListenerService, DeviceConnectionEventListenerService.class).toArray(new ServiceEventClientConfiguration[0]),
+                eventAddress,
+                serviceEventTransactionalHousekeeperFactory);
+    }
+
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceConnectionServiceConfigurationModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceConnectionServiceConfigurationModule.java
@@ -44,7 +44,7 @@ public class DeviceConnectionServiceConfigurationModule extends AbstractKapuaMod
     @Provides
     @Singleton
     @Named("DeviceConnectionServiceConfigurationManager")
-    ServiceConfigurationManager deviceConnectionServiceConfigurationManager(
+    protected ServiceConfigurationManager deviceConnectionServiceConfigurationManager(
             RootUserTester rootUserTester,
             KapuaJpaRepositoryConfiguration jpaRepoConfig,
             Map<String, DeviceConnectionCredentialAdapter> availableDeviceConnectionAdapters,

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
 import org.eclipse.kapua.commons.event.ServiceEventHouseKeeperFactory;
 import org.eclipse.kapua.commons.event.ServiceEventTransactionalModule;
 import org.eclipse.kapua.commons.event.ServiceInspector;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
-
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 public class DeviceServiceModule extends ServiceEventTransactionalModule {
 
@@ -28,7 +28,7 @@ public class DeviceServiceModule extends ServiceEventTransactionalModule {
                                KapuaDeviceRegistrySettings deviceRegistrySettings,
                                ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory) {
         super(Arrays.asList(ServiceInspector.getEventBusClients(deviceRegistryService, DeviceRegistryService.class),
-                                ServiceInspector.getEventBusClients(deviceConnectionService, DeviceRegistryService.class)
+                                ServiceInspector.getEventBusClients(deviceConnectionService, DeviceConnectionService.class)
                         )
                         .stream()
                         .flatMap(l -> l.stream())

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
@@ -59,10 +60,10 @@ public class DeviceRegistryServiceImpl
 
     @Inject
     public DeviceRegistryServiceImpl(
-            ServiceConfigurationManager serviceConfigurationManager,
+            @Named("DeviceRegistryServiceConfigurationManager") ServiceConfigurationManager serviceConfigurationManager,
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
-            TxManager txManager,
+            @Named("DeviceRegistryTransactionManager") TxManager txManager,
             DeviceRepository deviceRepository,
             DeviceFactory entityFactory,
             GroupQueryHelper groupQueryHelper,

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/BrokerSteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/BrokerSteps.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSetting;
-import org.eclipse.kapua.commons.core.ServiceModuleBundle;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.qa.common.StepData;
@@ -168,9 +167,6 @@ public class BrokerSteps extends TestBase {
         deviceCommandFactory = locator.getFactory(DeviceCommandFactory.class);
         deviceConnectionService = locator.getService(DeviceConnectionService.class);
         deviceAssetManagementService = locator.getService(DeviceAssetManagementService.class);
-
-        // Setup service events
-        locator.getService(ServiceModuleBundle.class).startup();
     }
 
     @Before(value = "@env_docker or @env_docker_base or @env_none", order = 10)

--- a/service/device/registry/test/src/test/java/org/eclipse/kapua/service/device/registry/test/DeviceRegistryLocatorConfiguration.java
+++ b/service/device/registry/test/src/test/java/org/eclipse/kapua/service/device/registry/test/DeviceRegistryLocatorConfiguration.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
+import org.eclipse.kapua.commons.jpa.EventStorer;
 import org.eclipse.kapua.commons.jpa.EventStorerImpl;
 import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
 import org.eclipse.kapua.commons.jpa.KapuaJpaTxManagerFactory;
@@ -114,6 +115,7 @@ public class DeviceRegistryLocatorConfiguration {
                 bind(DeviceFactory.class).toInstance(new DeviceFactoryImpl());
                 final KapuaJpaRepositoryConfiguration jpaRepoConfig = new KapuaJpaRepositoryConfiguration();
                 final TxManager txManager = new KapuaJpaTxManagerFactory(maxInsertAttempts).create("kapua-device");
+                final EventStorer eventStorer = new EventStorerImpl(new EventStoreRecordImplJpaRepository(jpaRepoConfig));
                 bind(DeviceConnectionService.class).toInstance(new DeviceConnectionServiceImpl(
                         Mockito.mock(ServiceConfigurationManager.class),
                         mockedAuthorization,
@@ -121,7 +123,8 @@ public class DeviceRegistryLocatorConfiguration {
                         new DeviceConnectionFactoryImpl(),
                         txManager,
                         new DeviceConnectionImplJpaRepository(jpaRepoConfig),
-                        availableDeviceConnectionAdapters));
+                        availableDeviceConnectionAdapters,
+                        eventStorer));
                 bind(DeviceConnectionFactory.class).toInstance(new DeviceConnectionFactoryImpl());
 
                 bind(DeviceRepository.class).toInstance(new DeviceImplJpaRepository(jpaRepoConfig));
@@ -145,7 +148,7 @@ public class DeviceRegistryLocatorConfiguration {
                         new DeviceImplJpaRepository(jpaRepoConfig),
                         new DeviceFactoryImpl(),
                         Mockito.mock(GroupQueryHelper.class),
-                        new EventStorerImpl(new EventStoreRecordImplJpaRepository(jpaRepoConfig)))
+                        eventStorer)
                 );
             }
         };


### PR DESCRIPTION
This adds the option to request that a DeviceConnection be disconnected from the broker via the REST API.

**Related Issue**
None

**Description of the solution adopted**
There was an existing "disconnect" method in the DeviceConnectionService API that had never been implemented and had been marked as deprecated.  This adds an implementation for the disconnect request, but using the KapuaId of the connection instead of the clientId string.  It works by raising a service event which the broker is listening for.

To implement this I added a new DeviceConnectionEventListenerService to setup the event listening, and the ServerPlugin registers itself with this service as a receiver of those messages.  When it receives a disconnect event, it makes use of the existing BrokerEventHandler to perform the disconnection.

In order for this to work I also had to have the ServerPlugin setup the KapuaLocator, startup the ServiceModuleBundle, and add a JAXBContextProvider.

**Screenshots**
None

**Any side note on the changes made**
None