### PR TITLE
Add tags to device on create operation

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceI9nTest.java
@@ -12,15 +12,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.integration.service.device;
 
-import org.junit.runner.RunWith;
-
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = {"classpath:features/device/DeviceServiceI9n.feature"
-                   },
+        features = {
+            "classpath:features/device/DeviceServiceI9n.feature",
+            "classpath:features/tag/TagI9n.feature"
+        },
         glue = {"org.eclipse.kapua.qa.common",
                 "org.eclipse.kapua.qa.integration.steps",
                 "org.eclipse.kapua.service.account.steps",

--- a/qa/integration/src/test/resources/features/tag/TagI9n.feature
+++ b/qa/integration/src/test/resources/features/tag/TagI9n.feature
@@ -1,0 +1,37 @@
+###############################################################################
+# Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+@deviceRegistry
+@env_docker
+
+Feature: Tag tests
+
+  @setup
+  Scenario: Start full docker environment
+    Given Init Jaxb Context
+    And Init Security Context
+    And Start full docker environment
+
+
+  Scenario: Create a single device with associated tags
+  Create some tags. Then create a device with that associated tags.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a device with name "device" and tags
+      | tag-1 |
+      | tag-2 |
+      | tag-3 |
+    When I search for a device with name "device"
+    Then Tag "tag-1" is assigned to device "device"
+    And Tag "tag-2" is assigned to device "device"
+    And Tag "tag-3" is assigned to device "device"

--- a/rest-api/resources/src/main/resources/openapi/device/device.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device.yaml
@@ -264,6 +264,12 @@ components:
             customAttribute5:
               description: A Custom Attirbute of this Device - 5
               type: string
+            tagIds:
+              description: A list of tag ID to link to the Device
+              type: array
+              items:
+                allOf:
+                  - $ref: '../openapi.yaml#/components/schemas/kapuaId'
           required:
             - clientId
           example:
@@ -279,6 +285,7 @@ components:
             osgiFrameworkVersion: 1.7.0
             acceptEncoding: gzip
             deviceCredentialsMode: LOOSE
+            tagIds: []
     deviceListResult:
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaListResult'

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
@@ -12,13 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.authorization.group.Group;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
-import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
-
+import java.util.List;
+import java.util.Set;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -26,8 +21,13 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.List;
-import java.util.Set;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 
 /**
  * {@link Device} is an object representing a device or gateway connected to the Kapua platform.<br>

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
@@ -12,20 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
-import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.authorization.group.Group;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
-import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
-
+import java.util.List;
+import java.util.Set;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.List;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 
 /**
  * {@link DeviceCreator} encapsulates all the information needed to create a new {@link Device} in the system.<br>
@@ -67,7 +68,8 @@ import java.util.List;
         "customAttribute3",
         "customAttribute4",
         "customAttribute5",
-        "extendedProperties"
+        "extendedProperties",
+        "tagIds"
 }, factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDeviceCreator")
 public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
 
@@ -557,4 +559,23 @@ public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
      * @since 1.5.0
      */
     void setExtendedProperties(List<DeviceExtendedProperty> extendedProperties);
+
+
+    /**
+     * Gets the list of tags associated with the device.
+     *
+     * @return The list of tags.
+     * @since 2.0.0
+     */
+    @XmlElement(name = "tagIds")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    Set<KapuaId> getTagIds();
+
+    /**
+     * Sets the list of tags associated with the device.
+     *
+     * @param tags The list of tags.
+     * @since 2.0.0
+     */
+    void setTagIds(Set<KapuaId> tags);
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
@@ -12,16 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.internal;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+
 import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceCreator;
 import org.eclipse.kapua.service.device.registry.DeviceExtendedProperty;
 import org.eclipse.kapua.service.device.registry.DeviceStatus;
-
-import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * {@link DeviceCreator} implementation.
@@ -59,6 +61,7 @@ public class DeviceCreatorImpl extends AbstractKapuaUpdatableEntityCreator<Devic
     private String customAttribute4;
     private String customAttribute5;
     private List<DeviceExtendedProperty> extendedProperties;
+    private Set<KapuaId> tagIds;
 
     /**
      * Constructor.
@@ -357,5 +360,15 @@ public class DeviceCreatorImpl extends AbstractKapuaUpdatableEntityCreator<Devic
     @Override
     public void setExtendedProperties(List<DeviceExtendedProperty> extendedProperties) {
         this.extendedProperties = extendedProperties;
+    }
+
+    @Override
+    public Set<KapuaId> getTagIds() {
+        return tagIds == null ? new HashSet<>() : tagIds;
+    }
+
+    @Override
+    public void setTagIds(Set<KapuaId> tagIds) {
+        this.tagIds = tagIds;
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.internal;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.eclipse.kapua.KapuaDuplicateNameException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceBase;
@@ -37,10 +41,6 @@ import org.eclipse.kapua.service.device.registry.common.DeviceValidation;
 import org.eclipse.kapua.storage.TxManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 
 /**
  * {@link DeviceRegistryService} implementation.
@@ -118,6 +118,7 @@ public class DeviceRegistryServiceImpl
                     device.setCustomAttribute4(deviceCreator.getCustomAttribute4());
                     device.setCustomAttribute5(deviceCreator.getCustomAttribute5());
                     device.setExtendedProperties(deviceCreator.getExtendedProperties());
+                    device.setTagIds(deviceCreator.getTagIds());
 
                     device.setConnectionId(deviceCreator.getConnectionId());
                     device.setLastEventId(deviceCreator.getLastEventId());

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceRegistrySteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceRegistrySteps.java
@@ -12,6 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.steps;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.Vector;
+import javax.inject.Inject;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.inject.Singleton;
@@ -101,19 +114,6 @@ import org.eclipse.kapua.service.user.UserService;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.Vector;
 
 /**
  * Implementation of Gherkin steps used in DeviceRegistry.feature scenarios.
@@ -2495,6 +2495,30 @@ public class DeviceRegistrySteps extends TestBase {
             primeException();
             stepData.remove(DEVICE);
             Device device = deviceRegistryService.create(deviceCreator);
+            stepData.put(DEVICE, device);
+        } catch (Exception ex) {
+            verifyException(ex);
+        }
+    }
+
+
+    @Then("I create a device with name {string} and tags")
+    public void iCreateADeviceWithName(String clientId, List<String> tags) throws Exception {
+        final HashSet<KapuaId> tagIds = new HashSet<>();
+        final TagCreator tagCreator = tagFactory.newCreator(getCurrentScopeId());
+        for (String tagName : tags) {
+            tagCreator.setName(tagName);
+            final Tag tag = tagService.create(tagCreator);
+            tagIds.add(tag.getId());
+        }
+        final DeviceCreator deviceCreator = deviceFactory.newCreator(getCurrentScopeId());
+        deviceCreator.setClientId(clientId);
+        deviceCreator.setTagIds(tagIds);
+        stepData.put(DEVICE_CREATOR, deviceCreator);
+        try {
+            primeException();
+            stepData.remove(DEVICE);
+            final Device device = deviceRegistryService.create(deviceCreator);
             stepData.put(DEVICE, device);
         } catch (Exception ex) {
             verifyException(ex);


### PR DESCRIPTION
### Summary
This pull request introduces a new feature that enhances the device creation process by allowing the addition of tags directly during device creation.
## Description
The current implementation limits the addition of tags to devices only after their creation. With this enhancement, users can now include tag information as part of the device creation payload, streamlining the workflow and providing greater flexibility.
## Changes Introduced
* Modified the device creation API to accept tag information in the request payload.
* Updated the relevant documentation to include details about the new feature.
* Ensured backward compatibility with the previous device creation process.
* Add test for the new feature.
## Usage Example
Users can include a `tagIds` field in the device creation payload, specifying the desired tags for the newly created device. For example:
```
{
  "clientId": "testDevice",
  "status": "ENABLED",
  "displayName": "Test Device",
  "serialNumber": "1234567890",
  "modelId": "Test Model",
  "biosVersion": "N/A",
  "firmwareVersion": "N/A",
  "osVersion": "3.13.0-93-generic",
  "jvmVersion": "24.111-b01 mixed mode",
  "osgiFrameworkVersion": "1.7.0",
  "acceptEncoding": "gzip",
  "deviceCredentialsMode": "LOOSE",
   "tagIds": ["bfPsA9-15Ng", "FJ6-FLuIcok"]
}
```