### PR TITLE
Include `clientId` field in Device update REST API example

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
@@ -54,6 +54,7 @@ paths:
               type: device
               optlock: 1
               status: ENABLED
+              clientId: Client-Id-1
               displayName: Test Device
               serialNumber: "1234567890"
               modelId: Test Model


### PR DESCRIPTION
This pull request enhances the clarity and completeness of the Device Update REST API documentation by explicitly including the `clientId` field in the example request body. It's important to note that the `clientId` field was already present in the code; however, this update ensures its explicit representation in the API documentation example.