### PR TITLE
fix(console): fixed error reporting for DeviceAssetChannel

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -383,28 +383,23 @@ public class DeviceAssetsValues extends LayoutContainer {
         });
     }
 
-    public void refreshAssetPanel(GwtDeviceAsset asset) {
+    public void refreshAssetPanel(final GwtDeviceAsset asset) {
         apply.setEnabled(false);
         reset.setEnabled(false);
 
         if (assetValuesPanel != null) {
             assetValuesPanel.removeFromParent();
         }
-        if (asset != null) {
 
-            assetValuesPanel = new DeviceAssetsPanel(asset, currentSession);
-            assetValuesPanel.addListener(Events.Change, new Listener<BaseEvent>() {
+        assetValuesPanel = new DeviceAssetsPanel(asset, currentSession);
+        assetValuesPanel.addListener(Events.Change, new Listener<BaseEvent>() {
+            @Override
+            public void handleEvent(BaseEvent be) {
+                apply.setEnabled(asset != null);
+                reset.setEnabled(asset != null);
+            }
+        });
 
-                @Override
-                public void handleEvent(BaseEvent be) {
-                    apply.setEnabled(true);
-                    reset.setEnabled(true);
-                }
-            });
-
-        } else {
-            assetValuesPanel = new DeviceAssetsPanel(null, currentSession);
-        }
         assetValuesContainer.add(assetValuesPanel, centerData);
         assetValuesContainer.layout();
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceAssetServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceAssetServiceImpl.java
@@ -29,7 +29,6 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.asset.DeviceAsset;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannel;
-import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannelMode;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
 import org.eclipse.kapua.service.device.management.asset.store.DeviceAssetStoreFactory;
@@ -87,12 +86,11 @@ public class GwtDeviceAssetServiceImpl extends KapuaRemoteServiceServlet impleme
                 DeviceAsset assetMetadata = assetsMetadata.getAssets().get(assetIndex);
                 DeviceAsset assetValues = assetsValues.getAssets().get(assetIndex);
                 for (DeviceAssetChannel channelMetadata : assetMetadata.getChannels()) {
-                    if (channelMetadata.getMode().equals(DeviceAssetChannelMode.READ) || channelMetadata.getMode().equals(DeviceAssetChannelMode.READ_WRITE)) {
-                        for (DeviceAssetChannel channelValue : assetValues.getChannels()) {
-                            if (channelValue.getName().equals(channelMetadata.getName())) {
-                                channelMetadata.setValue(channelValue.getValue());
-                                break;
-                            }
+                    for (DeviceAssetChannel channelValue : assetValues.getChannels()) {
+                        if (channelValue.getName().equals(channelMetadata.getName())) {
+                            channelMetadata.setValue(channelValue.getValue());
+                            channelMetadata.setError(channelValue.getError());
+                            break;
                         }
                     }
                 }
@@ -100,12 +98,13 @@ public class GwtDeviceAssetServiceImpl extends KapuaRemoteServiceServlet impleme
 
             gwtAssets = KapuaGwtDeviceModelConverter.convertDeviceAssets(assetsMetadata);
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
         return gwtAssets.getAssets();
     }
 
     // Asset Store Settings
+    @Override
     public boolean isStoreServiceEnabled(String scopeIdString, String deviceIdString) throws GwtKapuaException {
         try {
             KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(scopeIdString);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/management/assets/GwtDeviceAssetChannel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/management/assets/GwtDeviceAssetChannel.java
@@ -90,6 +90,10 @@ public class GwtDeviceAssetChannel extends KapuaBaseModel implements IsSerializa
         set("error", error);
     }
 
+    public boolean hasError() {
+        return getError() != null;
+    }
+
     public String getValue() {
         return get("value");
     }


### PR DESCRIPTION
This PR fixes showing of error messages when reading DeviceAssetChannels.

Previously there was no error shown and only successfully read channel were shown in the form

**Related Issue**
_None_

**Description of the solution adopted**
Added mapping in Console GWT of error property and displayed dedicated field in case of error

**Screenshots**
_None_

**Any side note on the changes made**
_None_