### PR TITLE
FIX - Restored support on XML content option on openApi doc for device configurations

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
@@ -30,6 +30,9 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurations'
+            application/xml:
+              schema:
+                $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurations'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -51,6 +54,9 @@ paths:
       requestBody:
         content:
           application/json:
+            schema:
+              $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurationInput'
+          application/xml:
             schema:
               $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurationInput'
         required: true

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml
@@ -29,6 +29,9 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurations'
+            application/xml:
+              schema:
+                $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurations'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -49,6 +52,9 @@ paths:
       requestBody:
         content:
           application/json:
+            schema:
+              $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurationsInput'
+          application/xml:
             schema:
               $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurationsInput'
         required: true


### PR DESCRIPTION
Brief description of the PR.
Users who handle device configurations sometimes uses XML format. However, before this PR, in Swagger UI the following endpoint only permits JSON response:

PUT /v1/{}/devices/{}/configurations/
GET /v1/{}/devices/{}/configurations/
PUT /v1/{}/devices/{}/configurations/{}
GET /v1/{}/devices/{}/configurations/{}

Support to XML needed to be added as well