### PR TITLE
Feature -  CI process optimization

### DIFF
--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -35,7 +35,7 @@ runs:
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
     - name: Docker images creation
       if: ${{ inputs.needs-docker-images == 'true' }}
-      run: mvn clean install -pl ${APP_PROJECTS} && mvn clean install -Pdocker --f assembly/pom.xml
+      run: mvn clean install -pl ${APP_PROJECTS} && mvn clean install -Pdocker -f assembly/pom.xml -pl '!:kapua-assembly-api' #api container not used in the tests at all se we don't need to build it here
       shell: bash
     - name: Dns look-up containers needed for tests - message-broker
       if: ${{ inputs.needs-docker-images == 'true' }}

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -28,7 +28,7 @@ runs:
     - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
       run: 'npm install -g @apidevtools/swagger-cli'
       shell: bash
-    - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
+    - uses: actions/cache@v4 # Reuse cached dependencies
       with:
         path: ~/.m2/repository
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -3,13 +3,17 @@ description: 'Execute tests suite for tests tagged as specified'
 inputs:
   tag:
     description: Cucumber tag of the tests to run
-    required: true
+    required: false
   needs-docker-images:
     description: true if this suite needs docker images, false otherwise
     required: false
     default: 'true'
   needs-api-docker-image:
     description: true if this suite needs the rest-api docker image, false otherwise
+    required: false
+    default: 'false'
+  run-junit:
+    description: true if you want to execute junit tests, false if you want to execute cucumber tests
     required: false
     default: 'false'
 #outputs:
@@ -28,7 +32,9 @@ runs:
     - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
       run: 'npm install -g @apidevtools/swagger-cli'
       shell: bash
-    - uses: actions/cache@v4 # Reuse cached dependencies
+    - name: Reuse cached maven artifacts dependencies
+      if: ${{ inputs.run-junit == 'false' }}
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
@@ -48,8 +54,13 @@ runs:
       if: ${{ inputs.needs-docker-images == 'true' }}
       run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
       shell: bash
-    - name: Test execution step
+    - name: Cucumber tests execution step
+      if: ${{ inputs.run-junit == 'false' }}
       run: mvn -B -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify
+      shell: bash
+    - name: Junit tests execution step
+      if: ${{ inputs.run-junit == 'true' }}
+      run: mvn -B -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
       shell: bash
     - name: Code coverage results upload
       uses: codecov/codecov-action@v4

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -49,7 +49,7 @@ runs:
       run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
       shell: bash
     - name: Test execution step
-      run: mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify
+      run: mvn -B -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify
       shell: bash
     - name: Code coverage results upload
       uses: codecov/codecov-action@v4

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: true if this suite needs docker images, false otherwise
     required: false
     default: 'true'
+  needs-api-docker-image:
+    description: true if this suite needs the rest-api docker image, false otherwise
+    required: false
+    default: 'false'
 #outputs:
 runs:
   using: "composite"
@@ -28,14 +32,13 @@ runs:
       with:
         path: ~/.m2/repository
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-    - name: Cache Maven repository
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2/repository
-        key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
     - name: Docker images creation
       if: ${{ inputs.needs-docker-images == 'true' }}
       run: mvn clean install -pl ${APP_PROJECTS} && mvn clean install -Pdocker -f assembly/pom.xml -pl '!:kapua-assembly-api' #api container not used in the tests at all se we don't need to build it here
+      shell: bash
+    - name: Docker rest-api image creation
+      if: ${{ inputs.needs-api-docker-image == 'true' }}
+      run: mvn clean install -Pdocker -pl :kapua-assembly-api
       shell: bash
     - name: Dns look-up containers needed for tests - message-broker
       if: ${{ inputs.needs-docker-images == 'true' }}

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -1,7 +1,7 @@
 name: Kapua CI
 on: [ push, pull_request ] # Triggers the workflow on push or pull request events
 
-env: #the last 2 env variables defines respectively the maven projects were cucumber tests resides and maven projects were consumers applications needed for docker images building resides.
+env: #these 2 env variables defines respectively the maven projects were cucumber tests resides and maven projects were consumers applications needed for docker images building resides.
   TEST_PROJECTS: "org.eclipse.kapua:kapua-security-test,org.eclipse.kapua:kapua-qa-integration,org.eclipse.kapua:kapua-scheduler-test,org.eclipse.kapua:kapua-user-test,org.eclipse.kapua:kapua-system-test,org.eclipse.kapua:kapua-job-test,org.eclipse.kapua:kapua-device-registry-test,org.eclipse.kapua:kapua-account-test,org.eclipse.kapua:kapua-tag-test,org.eclipse.kapua:kapua-translator-test"
   APP_PROJECTS: "org.eclipse.kapua:kapua-service-authentication-app,org.eclipse.kapua:kapua-consumer-lifecycle-app,org.eclipse.kapua:kapua-consumer-telemetry-app"
   # Secrets
@@ -28,7 +28,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: mvn -v
-      - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
+      - run: docker images -a  # used as log (should show only GitHub environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B -DskipTests clean install -T 1C
   test-brokerAcl:
     needs: build
@@ -334,19 +334,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/runTestsTaggedAs
         with:
-          distribution: 'zulu'
-          java-version: 11
-      - uses: actions/setup-node@v4 # Installs Node and NPM
-        with:
-          node-version: 16
-      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
-        run: 'npm install -g @apidevtools/swagger-cli'
-      - run: ./ci-output.sh mvn -B -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
-      - name: Code coverage results upload
-        uses: codecov/codecov-action@v4
+          needs-docker-images: 'false'
+          run-junit: 'true'
   build-javadoc:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
-      - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
+      - run: mvn -B ${BUILD_OPTS} -DskipTests clean install -T 1C
   test-brokerAcl:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -345,14 +345,6 @@ jobs:
           node-version: 16
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
-      - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
-        with:
-          path: ~/.m2/repository
-          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-      - uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
       - name: Code coverage results upload
         uses: codecov/codecov-action@v4
@@ -372,10 +364,6 @@ jobs:
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
       - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
-        with:
-          path: ~/.m2/repository
-          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -319,6 +319,7 @@ jobs:
         with:
           tag: '@rest_auth'
           needs-docker-images: 'true'
+          needs-api-docker-image: 'true'
   test-api-corsfilter:
     needs: test-endpoint # test suite dependent on the endpoint service (if it has failings it's useless to perform these tests)
     runs-on: ubuntu-latest
@@ -330,6 +331,7 @@ jobs:
         with:
           tag: '@rest_cors'
           needs-docker-images: 'true'
+          needs-api-docker-image: 'true'
   junit-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -2,9 +2,6 @@ name: Kapua CI
 on: [ push, pull_request ] # Triggers the workflow on push or pull request events
 
 env: #the last 2 env variables defines respectively the maven projects were cucumber tests resides and maven projects were consumers applications needed for docker images building resides.
-  BUILD_OPTS: ""
-  CONFIG_OVERRIDES: "-Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dbroker.host=localhost -Dcrypto.secret.key=kapuaTestsKey!!!"
-  MAVEN_OPTS: "-Xmx4096m"
   TEST_PROJECTS: "org.eclipse.kapua:kapua-security-test,org.eclipse.kapua:kapua-qa-integration,org.eclipse.kapua:kapua-scheduler-test,org.eclipse.kapua:kapua-user-test,org.eclipse.kapua:kapua-system-test,org.eclipse.kapua:kapua-job-test,org.eclipse.kapua:kapua-device-registry-test,org.eclipse.kapua:kapua-account-test,org.eclipse.kapua:kapua-tag-test,org.eclipse.kapua:kapua-translator-test"
   APP_PROJECTS: "org.eclipse.kapua:kapua-service-authentication-app,org.eclipse.kapua:kapua-consumer-lifecycle-app,org.eclipse.kapua:kapua-consumer-telemetry-app"
   # Secrets
@@ -32,7 +29,7 @@ jobs:
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
-      - run: mvn -B ${BUILD_OPTS} -DskipTests clean install -T 1C
+      - run: mvn -B -DskipTests clean install -T 1C
   test-brokerAcl:
     needs: build
     runs-on: ubuntu-latest
@@ -347,7 +344,7 @@ jobs:
           node-version: 16
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
-      - run: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
+      - run: ./ci-output.sh mvn -B -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
       - name: Code coverage results upload
         uses: codecov/codecov-action@v4
   build-javadoc:

--- a/pom.xml
+++ b/pom.xml
@@ -275,8 +275,13 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.version}</version>
                     <configuration>
+                        <!--Configuration needed to run the various tests under the codebase. Placed here so no need to pass them via args-->
                         <systemPropertyVariables>
                             <commons.settings.hotswap>true</commons.settings.hotswap>
+                            <commons.db.schema>kapuadb</commons.db.schema>
+                            <crypto.secret.key>kapuaTestsKey!!!</crypto.secret.key>
+                            <broker.host>localhost</broker.host>
+                            <user.timezone>UTC</user.timezone>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
@@ -11,7 +11,7 @@
 #     Eurotech - initial API and implementation
 ###############################################################################
 @endpoint
-@env_docker
+@env_docker_base
 
 Feature: Endpoint Info Service Integration Tests
   Integration test scenarios for Endpoint Info service

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -32,26 +32,6 @@
         <module>markers</module>
     </modules>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <systemPropertyVariables>
-                            <commons.settings.hotswap>true</commons.settings.hotswap>
-                            <commons.db.schema>kapuadb</commons.db.schema>
-                            <crypto.secret.key>kapuaTestsKey!!!</crypto.secret.key>
-                            <broker.host>localhost</broker.host>
-                            <user.timezone>UTC</user.timezone>
-                        </systemPropertyVariables>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-
     <profiles>
         <!-- Profile for running integration tests with Kapua infrastructure started inside dockerized environment. -->
         <profile>


### PR DESCRIPTION
Brief description of the PR.
This PR is a collection of optimizations for the CI configuration. They follow the work started with the PR https://github.com/eclipse/kapua/pull/3785. 
The scope of this work is not only to speed-up the build for our interest but also to reduce the utilization of resources running jobs that we share with other eclipse projects. 

**Description of the solution adopted**
First of all, in a separate investigation, I noticed that the 'kapua artifacts' (the ones created in the build job and later cached for the test jobs) could have been built with maven in multi-threading mode, because the plugins used for this build process are thread-safe (in contrast with the plugins used for building docker images, that are not thread-safe). As a consequence, I Inserted the multi-thread building with the '-1C' option, in this way 1 thread is spawn for each available core (this is nice in this GitHub environment because machines available for the build job could have different number of cores)

Running some tests locally, in the past, I realized that the kapua-api docker image is never used in a lot of ci-jobs. So, it is useless to re-build it in every job as we do now. I modified the abstract script that runs tests to introduce a new parameter that specifies if the job needs the rest-api image and builds it if necessary.

I modified this same script to insert a parameter (run-junit) that allows to choose if we want to run junit or cucumber tests. In this way now also the step that runs junit tests in the ci configuration uses this script.

I moved the configuration of the maven surefire plugin in the pom files that is needed to run tests without jvm parameters. In this way now there is no need to use the parameters present in the head of the CI configuration file

