### PR TITLE
Fix error while retrieving MFA option from REST API

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserMfaUnitTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserMfaUnitTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.service.user;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = { "classpath:features/user/UserMfaUnitTests.feature"
+    },
+    glue = {"org.eclipse.kapua.service.security.test",
+        "org.eclipse.kapua.service.authorization.steps",
+        "org.eclipse.kapua.service.authentication.steps",
+        "org.eclipse.kapua.service.user.steps",
+        "org.eclipse.kapua.service.account.steps",
+        "org.eclipse.kapua.qa.common"
+    },
+    plugin = {"pretty",
+        "html:target/cucumber/UserProfile",
+        "json:target/UserProfile_cucumber.json"
+    },
+    monochrome = true)
+public class RunUserMfaUnitTest {
+}

--- a/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -14,7 +14,7 @@
 @lockoutExpiration
 @env_none
 
-Feature: User and Credential expiration abd lockout features
+Feature: User and Credential expiration and lockout features
   User Service has expiration value after which user is disabled.
   There is also expiration and status on user's credentials which are also tested.
   Additionally login failures and lockout and lockout resets are tested.

--- a/qa/integration/src/test/resources/features/user/UserMfaUnitTests.feature
+++ b/qa/integration/src/test/resources/features/user/UserMfaUnitTests.feature
@@ -1,0 +1,45 @@
+###############################################################################
+# Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@user
+@userCredentials
+@env_none
+
+Feature: Feature file for testing Password user credential
+  This feature file provides test scenarios for user password credential.
+
+  @setup
+  Scenario: Init Security Context for all scenarios
+    Given Init Jaxb Context
+    And Init Security Context
+
+  Scenario: Find mfa of the user
+  Creating a new user "kapua-a" in kapua-sys account and enabled mfa.
+  After that login as "kapua-a" user and find the mfa of myself.
+  No exception should be thrown.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And A generic user
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User a | kapua_a@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And I add credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain      | action |
+      | credential  | read   |
+      | credential  | write  |
+    And I logout
+    And I login as user with name "kapua-a" and password "ToManySecrets123#"
+    And I enable mfa
+    Then mfa repository can get mfa for user "kapua-a"

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionImplJpaRepository.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionImplJpaRepository.java
@@ -15,6 +15,7 @@ package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
 import org.eclipse.kapua.commons.jpa.KapuaUpdatableEntityJpaRepository;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResult;
@@ -32,6 +33,7 @@ public class MfaOptionImplJpaRepository
 
     @Override
     public Optional<MfaOption> findByUserId(TxContext tx, KapuaId scopeId, KapuaId userId) throws KapuaException {
-        return doFindByField(tx, scopeId, MfaOptionImpl_.USER_ID, userId);
+        final KapuaEid userEid = KapuaEid.parseKapuaId(userId);
+        return doFindByField(tx, scopeId, MfaOptionImpl_.USER_ID, userEid);
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionImplJpaRepository.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionImplJpaRepository.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
 
+import java.util.Optional;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
 import org.eclipse.kapua.commons.jpa.KapuaUpdatableEntityJpaRepository;
@@ -22,13 +24,11 @@ import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResu
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionRepository;
 import org.eclipse.kapua.storage.TxContext;
 
-import java.util.Optional;
-
 public class MfaOptionImplJpaRepository
         extends KapuaUpdatableEntityJpaRepository<MfaOption, MfaOptionImpl, MfaOptionListResult>
         implements MfaOptionRepository {
     public MfaOptionImplJpaRepository(KapuaJpaRepositoryConfiguration jpaRepoConfig) {
-        super(MfaOptionImpl.class, MfaOption.TYPE, () -> new MfaOptionListResultImpl(), jpaRepoConfig);
+        super(MfaOptionImpl.class, MfaOption.TYPE, MfaOptionListResultImpl::new, jpaRepoConfig);
     }
 
     @Override

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -12,6 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.steps;
 
+import java.math.BigInteger;
+import java.text.MessageFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import javax.inject.Inject;
+
 import com.google.inject.Singleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
@@ -28,6 +43,7 @@ import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.domain.Domain;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdImpl;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.qa.common.BasicSteps;
@@ -76,21 +92,6 @@ import org.eclipse.kapua.service.user.UserQuery;
 import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.service.user.UserStatus;
 import org.junit.Assert;
-
-import javax.inject.Inject;
-import java.math.BigInteger;
-import java.text.MessageFormat;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
 
 /**
  * Implementation of Gherkin steps used in user test scenarios.
@@ -1235,6 +1236,21 @@ public class UserServiceSteps extends TestBase {
         } catch (KapuaException e) {
             e.printStackTrace();
         }
+        Assert.assertNotNull(mfaOption);
+    }
+
+    @Then("mfa repository can get mfa for user \"([^\"]*)\"$")
+    public void mfaRepositoryCanGetMfaForUser(String username) throws KapuaException {
+        BigInteger userId = null;
+        BigInteger scopeId = null;
+        try {
+            userId = KapuaSecurityUtils.doPrivileged(() -> userService.findByName(username).getId().getId());
+            scopeId = KapuaSecurityUtils.doPrivileged(() -> userService.findByName(username).getScopeId().getId());
+        } catch (KapuaException e) {
+            e.printStackTrace();
+        }
+        final MfaOptionService mfaOptionService = KapuaLocator.getInstance().getService(MfaOptionService.class);
+        final MfaOption mfaOption = mfaOptionService.findByUserId(new KapuaIdImpl(scopeId), new KapuaIdImpl(userId));
         Assert.assertNotNull(mfaOption);
     }
 


### PR DESCRIPTION
This PR addresses an issue related to the MFA retrieval endpoint (`GET /{scopeId}/users/{userID}/mfa`) that was causing an internal error. The problem stemmed from an error during the persistence operation.
The root cause was identified as the API passing a `KapuaId` object instead of a `KapuaEid` to the underline layer, leading to the persistence error.

**Description of the solution adopted**
Parse the `KapuaId` object to a `KapuaEid` object.