### PR TITLE
FIX - Restored support on XML content option on openApi doc for device snapshots

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
@@ -30,6 +30,9 @@ paths:
             application/json:
               schema:
                 $ref: '../deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfigurations'
+            application/xml:
+              schema:
+                $ref: '../deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfigurations'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId.yaml
@@ -29,6 +29,9 @@ paths:
             application/json:
               schema:
                 $ref: './deviceSnapshot.yaml#/components/schemas/snapshots'
+            application/xml:
+              schema:
+                $ref: './deviceSnapshot.yaml#/components/schemas/snapshots'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:


### PR DESCRIPTION
Brief description of the PR.
Users who handle snapshots sometimes uses XML format. However, before this PR, in Swagger UI the following endpoint only permits JSON response:

GET /v1/{}/devices/{}/snapthots/{}
GET /v1/{}/devices/{}/snapthots/

Support to XML needed to be added as well