### PR TITLE
Fix device snapshot handling in XML format

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfiguration.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfiguration.java
@@ -26,7 +26,7 @@ import org.eclipse.kapua.KapuaSerializable;
  *
  * @since 1.0
  */
-@XmlRootElement(name = "configurations")
+@XmlRootElement(name = "serviceConfigurations")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = ServiceConfigurationXmlRegistry.class, factoryMethod = "newConfiguration")
 public interface ServiceConfiguration extends KapuaSerializable {

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
-@XmlRootElement(name = "configurations")
+@XmlRootElement(name = "deviceConfigurations")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceConfigurationXmlRegistry.class, factoryMethod = "newConfiguration")
 public interface DeviceConfiguration extends KapuaSerializable {


### PR DESCRIPTION
This PR fix the problem regarding the REST APIs that are not able to process a DeviceConfiguration in XML format.

**Related Issue**
Due to the overlapping `configuration` XML root element for both the device configuration and the service configuration, the following request
```
curl -vvvv -X 'PUT' \
  'https://api-lt-1.dev.everyware.io/v1/_/devices/ZWBkYtz2HxE/configurations?timeout=30000' \
  -H 'accept: */*' \
  -H 'Authorization: Bearer {A_TOKEN_MUST_BE_PLACED_HERE}' \
  -H 'Content-Type: application/xml' \
  -d '{<a device snapshot XML file path>}'
```
results in
```
<?xml version="1.0" encoding="UTF-8"?><throwableInfo><httpErrorCode>500</httpErrorCode><message>
Exception Description: No conversion value provided for the value [Password] in field [@type].
Mapping: org.eclipse.persistence.oxm.mappings.XMLDirectMapping[type-->@type]
```

**Description of the solution adopted**
Renamed overlapping `configuration` XML root element to `deviceConfiguration` and `serviceConfiguration`.

**Any side note on the changes made**
Please note that this fix will introduce a breaking change.
