### PR TITLE
FIX - count dataStore items when more than 10k documents stored

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterServlet.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterServlet.java
@@ -21,11 +21,13 @@ import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModel
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.MessageStoreFactory;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory;
+import org.eclipse.kapua.service.elasticsearch.client.exception.ClientLimitsExceededException;
 import org.eclipse.kapua.service.storable.model.query.SortDirection;
 import org.eclipse.kapua.service.storable.model.query.SortField;
 import org.eclipse.kapua.service.storable.model.query.predicate.AndPredicate;
@@ -132,8 +134,16 @@ public class DataExporterServlet extends HttpServlet {
 
             query.setPredicate(predicate);
             MessageListResult result;
+            long totalCount = 0;
 
-            long totalCount = MESSAGE_STORE_SERVICE.count(query);
+            try {
+                totalCount = MESSAGE_STORE_SERVICE.count(query);
+            } catch (DatastoreException e) {
+                if (e.getCause() != null && (e.getCause() instanceof ClientLimitsExceededException) ) { //case in which there are more than 10k results in datastore but ES cannot count them precisely
+                    totalCount = 10000;
+                }
+            }
+
             long totalOffset = 0;
             query.setLimit(250);
             int maxRows = MAX_PAGE_SIZE * MAX_PAGES;

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterServlet.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterServlet.java
@@ -18,16 +18,15 @@ import org.eclipse.kapua.KapuaUnauthenticatedException;
 import org.eclipse.kapua.app.console.module.api.setting.ConsoleSetting;
 import org.eclipse.kapua.app.console.module.api.setting.ConsoleSettingKeys;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
+import org.eclipse.kapua.app.console.module.data.shared.util.KapuaGwtDataModelConverter;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.MessageStoreFactory;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
-import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory;
-import org.eclipse.kapua.service.elasticsearch.client.exception.ClientLimitsExceededException;
 import org.eclipse.kapua.service.storable.model.query.SortDirection;
 import org.eclipse.kapua.service.storable.model.query.SortField;
 import org.eclipse.kapua.service.storable.model.query.predicate.AndPredicate;
@@ -135,14 +134,7 @@ public class DataExporterServlet extends HttpServlet {
             query.setPredicate(predicate);
             MessageListResult result;
             long totalCount = 0;
-
-            try {
-                totalCount = MESSAGE_STORE_SERVICE.count(query);
-            } catch (DatastoreException e) {
-                if (e.getCause() != null && (e.getCause() instanceof ClientLimitsExceededException) ) { //case in which there are more than 10k results in datastore but ES cannot count them precisely
-                    totalCount = 10000;
-                }
-            }
+            totalCount = KapuaGwtDataModelConverter.countEsDataCap10k(MESSAGE_STORE_SERVICE, query);
 
             long totalOffset = 0;
             query.setLimit(250);

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/KapuaGwtDataModelConverter.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/KapuaGwtDataModelConverter.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.data.shared.util;
 
+import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.module.data.client.GwtTopic;
 import org.eclipse.kapua.app.console.module.data.client.util.GwtMessage;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreAsset;
@@ -21,6 +22,11 @@ import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
+import org.eclipse.kapua.service.elasticsearch.client.exception.ClientLimitsExceededException;
+import org.eclipse.kapua.service.storable.StorableService;
+import org.eclipse.kapua.service.storable.model.Storable;
+import org.eclipse.kapua.service.storable.model.StorableListResult;
+import org.eclipse.kapua.service.storable.model.query.StorableQuery;
 
 import java.util.List;
 
@@ -74,5 +80,27 @@ public class KapuaGwtDataModelConverter {
             gwtMessage.set(header.getName(), message.getPayload().getMetrics().get(header.getName()));
         }
         return gwtMessage;
+    }
+
+    /**
+     * This method counts the documents in ES (clients, channels, messages etc.) with a cap to 10k (the maximum value that the Datastore it's capable of counting).
+     * This is accomplished converting the ClientLimitsExceededException thrown when there are more than 10k messages to a result of 10k
+     * In a sense, this method is an adapter inserted into the console code for the introduction of the ClientLimitsExceededException, because before counting was capped to 10k as well in the console logic
+     * @param service the StorableService instance where you want to count documents
+     * @param query the count query that will be performed on the service
+     * @return the number of requested documents
+     */
+    public static <S extends Storable, L extends StorableListResult<S>, Q extends StorableQuery> long countEsDataCap10k(StorableService<S,L,Q> service, Q query) throws KapuaException {
+        long totalLength = 0;
+        try {
+            totalLength = service.count(query);
+        } catch (KapuaException e) {
+            if (e.getCause() != null && (e.getCause() instanceof ClientLimitsExceededException)) { //case in which there are more than 10k results in datastore but ES cannot count them precisely
+                totalLength = 10000;
+            } else {
+                throw e;
+            }
+        }
+        return totalLength;
     }
 }

--- a/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/client/messages/ConsoleDataMessages.properties
+++ b/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/client/messages/ConsoleDataMessages.properties
@@ -76,4 +76,4 @@ dateRange=Date Range:
 refresh=Refresh
 searchButton=Search
 
-warningLimitReached=Warning! The query returned more than 10000 results. Please refine the time range.
+warningLimitReached=Warning! These are the last 10k results, but the datastore could contain more. Please refine the date range in order to extract all of them. This impacts also the "export to csv" feature.

--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -1441,6 +1441,18 @@ Feature: Datastore tests
     Then The message list "MessageInfo" have limitExceed value true
     And I delete all indices
 
+  Scenario: Create 10k messages and more, test if counting messages throws exception
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I store 10001 messages in bulk mode to the index "1-data-message-2023-1"
+    And I refresh all indices
+    Given I expect the exception "DatastoreException" with the text "An internal error occurred: Elasticsearch internal limits exceeded: MAX_RESULT_WINDOW overflow, unable to count precise number of documents stored in ES (more than 10k)"
+    When I create message query for current account with limit 1
+    And I count for data message
+    Then An exception was thrown
+    And I delete all indices
+
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/ElasticsearchRepository.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/ElasticsearchRepository.java
@@ -157,7 +157,7 @@ public abstract class ElasticsearchRepository<
 
             return elasticsearchClientProviderInstance.getElasticsearchClient().count(getDescriptor(indexName), query);
         } catch (ClientException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/exception/ClientErrorCodes.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/exception/ClientErrorCodes.java
@@ -89,5 +89,13 @@ public enum ClientErrorCodes implements KapuaErrorCode {
      *
      * @since 1.3.0
      */
-    ACTION_RESPONSE_ERROR
+    ACTION_RESPONSE_ERROR,
+
+    /**
+     * see {@link ClientLimitsExceededException}
+     *
+     * @since 2.0.0
+     */
+    LIMITS_EXCEEDED
+
 }

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/exception/ClientLimitsExceededException.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/exception/ClientLimitsExceededException.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.elasticsearch.client.exception;
+
+import org.eclipse.kapua.service.elasticsearch.client.ElasticsearchClient;
+
+/**
+ * {@link ClientException} to throw when {@link ElasticsearchClient} received a request that is not able to process correctly for internal technical limits problems.
+ *
+ * @since 2.0.0
+ */
+public class ClientLimitsExceededException extends ClientException {
+
+    private static final long serialVersionUID = 2212581033816589804L;
+
+    private final String reason;
+
+    /**
+     * Constructor.
+     *
+     * @param reason The reason of the exception.
+     * @since 2.0.0
+     */
+    public ClientLimitsExceededException(String reason) {
+        this(null, reason);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cause  The root {@link Throwable} of this {@link ClientLimitsExceededException}.
+     * @param reason The reason of the exception.
+     * @since 2.0.0
+     */
+    public ClientLimitsExceededException(Throwable cause, String reason) {
+        super(ClientErrorCodes.LIMITS_EXCEEDED, cause, reason);
+
+        this.reason = reason;
+    }
+
+    /**
+     * Gets the reason of the initialization error.
+     *
+     * @return The reason of the initialization error.
+     * @since 2.0.0
+     */
+    public String getReason() {
+        return reason;
+    }
+
+
+}

--- a/service/commons/elasticsearch/client-api/src/main/resources/elasticsearch-client-error-messages.properties
+++ b/service/commons/elasticsearch/client-api/src/main/resources/elasticsearch-client-error-messages.properties
@@ -22,6 +22,7 @@ CLIENT_UNAVAILABLE=The Elasticsearch Client is not currently available: {0}
 
 DATAMODEL_MAPPING_EXCEPTION=Document cannot be mapped. Cause: {0}
 QUERY_MAPPING_EXCEPTION=Query cannot be mapped.
+LIMITS_EXCEEDED=Elasticsearch internal limits exceeded: {0}
 
 INTERNAL_ERROR=Internal client error! Error: {0}
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -36,6 +36,7 @@ import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.elasticsearch.client.exception.ClientCommunicationException;
+import org.eclipse.kapua.service.elasticsearch.client.exception.ClientException;
 import org.eclipse.kapua.service.storable.model.id.StorableId;
 import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
 import org.eclipse.kapua.storage.TxManager;
@@ -183,7 +184,9 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
             return messageStoreFacade.count(query);
         } catch (Exception e) {
             logException(e);
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getMessage());
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR,
+                    e.getCause() != null && (e.getCause() instanceof ClientException) ? e.getCause() : e, //in case where there is a ClientException I just want this as a cause and not the runtime exception
+                    e.getMessage());
         }
     }
 

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -1387,10 +1387,15 @@ public class DatastoreSteps extends TestBase {
     }
 
     @When("I count for data message(s)")
-    public void countForDataMessage() throws KapuaException {
-        MessageQuery messageQuery = (MessageQuery) stepData.get(MESSAGE_QUERY);
-        long count = messageStoreService.count(messageQuery);
-        stepData.put(MESSAGE_COUNT_RESULT, count);
+    public void countForDataMessage() throws Exception {
+        primeException();
+        try {
+            MessageQuery messageQuery = (MessageQuery) stepData.get(MESSAGE_QUERY);
+            long count = messageStoreService.count(messageQuery);
+            stepData.put(MESSAGE_COUNT_RESULT, count);
+        } catch (KapuaException e) {
+            verifyException(e);
+        }
     }
 
     @Then("I get message count {int}")


### PR DESCRIPTION
**Brief description of the PR**
For the ES technical limit on max. 10k documents fetched that has not been taken into consideration in the past, the count of total number of documents counted via the kapua API (for example, in the case of the call to the API _/{scopeId}/data/messages/_count_ or in _/{scopeId}/data/messages_ but also in _/{scopeId}/data/channels_) is limited to a maximum value of 10k results, even when more than 10k documents are in the dataStore.

**Description of the solution adopted**
A new **ClientException** has been added to notify when ES internal limits are exceeded, for example in this case of overflow in the MAX_RESULT_WINDOW internal value (10k as default). Coupled together with a meaningful message, now clients are notified when there are actually more results on the dataStore.

*console adaptation to this new exception*
The console code has been adapted to expect this new Exception and the behaviour is similar to the old logic: total number of counted documents (and queried) is capped at 10k and there is an appropriate warning that signals to the user the fact that more documents exists in the datastore. I revisited this message ( that was already present in the code) with a more meaningful one. 

*test*
a test for the new **ClientException** has been added to verify that is in fact thrown when there are more than 10k messages in the dataStore

**side notes or improvements**
With this contribution, the error code returned via the API when more than 10k messages are in the datastore is 500.
Maybe, a more appropriate one would be in the range 4xx but I noticed that, in the present code, all the exceptions regarding ElasticSearchClient (**ClientException**s) are converted and thrown into a generic internal Exception (or Datastore exception for data messages) and then the "generic mapper" for Rest creates the HTTP response with the 500 code. Therefore, I decided to maintain this behavior also for this new **ClientLimitsExceededException**