### PR TITLE
FIX - Jaxb configuration changed to serialize EntityUniquenessExceptionInfo

### DIFF
--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -33,6 +33,7 @@ import org.eclipse.kapua.commons.rest.model.errors.DeviceManagementSendException
 import org.eclipse.kapua.commons.rest.model.errors.DeviceManagementTimeoutExceptionInfo;
 import org.eclipse.kapua.commons.rest.model.errors.DeviceNotConnectedExceptionInfo;
 import org.eclipse.kapua.commons.rest.model.errors.EntityNotFoundExceptionInfo;
+import org.eclipse.kapua.commons.rest.model.errors.EntityUniquenessExceptionInfo;
 import org.eclipse.kapua.commons.rest.model.errors.ExceptionInfo;
 import org.eclipse.kapua.commons.rest.model.errors.IllegalArgumentExceptionInfo;
 import org.eclipse.kapua.commons.rest.model.errors.IllegalNullArgumentExceptionInfo;
@@ -362,6 +363,7 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     InternalUserOnlyExceptionInfo.class,
                     SelfManagedOnlyExceptionInfo.class,
                     SubjectUnauthorizedExceptionInfo.class,
+                    EntityUniquenessExceptionInfo.class,
 
                     EntityNotFoundExceptionInfo.class,
                     IllegalArgumentExceptionInfo.class,


### PR DESCRIPTION
Brief description of the PR.
Before this PR Jaxb was not correctly serializing the EntityUniquenessExceptionInfo that we insert in the response body if needed. It was, instead, serializing to a basic ExceptionInfo without the additional fields in EntityUniquenessExceptionInfo class. 


**Description of the solution adopted**
The problem was that the EntityUniquenessExceptionInfo class was not inserted inside the configuration of jaxb so the framework was not able to perform the operation