### PR TITLE
fix(openapi): fixed openAPI deviceInventory example

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory.yaml
@@ -40,10 +40,10 @@ components:
         inventoryItems:
           - name: adduser
             version: 3.118
-            type: DEB
-          - name: alsa-utils
-            version: 1.1.8-2
-            type: DEB
+            itemType: DEB
+          - name: redis
+            version: latest
+            itemType: DOCKER
     deviceInventoryBundle:
       type: object
       properties:


### PR DESCRIPTION
This PR fixes a small issue in the `deviceInventory` example in OpenAPI which was not matching the schema and the actual value returned by the REST API

**Related Issue**
_None_

**Description of the solution adopted**
Fixed the example

**Screenshots**
_None_

**Any side note on the changes made**
_None_