### PR TITLE
Fix/device event deadlock

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/KapuaEntityJpaRepository.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/KapuaEntityJpaRepository.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import javax.persistence.Embedded;
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
 import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
@@ -127,9 +128,13 @@ public class KapuaEntityJpaRepository<E extends KapuaEntity, C extends E, L exte
     }
 
     protected Optional<E> doFind(EntityManager em, KapuaId scopeId, KapuaId entityId) {
+        return doFind(em, scopeId, entityId, null);
+    }
+
+    protected Optional<E> doFind(EntityManager em, KapuaId scopeId, KapuaId entityId, LockModeType lockModeType) {
         final KapuaEid eId = KapuaEid.parseKapuaId(entityId);
         // Checking existence
-        final Optional<E> entityToFind = Optional.ofNullable(em.find(concreteClass, eId));
+        final Optional<E> entityToFind = Optional.ofNullable(em.find(concreteClass, eId, lockModeType));
 
         return entityToFind
                 .filter(e -> scopeId == null || KapuaId.ANY.equals(scopeId)

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRepository.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRepository.java
@@ -17,9 +17,12 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.storage.KapuaUpdatableEntityRepository;
 import org.eclipse.kapua.storage.TxContext;
 
+import java.util.Date;
 import java.util.Optional;
 
 public interface DeviceRepository extends
         KapuaUpdatableEntityRepository<Device, DeviceListResult> {
     Optional<Device> findByClientId(TxContext tx, KapuaId scopeId, String clientId) throws KapuaException;
+
+    void updateLastEvent(TxContext tx, KapuaId scopeId, KapuaId deviceId, KapuaId deviceEventId, Date receivedOn);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRepository.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRepository.java
@@ -17,12 +17,11 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.storage.KapuaUpdatableEntityRepository;
 import org.eclipse.kapua.storage.TxContext;
 
-import java.util.Date;
 import java.util.Optional;
 
 public interface DeviceRepository extends
         KapuaUpdatableEntityRepository<Device, DeviceListResult> {
     Optional<Device> findByClientId(TxContext tx, KapuaId scopeId, String clientId) throws KapuaException;
 
-    void updateLastEvent(TxContext tx, KapuaId scopeId, KapuaId deviceId, KapuaId deviceEventId, Date receivedOn);
+    Optional<Device> findForUpdate(TxContext tx, KapuaId scopeId, KapuaId deviceId);
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/CachingDeviceRepository.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/CachingDeviceRepository.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DeviceRepository;
 import org.eclipse.kapua.storage.TxContext;
 
+import java.util.Date;
 import java.util.Optional;
 
 public class CachingDeviceRepository
@@ -43,5 +44,11 @@ public class CachingDeviceRepository
         final Optional<Device> found = wrapped.findByClientId(tx, scopeId, clientId);
         found.ifPresent(entityCache::put);
         return found;
+    }
+
+    @Override
+    public void updateLastEvent(TxContext tx, KapuaId scopeId, KapuaId deviceId, KapuaId deviceEventId, Date receivedOn) {
+        wrapped.updateLastEvent(tx, scopeId, deviceId, deviceEventId, receivedOn);
+        entityCache.remove(scopeId, deviceId);
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/CachingDeviceRepository.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/CachingDeviceRepository.java
@@ -20,7 +20,6 @@ import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DeviceRepository;
 import org.eclipse.kapua.storage.TxContext;
 
-import java.util.Date;
 import java.util.Optional;
 
 public class CachingDeviceRepository
@@ -47,8 +46,13 @@ public class CachingDeviceRepository
     }
 
     @Override
-    public void updateLastEvent(TxContext tx, KapuaId scopeId, KapuaId deviceId, KapuaId deviceEventId, Date receivedOn) {
-        wrapped.updateLastEvent(tx, scopeId, deviceId, deviceEventId, receivedOn);
+    public Optional<Device> findForUpdate(TxContext tx, KapuaId scopeId, KapuaId deviceId) {
+        /*
+        The correct approach in thi scenario is  to leave to JPA the persistence of the updated entity at transaction's closure,
+        without calling explicitly update. Therefore if we don't clear the cache the next items would find an outdated optlock, and fail
+         */
         entityCache.remove(scopeId, deviceId);
+        final Optional<Device> found = wrapped.findForUpdate(tx, scopeId, deviceId);
+        return found;
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImplJpaRepository.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImplJpaRepository.java
@@ -18,6 +18,7 @@ import org.eclipse.kapua.commons.jpa.JpaAwareTxContext;
 import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
 import org.eclipse.kapua.commons.jpa.KapuaUpdatableEntityJpaRepository;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceAttributes;
@@ -59,6 +60,8 @@ public class DeviceImplJpaRepository
         final Root<DeviceImpl> root = update.from(DeviceImpl.class);
         final Join<DeviceImpl, DeviceEventImpl> lastEventJoin = root.join(DeviceImpl_.lastEvent, JoinType.LEFT);
         update.set(root.get(DeviceImpl_.lastEventId), KapuaEid.parseKapuaId(deviceEventId));
+        update.set(root.get(DeviceImpl_.modifiedBy), KapuaEid.parseKapuaId(KapuaSecurityUtils.getSession().getUserId()));
+        update.set(root.get(DeviceImpl_.modifiedOn), new Date());
         update.where(
                 cb.and(
                         cb.equal(root.get(DeviceImpl_.scopeId), KapuaEid.parseKapuaId(scopeId)),

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImplJpaRepository.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImplJpaRepository.java
@@ -14,15 +14,26 @@ package org.eclipse.kapua.service.device.registry.internal;
 
 import com.google.common.collect.Lists;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.JpaAwareTxContext;
 import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
 import org.eclipse.kapua.commons.jpa.KapuaUpdatableEntityJpaRepository;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceAttributes;
 import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DeviceRepository;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventImpl;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventImpl_;
 import org.eclipse.kapua.storage.TxContext;
 
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaUpdate;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Root;
+import java.util.Date;
 import java.util.Optional;
 
 public class DeviceImplJpaRepository
@@ -38,5 +49,26 @@ public class DeviceImplJpaRepository
         query.setPredicate(query.attributePredicate(DeviceAttributes.CLIENT_ID, clientId));
         query.setFetchAttributes(Lists.newArrayList(DeviceAttributes.CONNECTION, DeviceAttributes.LAST_EVENT));
         return Optional.ofNullable(this.query(tx, query).getFirstItem());
+    }
+
+    @Override
+    public void updateLastEvent(TxContext tx, KapuaId scopeId, KapuaId deviceId, KapuaId deviceEventId, Date receivedOn) {
+        final EntityManager em = JpaAwareTxContext.extractEntityManager(tx);
+        final CriteriaBuilder cb = em.getCriteriaBuilder();
+        final CriteriaUpdate<DeviceImpl> update = cb.createCriteriaUpdate(DeviceImpl.class);
+        final Root<DeviceImpl> root = update.from(DeviceImpl.class);
+        final Join<DeviceImpl, DeviceEventImpl> lastEventJoin = root.join(DeviceImpl_.lastEvent, JoinType.LEFT);
+        update.set(root.get(DeviceImpl_.lastEventId), KapuaEid.parseKapuaId(deviceEventId));
+        update.where(
+                cb.and(
+                        cb.equal(root.get(DeviceImpl_.scopeId), KapuaEid.parseKapuaId(scopeId)),
+                        cb.equal(root.get(DeviceImpl_.id), KapuaEid.parseKapuaId(deviceId)),
+                        cb.or(
+                                cb.isNull(lastEventJoin.get(DeviceEventImpl_.receivedOn)),
+                                cb.lessThan(lastEventJoin.get(DeviceEventImpl_.receivedOn), receivedOn)
+                        )
+                )
+        );
+        em.createQuery(update).executeUpdate();
     }
 }

--- a/service/device/registry/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/device/registry/internal/src/main/resources/META-INF/persistence.xml
@@ -48,8 +48,10 @@
 
         <properties>
             <property name="javax.persistence.lock.timeout" value="1000"/>
-            <!-- <property name="eclipselink.logging.level.sql" value="FINE"/>
-            <property name="eclipselink.logging.parameters" value="true"/> -->
+            <!--            <property name="javax.persistence.lock.timeout" value="100000"/>-->
+            <!--            <property name="eclipselink.logging.level" value="FINE"/>-->
+            <!--            <property name="eclipselink.logging.level.sql" value="FINE"/>-->
+            <!--            <property name="eclipselink.logging.parameters" value="true"/>-->
 
             <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
         </properties>


### PR DESCRIPTION
Fixes a deadlock issue occurring upon creation of multiple concurrent device events.

**Related Issue**
This PR fixes/closes [3945](https://github.com/eclipse/kapua/issues/3945)

**Description of the solution adopted**
One one hand, the PR removes the retrieval of the device prior to the event's creation (event insert would fail if the device does not exist anyway, due to the foreign key violation). Then it directly updates the last_event_id field in the database table (directly creating an exclusive lock on Device, instead of a shared one as the previous read was doing). This should avoid the deadlock.

On the other hand, the JpaTxContext class has been updated to recognize deadlock-related exceptions and consider them recoverable, allowing for a retry according to the general rules of transactions reattempt.
