### PR TITLE
feat(deviceManagement): mapped missing `DeviceInventoryContainer.state` property

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventoryTabContainer.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventoryTabContainer.java
@@ -114,6 +114,12 @@ public class DeviceTabInventoryTabContainer extends TabItem {
         column.setWidth(80);
         configs.add(column);
 
+        column = new ColumnConfig();
+        column.setId("state");
+        column.setHeader("State");
+        column.setWidth(80);
+        configs.add(column);
+
         ColumnModel columnModel = new ColumnModel(configs);
 
         RpcProxy<ListLoadResult<GwtInventoryContainer>> proxy = new RpcProxy<ListLoadResult<GwtInventoryContainer>>() {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceInventoryManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceInventoryManagementServiceImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundles;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
+import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerState;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
@@ -154,6 +155,7 @@ public class GwtDeviceInventoryManagementServiceImpl extends KapuaRemoteServiceS
                 gwtInventoryContainer.setName(inventoryContainer.getName());
                 gwtInventoryContainer.setVersion(inventoryContainer.getVersion());
                 gwtInventoryContainer.setType(inventoryContainer.getContainerType());
+                gwtInventoryContainer.setState(inventoryContainer.getState().name());
 
                 gwtInventoryContainers.add(gwtInventoryContainer);
             }
@@ -176,6 +178,7 @@ public class GwtDeviceInventoryManagementServiceImpl extends KapuaRemoteServiceS
             deviceInventoryContainer.setName(gwtInventoryContainer.getName());
             deviceInventoryContainer.setVersion(gwtInventoryContainer.getVersion());
             deviceInventoryContainer.setContainerType(gwtInventoryContainer.getType());
+            deviceInventoryContainer.setState(DeviceInventoryContainerState.valueOf(gwtInventoryContainer.getState()));
 
             DEVICE_INVENTORY_MANAGEMENT_SERVICE.execContainer(
                     scopeId,

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/management/inventory/GwtInventoryContainer.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/management/inventory/GwtInventoryContainer.java
@@ -16,6 +16,22 @@ import org.eclipse.kapua.app.console.module.api.shared.model.KapuaBaseModel;
 
 public class GwtInventoryContainer extends KapuaBaseModel {
 
+    public enum GwtInventoryContainerState {
+        UNKNOWN,
+        INSTALLED,
+        UNINSTALLED,
+        ACTIVE
+    }
+
+    @Override
+    public <X> X get(String property) {
+        if ("stateEnum".equals(property)) {
+            return (X) (GwtInventoryContainer.GwtInventoryContainerState.valueOf(getState()));
+        } else {
+            return super.get(property);
+        }
+    }
+
     private static final long serialVersionUID = -4434969168565872354L;
 
     public void setName(String name) {
@@ -41,4 +57,17 @@ public class GwtInventoryContainer extends KapuaBaseModel {
     public String getType() {
         return get("type");
     }
+
+    public String getState() {
+        return get("state");
+    }
+
+    public GwtInventoryContainerState getStateEnum() {
+        return get("stateEnum");
+    }
+
+    public void setState(String state) {
+        set("state", state);
+    }
+
 }

--- a/qa/integration/src/test/resources/mqtt/INVENTORY-V1_GET_inventory_containers_reply.json
+++ b/qa/integration/src/test/resources/mqtt/INVENTORY-V1_GET_inventory_containers_reply.json
@@ -8,52 +8,62 @@
     {
       "name": "consumer-telemetry",
       "version": "kapua/kapua-consumer-telemetry:latest",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "ACTIVE"
     },
     {
       "name": "job-engine",
       "version": "kapua/kapua-job-engine:latest",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "ACTIVE"
     },
     {
       "name": "kapua-console",
       "version": "kapua/kapua-console:latest",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "ACTIVE"
     },
     {
       "name": "kapua-api",
       "version": "kapua/kapua-api:latest",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "ACTIVE"
     },
     {
       "name": "message-broker",
       "version": "kapua/kapua-broker:latest",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "ACTIVE"
     },
     {
       "name": "es",
       "version": "docker.elastic.co/elasticsearch/elasticsearch:7.8.1",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "ACTIVE"
     },
     {
       "name": "db",
       "version": "kapua/kapua-sql:latest",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "ACTIVE"
     },
     {
       "name": "events-broker",
       "version": "kapua/kapua-events-broker:latest",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "UNKNOWN"
     },
     {
       "name": "clever_heisenberg",
       "version": "kura_alpine:",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "UNINSTALLED"
     },
     {
       "name": "kura",
       "version": "eclipse/kura:latest",
-      "type": "DOCKER"
+      "type": "DOCKER",
+      "state": "INSTALLED"
     }
   ]
 }

--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory.yaml
@@ -11,7 +11,7 @@ info:
     name: Eclipse Public License 2.0
     url: https://www.eclipse.org/legal/epl-2.0
 
-paths: { }
+paths: {}
 
 components:
   schemas:
@@ -81,6 +81,13 @@ components:
             name: org.eclipse.equinox.cm
             version: 1.4.400.v20200422-1833
             status: RESOLVED
+    deviceInventoryContainerState:
+      type: string
+      enum:
+        - ACTIVE
+        - INSTALLED
+        - UNINSTALLED
+        - UNKNOWN
     deviceInventoryContainer:
       type: object
       properties:
@@ -90,10 +97,13 @@ components:
           type: string
         containerType:
           type: string
+        state:
+          $ref: '#/components/schemas/deviceInventoryContainerState'
       example:
         name: docker_container_1
         version: nginx:latest
         containerType: DOCKER
+        state: ACTIVE
     deviceInventoryContainers:
       type: object
       properties:
@@ -107,9 +117,11 @@ components:
           - name: docker_container_1
             version: nginx:latest
             containerType: DOCKER
+            state: ACTIVE
           - name: docker_container_2
             version: haproxy:latest
             containerType: DOCKER
+            state: INSTALLED
     deviceInventorySystemPackage:
       type: object
       properties:

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/inventory/containers/KuraInventoryContainer.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/inventory/containers/KuraInventoryContainer.java
@@ -32,6 +32,9 @@ public class KuraInventoryContainer {
     @JsonProperty("type")
     public String type;
 
+    @JsonProperty("state")
+    public String state;
+
     /**
      * Gets the name.
      *
@@ -73,9 +76,9 @@ public class KuraInventoryContainer {
     }
 
     /**
-     * Gets the state.
+     * Gets the type.
      *
-     * @return The state.
+     * @return The type.
      * @since 2.0.0
      */
     public String getType() {
@@ -83,13 +86,32 @@ public class KuraInventoryContainer {
     }
 
     /**
-     * Sets the state.
+     * Sets the type.
      *
-     * @param type The state.
+     * @param type The type.
      * @since 2.0.0
      */
     public void setType(String type) {
         this.type = type;
     }
 
+    /**
+     * Gets the state
+     *
+     * @return The state
+     * @since 2.0.0
+     */
+    public String getState() {
+        return state;
+    }
+
+    /**
+     * Sets the state
+     *
+     * @param state The state
+     * @since 2.0.0
+     */
+    public void setState(String state) {
+        this.state = state;
+    }
 }

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/container/DeviceInventoryContainer.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/container/DeviceInventoryContainer.java
@@ -80,4 +80,21 @@ public interface DeviceInventoryContainer {
      * @since 2.0.0
      */
     void setContainerType(String containerType);
+
+    /**
+     * Gets the {@link DeviceInventoryContainerState}.
+     *
+     * @return The {@link DeviceInventoryContainerState}.
+     * @since 2.0.0
+     */
+    DeviceInventoryContainerState getState();
+
+    /**
+     * Sets the {@link DeviceInventoryContainerState}.
+     *
+     * @param state The {@link DeviceInventoryContainerState}.
+     * @since 2.0.0
+     */
+    void setState(DeviceInventoryContainerState state);
+
 }

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/container/DeviceInventoryContainerState.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/container/DeviceInventoryContainerState.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory.model.container;
+
+/**
+ * The {@link DeviceInventoryContainer} states.
+ *
+ * @since 2.0.0
+ */
+public enum DeviceInventoryContainerState {
+
+    /**
+     * The container is running.
+     *
+     * @since 2.0.0
+     */
+    ACTIVE,
+
+    /**
+     * The container is starting
+     *
+     * @since 2.0.0
+     */
+    INSTALLED,
+
+    /**
+     * Tontainer has failed, or is stopped
+     *
+     * @since 2.0.0
+     */
+    UNINSTALLED,
+
+    /**
+     * The container state can not be determined
+     *
+     * @since 2.0.0
+     */
+    UNKNOWN,
+}

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
@@ -307,6 +307,7 @@ public class DeviceInventoryManagementServiceImpl extends AbstractDeviceManageme
         ArgumentValidator.notNull(deviceInventoryContainer.getName(), "deviceInventoryContainer.name");
         ArgumentValidator.notNull(deviceInventoryContainer.getVersion(), "deviceInventoryContainer.version");
         ArgumentValidator.notNull(deviceInventoryContainer.getContainerType(), "deviceInventoryContainer.type");
+        ArgumentValidator.notNull(deviceInventoryContainer.getState(), "deviceInventoryContainer.state");
         ArgumentValidator.notNull(deviceInventoryContainerAction, "deviceInventoryContainerAction");
         // Check Access
         authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
@@ -306,8 +306,6 @@ public class DeviceInventoryManagementServiceImpl extends AbstractDeviceManageme
         ArgumentValidator.notNull(deviceInventoryContainer, "deviceInventoryContainer");
         ArgumentValidator.notNull(deviceInventoryContainer.getName(), "deviceInventoryContainer.name");
         ArgumentValidator.notNull(deviceInventoryContainer.getVersion(), "deviceInventoryContainer.version");
-        ArgumentValidator.notNull(deviceInventoryContainer.getContainerType(), "deviceInventoryContainer.type");
-        ArgumentValidator.notNull(deviceInventoryContainer.getState(), "deviceInventoryContainer.state");
         ArgumentValidator.notNull(deviceInventoryContainerAction, "deviceInventoryContainerAction");
         // Check Access
         authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/container/internal/DeviceInventoryContainerImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/container/internal/DeviceInventoryContainerImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.service.device.management.inventory.model.container.internal;
 
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
+import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerState;
 
 /**
  * {@link DeviceInventoryContainer} implementation.
@@ -24,6 +25,8 @@ public class DeviceInventoryContainerImpl implements DeviceInventoryContainer {
     private String name;
     private String version;
     private String containerType;
+
+    private DeviceInventoryContainerState state;
 
     /**
      * Constructor.
@@ -61,5 +64,15 @@ public class DeviceInventoryContainerImpl implements DeviceInventoryContainer {
     @Override
     public void setContainerType(String containerType) {
         this.containerType = containerType;
+    }
+
+
+    public DeviceInventoryContainerState getState() {
+        return state;
+    }
+
+    @Override
+    public void setState(DeviceInventoryContainerState state) {
+        this.state = state;
     }
 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/inventory/TranslatorAppInventoryContainerExecKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/inventory/TranslatorAppInventoryContainerExecKapuaKura.java
@@ -74,6 +74,9 @@ public class TranslatorAppInventoryContainerExecKapuaKura extends AbstractTransl
                 kuraInventoryContainer.setName(deviceInventoryContainer.getName());
                 kuraInventoryContainer.setVersion(deviceInventoryContainer.getVersion());
                 kuraInventoryContainer.setType(deviceInventoryContainer.getContainerType());
+                if (deviceInventoryContainer.getState() != null) {
+                    kuraInventoryContainer.setState(deviceInventoryContainer.getState().name());
+                }
 
                 kuraRequestPayload.setBody(getJsonMapper().writeValueAsString(kuraInventoryContainer).getBytes(CHAR_ENCODING));
             }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
@@ -140,11 +140,13 @@ public class AbstractTranslatorAppInventoryKuraKapua<M extends InventoryResponse
             deviceInventoryContainer.setVersion(kuraInventoryContainer.getVersion());
             deviceInventoryContainer.setContainerType(kuraInventoryContainer.getType());
 
-            try {
-                deviceInventoryContainer.setState(DeviceInventoryContainerState.valueOf(kuraInventoryContainer.getState()));
-            } catch (IllegalArgumentException iae) {
-                LOG.warn("Unrecognised KuraInventoryContainer.state '{}' received. Defaulting to UNKNOWN state for DeviceInventoryContainer {}", kuraInventoryContainer.getState(), deviceInventoryContainer.getName(), iae);
-                deviceInventoryContainer.setState(DeviceInventoryContainerState.UNKNOWN);
+            if (deviceInventoryContainer.getState() != null) {
+                try {
+                    deviceInventoryContainer.setState(DeviceInventoryContainerState.valueOf(kuraInventoryContainer.getState()));
+                } catch (IllegalArgumentException iae) {
+                    LOG.warn("Unrecognised KuraInventoryContainer.state '{}' received. Defaulting to UNKNOWN state for DeviceInventoryContainer {}", kuraInventoryContainer.getState(), deviceInventoryContainer.getName(), iae);
+                    deviceInventoryContainer.setState(DeviceInventoryContainerState.UNKNOWN);
+                }
             }
 
             deviceInventoryContainers.addInventoryContainer(deviceInventoryContainer);

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
@@ -28,6 +28,7 @@ import org.eclipse.kapua.service.device.management.inventory.internal.message.In
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundle;
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundles;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
+import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerState;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
@@ -39,6 +40,8 @@ import org.eclipse.kapua.translator.Translator;
 import org.eclipse.kapua.translator.exception.InvalidChannelException;
 import org.eclipse.kapua.translator.kura.kapua.AbstractSimpleTranslatorResponseKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.TranslatorKuraKapuaUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link Translator} {@code abstract} implementation from {@link KuraResponseMessage} to {@link InventoryResponseMessage}
@@ -46,6 +49,8 @@ import org.eclipse.kapua.translator.kura.kapua.TranslatorKuraKapuaUtils;
  * @since 1.5.0
  */
 public class AbstractTranslatorAppInventoryKuraKapua<M extends InventoryResponseMessage> extends AbstractSimpleTranslatorResponseKuraKapua<InventoryResponseChannel, InventoryResponsePayload, M> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractTranslatorAppInventoryKuraKapua.class);
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
@@ -134,6 +139,13 @@ public class AbstractTranslatorAppInventoryKuraKapua<M extends InventoryResponse
             deviceInventoryContainer.setName(kuraInventoryContainer.getName());
             deviceInventoryContainer.setVersion(kuraInventoryContainer.getVersion());
             deviceInventoryContainer.setContainerType(kuraInventoryContainer.getType());
+
+            try {
+                deviceInventoryContainer.setState(DeviceInventoryContainerState.valueOf(kuraInventoryContainer.getState()));
+            } catch (IllegalArgumentException iae) {
+                LOG.warn("Unrecognised KuraInventoryContainer.state '{}' received. Defaulting to UNKNOWN state for DeviceInventoryContainer {}", kuraInventoryContainer.getState(), deviceInventoryContainer.getName(), iae);
+                deviceInventoryContainer.setState(DeviceInventoryContainerState.UNKNOWN);
+            }
 
             deviceInventoryContainers.addInventoryContainer(deviceInventoryContainer);
         });


### PR DESCRIPTION
This PR maps the `state` property of the DeviceInventoryContainer object.

**Related Issue**
_None_

**Description of the solution adopted**
Mapped new property according to [Kura Inventory Documentation](https://esf.eurotech.com/docs/mqtt-namespace#inventory-containers)

**Screenshots**
_None_

**Any side note on the changes made**
FIxed required parameters for  start and stop operations on Device Inventory Container