### PR TITLE
fix(openapi): added missing DeviceInventory schermas to root openapi.yaml

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -797,6 +797,12 @@ components:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryBundle'
     deviceInventoryBundles:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryBundles'
+    deviceInventoryContainerState:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryContainerState'
+    deviceInventoryContainer:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryContainer'
+    deviceInventoryContainers:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryContainers'
     deviceInventoryPackage:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventorySystemPackage'
     deviceInventoryPackages:


### PR DESCRIPTION
This PR adds missing DeviceInventory schemas to root openapi.yaml

**Related Issue**
_None_

**Description of the solution adopted**
Added missing schemas to root openapi.yaml

**Screenshots**
_None_

**Any side note on the changes made**
_None_