### PR TITLE
fix(deviceManageemntInventory): fixed handling of 'null' state for a InventoryContainer

### DIFF
--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
@@ -147,6 +147,9 @@ public class AbstractTranslatorAppInventoryKuraKapua<M extends InventoryResponse
                     LOG.warn("Unrecognised KuraInventoryContainer.state '{}' received. Defaulting to UNKNOWN state for DeviceInventoryContainer {}", kuraInventoryContainer.getState(), deviceInventoryContainer.getName(), iae);
                     deviceInventoryContainer.setState(DeviceInventoryContainerState.UNKNOWN);
                 }
+            } else {
+                LOG.warn("Property KuraInventoryContainer.state '{}' not present. Defaulting to UNKNOWN state for DeviceInventoryContainer {}", kuraInventoryContainer.getState(), deviceInventoryContainer.getName());
+                deviceInventoryContainer.setState(DeviceInventoryContainerState.UNKNOWN);
             }
 
             deviceInventoryContainers.addInventoryContainer(deviceInventoryContainer);


### PR DESCRIPTION
This PR fixes the handling of `state` property of a DeviceInventoryContainer when it is not provided by the INVENTORY-V1 app

**Related Issue**
This PR fixes an issue introduced in #3925

**Description of the solution adopted**
If `state` property is not present, `UNKNOWN` status is applyed.

**Screenshots**
_None_

**Any side note on the changes made**
_None_