### PR TITLE
FIX - introduced new changeset to update databasechangelog

### DIFF
--- a/commons/src/main/resources/liquibase/2.0.0/databasechangelog_fields_update.xml
+++ b/commons/src/main/resources/liquibase/2.0.0/databasechangelog_fields_update.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/databasechangelog_fields_update.xml">
+
+    <!-- This changesets maintains aligned the schema of the "databasechangelog" table between different liquibase versions, upgrading the important fields that could cause problems in liquibase updates -->
+    <!-- This is needed because liquibase doesn't automatically update schema when the specification of "databasechangelog" table changes (as happened, for example, between the 3.0.5 version and 3.6.7) -->
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="databasechangelog_removePrimaryKeyConstraint" author="eurotech"> <!-- recent versions removed primary key constraint between <id, author, filename> fields, see https://forum.liquibase.org/t/length-of-id-column-for-databasechangeloglog/1274 regarding old limit on 63 chars. Maybe this changeset could be deleted but maintained to avoid problems-->
+        <preConditions onFail="MARK_RAN">
+            <primaryKeyExists tableName="databasechangelog" primaryKeyName="pk_databasechangelog"/>
+        </preConditions>
+        <dropPrimaryKey tableName="databasechangelog" constraintName="pk_databasechangelog"/>
+    </changeSet>
+
+    <changeSet id="databasechangelog_fields-update-id" author="eurotech">
+        <modifyDataType
+                columnName="id"
+                newDataType="varchar(255)"
+                tableName="databasechangelog"/>
+    </changeSet>
+
+    <changeSet id="databasechangelog_fields-update-id-notnull" author="eurotech" dbms="mariadb"> <!--this changeset is needed because for mysql/mariadb you loose not null constraint with previous changeset -->
+    <addNotNullConstraint
+            columnName="id"
+            columnDataType="varchar(255)"
+            tableName="databasechangelog"/>
+    </changeSet>
+
+    <changeSet id="databasechangelog_fields-update-filename" author="eurotech">
+        <modifyDataType
+                columnName="filename"
+                newDataType="varchar(255)"
+                tableName="databasechangelog"/>
+    </changeSet>
+
+    <changeSet id="databasechangelog_fields-update-filename-notnull" author="eurotech" dbms="mariadb"> <!--this changeset is needed because for mysql/mariadb you loose not null constraint with previous changeset -->
+        <addNotNullConstraint
+                columnName="filename"
+                columnDataType="varchar(255)"
+                tableName="databasechangelog"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/commons/src/main/resources/liquibase/changelog-databasechangelog-fields-update-master.pre.xml
+++ b/commons/src/main/resources/liquibase/changelog-databasechangelog-fields-update-master.pre.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./2.0.0/databasechangelog_fields_update.xml"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
Brief description of the PR.
Old versions of liquibase (for example, 3.0.5 used in old kapua releases) were using different fields and columns in the "databasechangelog" table wrt to new versions (for example, the 3.6.7 the latest releases are using). 
The problem is that upgrading between different liquibase versions, the tool does not upgrade fields and as a consequence, you could have an installation with the latest kapua release and the old state of the databasechangelog table in it.
To be precise, if new columns are added to the specification of the databasechangelog table in a new liquibase version, then running an update with that new version inserts the columns BUT pre-existing fields are not modified in the process, so if they have been modified in length they will remain with the old length.

This, for example, poses a limitation on the size of id for liquibase changesets because in the old versions the field had 63 chars but then became 255 chars.

**Description of the solution adopted**
In order to maintain updated the "databasechangelog" table, a new changelog file has been added that keeps that table updated. Only the relevant fields has been inserted inside this changelog (_id_ and _filename_) because they are the only ones that could pose a factual limitation on future liquibase updates. 

**Any side note on the changes made**
The added changelog has to be maintained aligned with modifications on databasechangelog specification and the liquibase version we will use in the future. This is bad but necessary considering that liquibase doesn't take the responsibility to do this dirty work