### PR TITLE
[ECED-1991] :fix: avoid returning incorrect password within error message

### DIFF
--- a/qa/integration/src/test/resources/features/authentication/UserCredentialServiceUnitTests.feature
+++ b/qa/integration/src/test/resources/features/authentication/UserCredentialServiceUnitTests.feature
@@ -58,7 +58,7 @@ Feature: User Credential
     And I create a new PASSWORD credential for the default user with password "Welcome12345!"
     And I login as user with name "test-user" and password "Welcome12345!"
     And No exception was thrown
-    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument passwordChangeRequest.currentPassword: WrongPassword!"
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
     When I change the user credential password with old password "WrongPassword!" and new password "Welcome12345!"
     Then An exception was thrown
 

--- a/service/api/src/main/resources/kapua-service-error-messages.properties
+++ b/service/api/src/main/resources/kapua-service-error-messages.properties
@@ -35,7 +35,6 @@ RESOURCE_RESTRICTED_TO_FIRST_LEVEL_ACCOUNTS=The resource {0} can only be created
 RESOURCE_RESTRICTED_TO_SYS_ADMIN_ACCOUNT=The resource {0} can only be created and managed in the system administrator account.
 SERVICE_DISABLED=The Service is disabled: {0}
 UNAUTHENTICATED=No authenticated Subject found in context.
-INCORRECT_CURRENT_PASSWORD=Incorrect current password
 # Deprecated codes
 USER_ALREADY_RESERVED_BY_ANOTHER_CONNECTION=This user is already reserved for another connection. Please select different user for this connection.
 DEVICE_NOT_FOUND=The selected devices were not found. Please refresh device list.

--- a/service/api/src/main/resources/kapua-service-error-messages.properties
+++ b/service/api/src/main/resources/kapua-service-error-messages.properties
@@ -34,9 +34,8 @@ PERMISSION_DELETE_NOT_ALLOWED=Operation not allowed on this specific permission.
 RESOURCE_RESTRICTED_TO_FIRST_LEVEL_ACCOUNTS=The resource {0} can only be created and managed in the first level accounts (direct child account of the Sys Admin Account).
 RESOURCE_RESTRICTED_TO_SYS_ADMIN_ACCOUNT=The resource {0} can only be created and managed in the system administrator account.
 SERVICE_DISABLED=The Service is disabled: {0}
-
 UNAUTHENTICATED=No authenticated Subject found in context.
-
+INCORRECT_CURRENT_PASSWORD=Incorrect current password
 # Deprecated codes
 USER_ALREADY_RESERVED_BY_ANOTHER_CONNECTION=This user is already reserved for another connection. Please select different user for this connection.
 DEVICE_NOT_FOUND=The selected devices were not found. Please refresh device list.

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/exception/KapuaAuthenticationErrorCodes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/exception/KapuaAuthenticationErrorCodes.java
@@ -177,5 +177,9 @@ public enum KapuaAuthenticationErrorCodes implements KapuaErrorCode {
      *
      * @since 1.4.0
      */
-    REQUIRE_MFA_CREDENTIALS
+    REQUIRE_MFA_CREDENTIALS,
+    /**
+     * When changing password, the value inserted for current password is incorrect
+     */
+    INCORRECT_CURRENT_PASSWORD
 }

--- a/service/security/authentication/api/src/main/resources/authentication-error-messages.properties
+++ b/service/security/authentication/api/src/main/resources/authentication-error-messages.properties
@@ -13,7 +13,6 @@
 ###############################################################################
 DUPLICATED_PASSWORD_CREDENTIAL=The user already has a Credential of type PASSWORD.
 PASSWORD_INVALID_LENGTH=Password length must be between {0} and {1} characters long (inclusive).
-
 # Following does not have a dedicated KapuaAuthenticationException sub-class
 SUBJECT_ALREADY_LOGGED=The User is already authenticated.
 INVALID_CREDENTIALS_TYPE_PROVIDED=The credentials provided are invalid.
@@ -35,3 +34,4 @@ JWK_GENERATION_ERROR=This code is deprecated.
 JWT_CERTIFICATE_NOT_FOUND=Cannot find a JWT Certificate to sign the AccessToken JWT
 PASSWORD_CANNOT_BE_CHANGED=This code is deprecated.
 REQUIRE_MFA_CREDENTIALS=This User has MFA enabled and the authorization code must be provided.
+INCORRECT_CURRENT_PASSWORD=Incorrect current password

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/user/shiro/UserCredentialsServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/user/shiro/UserCredentialsServiceImpl.java
@@ -31,6 +31,7 @@ import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
 import org.eclipse.kapua.service.authentication.credential.shiro.CredentialMapper;
 import org.eclipse.kapua.service.authentication.credential.shiro.PasswordValidator;
+import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationErrorCodes;
 import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationException;
 import org.eclipse.kapua.service.authentication.user.PasswordChangeRequest;
 import org.eclipse.kapua.service.authentication.user.PasswordResetRequest;
@@ -102,7 +103,7 @@ public class UserCredentialsServiceImpl implements UserCredentialsService {
             try {
                 authenticationService.verifyCredentials(usernamePasswordCredentials);
             } catch (KapuaAuthenticationException e) {
-                throw new KapuaIllegalArgumentException("passwordChangeRequest.currentPassword", passwordChangeRequest.getCurrentPassword());
+                throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INCORRECT_CURRENT_PASSWORD);
             }
 
             CredentialListResult credentials = credentialRepository.findByUserId(tx, KapuaSecurityUtils.getSession().getScopeId(), KapuaSecurityUtils.getSession().getUserId());


### PR DESCRIPTION
Currently the POST to {scopeId}/user/credentials/currentPassword returns as follows:
HTTP status code 400, with message "An illegal value was provided for the argument.currentPassword: XXXXX."
This is not acceptable as the inserted password is returned in plain text, and potentially shown to the user (if used in a UI).

**Description of the solution adopted**
A dedicated error code has been created for this case. The exception has been changed to a more appopriate KapuaAuthenticationException. 
The class org.eclipse.kapua.commons.rest.errors.KapuaAuthenticationExceptionMapper will handle converting this exception to a proper 401 code.
