### PR TITLE
FIX - wrong Cors filtering error upon unauthorized API request

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilter.java
@@ -69,7 +69,7 @@ public class KapuaTokenAuthenticationFilter extends AuthenticatingFilter {
     protected boolean onAccessDenied(ServletRequest request, ServletResponse response) throws Exception {
         HttpServletResponse httpResponse = WebUtils.toHttp(response);
         httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        // Continue with the filter chain, because CORS headers are still needed
+        // Continue with the filter chain, because CORS headers are still needed in the case when token is not authenticated or expired
         return true;
     }
 


### PR DESCRIPTION
**Brief description of the PR**
If you tried to call the API using a wrong auth token (for example, empty or expired) Kapua was returning a wrong error message in the HTTP body regarding the CORS filtering error, even though the "allowed origins" contained the origin used to perform the call. The right response you would expect in this case is a 401 error code and nothing else.

**Description of the solution adopted**
This problem was caused by a regression I introduced in a past work on the CORS filtering logic. I didn't realize that the KapuaTokenAuthenticationFilter class, upon wrong authentication, was continuing the filtering chain to the CORS filter, and this one had to perform the filtering before returning the 401 error code to the client. This is the reason behind (see also https://github.com/eclipse/kapua/pull/3324): the browser, having made an API request, will check first of all if the header of the response contains the _origin_ headers. If not, it will display a network problem/CORS problem without showing the content of the response, even when it could contain, for example, a 401 status in the header. This means that to correctly display the 401 error code on the client side, the back-end side has to perform the cors filtering even if authentication fails.

**Tests done to verify the change**
To test the change, I've performed API calls with swagger using both _same-origin_ and _cross-origin_ as values in the SEC_FETCH_SITE field of the header. Also, I tried using wrong, empty or expired token as auth. fields. In this way, all possible scenarios were covered
