### PR TITLE
fix(javadoc): fixed javadoc after #3924

### DIFF
--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
@@ -81,8 +81,8 @@ public interface DeviceConnectionService extends KapuaEntityService<DeviceConnec
     /**
      * Disconnect the specified {@link DeviceConnection} from the broker
      *
-     * @param scopeId  The {@link DeviceConnection#getScopeId()}.
-     * @param id The {@link DeviceConnection#getId()}.
+     * @param scopeId            The {@link DeviceConnection#getScopeId()}.
+     * @param deviceConnectionId The {@link DeviceConnection#getId()}.
      * @throws KapuaException In case of errors.
      * @since 2.0.0
      */


### PR DESCRIPTION
This PR fixes a small javadoc error introduced with #3924

**Related Issue**
This PR fixes issue introduced #3924

**Description of the solution adopted**
Fixed the `@param` name reference.

**Screenshots**
_None_

**Any side note on the changes made**
_None_