### PR TITLE
FIX - error section on openApi doc.

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessInfoListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessPermissionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-accessPermissionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-accessPermissionId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessPermission'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -49,6 +51,8 @@ paths:
       responses:
         204:
           description: The AccessPermission has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
@@ -33,6 +33,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessPermissionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -59,6 +61,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessPermissionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessRoleListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-accessRoleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-accessRoleId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessRole'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -49,6 +51,8 @@ paths:
       responses:
         204:
           description: The AccessRole has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles.yaml
@@ -31,6 +31,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessRoleListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -57,6 +59,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessRoleListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessInfo'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -47,6 +49,8 @@ paths:
       responses:
         204:
           description: The AccessInfo has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessInfoListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -57,6 +59,8 @@ paths:
             application/json:
               schema:
                 $ref: './accessInfo.yaml#/components/schemas/accessInfoListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './account.yaml#/components/schemas/accountListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId-accountId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId-accountId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './account.yaml#/components/schemas/account'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -77,6 +79,8 @@ paths:
             application/json:
               schema:
                 $ref: './account.yaml#/components/schemas/account'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -97,6 +101,8 @@ paths:
       responses:
         204:
           description: The Account has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId.yaml
@@ -43,6 +43,8 @@ paths:
             application/json:
               schema:
                 $ref: './account.yaml#/components/schemas/accountListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -71,6 +73,8 @@ paths:
             application/json:
               schema:
                 $ref: './account.yaml#/components/schemas/account'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-apikey.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-apikey.yaml
@@ -37,6 +37,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
       security: []

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-apikey.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-apikey.yaml
@@ -37,6 +37,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-info.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-info.yaml
@@ -26,6 +26,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/loginInfo'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-jwt.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-jwt.yaml
@@ -35,6 +35,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-jwt.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-jwt.yaml
@@ -35,6 +35,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
       security: []

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-logout.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-logout.yaml
@@ -21,6 +21,8 @@ paths:
       responses:
         204:
           description: Logout Successful
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-mfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-mfa.yaml
@@ -59,6 +59,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
       security: [ ]

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-mfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-mfa.yaml
@@ -59,6 +59,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-refresh.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-refresh.yaml
@@ -45,6 +45,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
@@ -47,6 +47,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
@@ -47,6 +47,8 @@ paths:
             application/json:
               schema:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
       security: []

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './credential.yaml#/components/schemas/credentialListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId-unlock.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId-unlock.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './credential.yaml#/components/schemas/credential'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -54,6 +56,8 @@ paths:
             application/json:
               schema:
                 $ref: './credential.yaml#/components/schemas/credential'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId.yaml
@@ -63,6 +63,8 @@ paths:
                     firstLoginFailure: "2023-03-09T13:58:30.385Z"
                     loginFailuresReset: "2023-03-10T13:58:30.385Z"
                     lockoutReset: "2023-03-09T14:58:30.385Z"
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -109,6 +111,8 @@ paths:
                 firstLoginFailure: "2023-03-09T13:58:30.385Z"
                 loginFailuresReset: "2023-03-10T13:58:30.385Z"
                 lockoutReset: "2023-03-09T14:58:30.385Z"
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -128,6 +132,8 @@ paths:
       responses:
         204:
           description: The Credential has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId.yaml
@@ -70,6 +70,8 @@ paths:
                     firstLoginFailure: "2023-03-09T13:58:30.385Z"
                     loginFailuresReset: "2023-03-10T13:58:30.385Z"
                     lockoutReset: "2023-03-09T14:58:30.385Z"
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -149,6 +151,8 @@ paths:
                     firstLoginFailure: "2023-03-09T13:58:30.385Z"
                     loginFailuresReset: "2023-03-10T13:58:30.385Z"
                     lockoutReset: "2023-03-09T14:58:30.385Z"
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-channelInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-channelInfoId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataChannel.yaml#/components/schemas/channelInfo'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId.yaml
@@ -53,6 +53,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataChannel.yaml#/components/schemas/channelInfoListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-clientInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-clientInfoId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataClient.yaml#/components/schemas/clientInfo'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId.yaml
@@ -34,6 +34,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataClient.yaml#/components/schemas/clientInfoListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-datastoreMessageId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-datastoreMessageId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataMessage.yaml#/components/schemas/dataMessageListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId.yaml
@@ -85,6 +85,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataMessage.yaml#/components/schemas/dataMessageListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -138,6 +140,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataMessage.yaml#/components/schemas/dataMessageInsertResponse'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-metricInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-metricInfoId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataMetric.yaml#/components/schemas/metricInfo'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId.yaml
@@ -44,6 +44,8 @@ paths:
             application/json:
               schema:
                 $ref: './dataMetric.yaml#/components/schemas/metricInfoListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './device.yaml#/components/schemas/deviceListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './device.yaml#/components/schemas/device'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -83,6 +85,8 @@ paths:
             application/json:
               schema:
                 $ref: './device.yaml#/components/schemas/device'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -102,6 +106,8 @@ paths:
       responses:
         204:
           description: The Device has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
@@ -162,6 +162,8 @@ paths:
                           tamperStatus: NOT_TAMPERED
                           tagIds: []
 
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -189,6 +191,8 @@ paths:
             application/json:
               schema:
                 $ref: './device.yaml#/components/schemas/device'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_read.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_read.yaml
@@ -78,6 +78,8 @@ paths:
                             valueType: integer
                             error: Connection failed. Unable to Connect...
                             timestamp: '2019-09-12T14:50:24.446Z'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceAsset.yaml#/components/schemas/deviceAssetStoreSettings'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -54,6 +56,8 @@ paths:
       responses:
         204:
           description: The Device Management Settings have been applied
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_write.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_write.yaml
@@ -72,6 +72,8 @@ paths:
                           - name: Channel-2
                             error: "Channel not available"
                             timestamp: '2019-09-12T14:50:24.446Z'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId.yaml
@@ -70,20 +70,6 @@ paths:
             application/json:
               schema:
                 $ref: './deviceAsset.yaml#/components/schemas/deviceAssetDefinitions'
-              example:
-                type: deviceAssets
-                deviceAsset:
-                  - name: asset2
-                    channels:
-                      - valueType: integer
-                        name: Channel-1
-                        mode: READ
-                      - valueType: integer
-                        name: Channel-2
-                        mode: WRITE
-                      - valueType: integer
-                        name: Channel-3
-                        mode: READ_WRITE
         400:
           $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceAsset.yaml#/components/schemas/deviceAssetDefinitions'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -68,6 +70,22 @@ paths:
             application/json:
               schema:
                 $ref: './deviceAsset.yaml#/components/schemas/deviceAssetDefinitions'
+              example:
+                type: deviceAssets
+                deviceAsset:
+                  - name: asset2
+                    channels:
+                      - valueType: integer
+                        name: Channel-1
+                        mode: READ
+                      - valueType: integer
+                        name: Channel-2
+                        mode: WRITE
+                      - valueType: integer
+                        name: Channel-3
+                        mode: READ_WRITE
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_start.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_start.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         204:
           description: The Bundle has been successfully started
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_stop.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_stop.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         204:
           description: The Bundle has been successfully stopped
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId.yaml
@@ -31,6 +31,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceBundle.yaml#/components/schemas/deviceBundles'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand-scopeId-deviceId-_execute.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand-scopeId-deviceId-_execute.yaml
@@ -54,6 +54,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceCommand.yaml#/components/schemas/commandOutput'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConfiguration.yaml#/components/schemas/deviceConfigurationStoreSettings'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -54,6 +56,8 @@ paths:
       responses:
         204:
           description: The Device Management Settings have been applied
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
@@ -33,6 +33,8 @@ paths:
             application/xml:
               schema:
                 $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurations'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -63,6 +65,8 @@ paths:
       responses:
         204:
           description: The updated Configuration details of a single Service on a single Device
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml
@@ -32,6 +32,8 @@ paths:
             application/xml:
               schema:
                 $ref: './deviceConfiguration.yaml#/components/schemas/componentConfigurations'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -61,6 +63,8 @@ paths:
       responses:
         204:
           description: The updated list of Configurations on a single Device
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConnection.yaml#/components/schemas/connectionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-_disconnect.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-_disconnect.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConnection.yaml#/components/schemas/connectionOptions'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-options.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-options.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConnection.yaml#/components/schemas/connectionOptions'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -56,6 +58,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConnection.yaml#/components/schemas/connectionOptions'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConnection.yaml#/components/schemas/connection'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId.yaml
@@ -33,6 +33,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConnection.yaml#/components/schemas/connectionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -54,6 +56,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceConnection.yaml#/components/schemas/connectionAuthAdapters'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceEvent.yaml#/components/schemas/deviceEventListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-deviceEventId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-deviceEventId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceEvent.yaml#/components/schemas/deviceEvent'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -49,6 +51,8 @@ paths:
       responses:
         204:
           description: The Device Event has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId.yaml
@@ -50,6 +50,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceEvent.yaml#/components/schemas/deviceEventListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceInventory.yaml#/components/schemas/deviceInventory'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -54,6 +56,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceInventory.yaml#/components/schemas/deviceInventoryBundles'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -80,6 +84,8 @@ paths:
       responses:
         204:
           description: The inventory bundle has been started
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -106,6 +112,8 @@ paths:
       responses:
         204:
           description: The inventory bundle has been stopped
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -131,6 +139,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceInventory.yaml#/components/schemas/deviceInventoryContainers'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -157,6 +167,8 @@ paths:
       responses:
         204:
           description: The inventory container has been started
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -183,6 +195,8 @@ paths:
       responses:
         204:
           description: The inventory container has been stopped
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -208,6 +222,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceInventory.yaml#/components/schemas/deviceInventorySystemPackages'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -233,6 +249,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceInventory.yaml#/components/schemas/deviceInventoryDeploymentPackages'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore-scopeId-deviceId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceKeystore.yaml#/components/schemas/deviceKeystores'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -64,6 +66,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceKeystore.yaml#/components/schemas/deviceKeystoreItems'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -101,6 +105,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceKeystore.yaml#/components/schemas/deviceKeystoreItem'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -133,6 +139,8 @@ paths:
       responses:
         204:
           description: The keystore item has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -159,6 +167,8 @@ paths:
       responses:
         204:
           description: The certificate has been created into the device keystore
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -185,6 +195,8 @@ paths:
       responses:
         204:
           description: The certificate has been created into the device keystore
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -211,6 +223,8 @@ paths:
       responses:
         204:
           description: The keypair has been created into the device keystore
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -241,6 +255,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceKeystore.yaml#/components/schemas/deviceKeystoreCSR'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_count.yaml
@@ -27,6 +27,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_query.yaml
@@ -31,6 +31,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceNotification.yaml#/components/schemas/deviceNotificationListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-notificationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-notificationId.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceNotification.yaml#/components/schemas/deviceNotification'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -51,6 +53,8 @@ paths:
       responses:
         204:
           description: The Registry Notification has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId.yaml
@@ -36,6 +36,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceNotification.yaml#/components/schemas/deviceNotificationListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceOperation.yaml#/components/schemas/deviceOperationListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-operationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-operationId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceOperation.yaml#/components/schemas/deviceOperation'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -49,6 +51,8 @@ paths:
       responses:
         204:
           description: The Registry Operation has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
@@ -35,6 +35,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceOperation.yaml#/components/schemas/deviceOperationListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
@@ -69,6 +69,8 @@ paths:
             The Package Install request has been successfully received. However, this does NOT mean that the package has been successfully installed, since the Package Install
             is an asynchronous operation and may still be in progress. APIs are available at `device/{deviceId}/operations` and `device/{deviceId}/operations/{operationId}/notifications`
             to track asynchronous operations.
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
@@ -54,6 +54,8 @@ paths:
             The Package Install request has been successfully received. However, this does NOT mean that the package has been successfully installed, since the Package Install
             is an asynchronous operation and may still be in progress. APIs are available at `device/{deviceId}/operations` and `device/{deviceId}/operations/{operationId}/notifications`
             to track asynchronous operations.
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './devicePackage.yaml#/components/schemas/devicePackages'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest-scopeId-deviceId.yaml
@@ -35,6 +35,8 @@ paths:
             application/json:
               schema:
                 $ref: './deviceRequest.yaml#/components/schemas/requestOutput'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId-_rollback.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId-_rollback.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         204:
           description: The Snapshot has been applied
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
@@ -33,6 +33,8 @@ paths:
             application/xml:
               schema:
                 $ref: '../deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfigurations'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId.yaml
@@ -32,6 +32,8 @@ paths:
             application/xml:
               schema:
                 $ref: './deviceSnapshot.yaml#/components/schemas/snapshots'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './domain.yaml#/components/schemas/domainListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-domainId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-domainId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './domain.yaml#/components/schemas/domain'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId.yaml
@@ -34,6 +34,8 @@ paths:
             application/json:
               schema:
                 $ref: './domain.yaml#/components/schemas/domainListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './endpointInfo.yaml#/components/schemas/endpointInfoListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './endpointInfo.yaml#/components/schemas/endpointInfo'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -69,6 +71,8 @@ paths:
             application/json:
               schema:
                 $ref: './endpointInfo.yaml#/components/schemas/endpointInfo'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -90,6 +94,8 @@ paths:
       responses:
         204:
           description: The EndpointInfo has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
@@ -35,6 +35,8 @@ paths:
             application/json:
               schema:
                 $ref: './endpointInfo.yaml#/components/schemas/endpointInfoListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -62,6 +64,8 @@ paths:
             application/json:
               schema:
                 $ref: './endpointInfo.yaml#/components/schemas/endpointInfo'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './group.yaml#/components/schemas/groupListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId-groupId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId-groupId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './group.yaml#/components/schemas/group'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -63,6 +65,8 @@ paths:
             application/json:
               schema:
                 $ref: './group.yaml#/components/schemas/group'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -82,6 +86,8 @@ paths:
       responses:
         204:
           description: The Group has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId.yaml
@@ -34,6 +34,8 @@ paths:
             application/json:
               schema:
                 $ref: './group.yaml#/components/schemas/groupListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -61,6 +63,8 @@ paths:
             application/json:
               schema:
                 $ref: './group.yaml#/components/schemas/group'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './job.yaml#/components/schemas/jobListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId-jobId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId-jobId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './job.yaml#/components/schemas/job'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -61,6 +63,8 @@ paths:
             application/json:
               schema:
                 $ref: './job.yaml#/components/schemas/job'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -86,6 +90,8 @@ paths:
       responses:
         204:
           description: The Job has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId.yaml
@@ -47,6 +47,8 @@ paths:
             application/json:
               schema:
                 $ref: './job.yaml#/components/schemas/jobListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -74,6 +76,8 @@ paths:
             application/json:
               schema:
                 $ref: './job.yaml#/components/schemas/job'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId-executionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId-executionId.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         204:
           description: The Job Engine has received the Resume Execution request
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -46,6 +48,8 @@ paths:
       responses:
         204:
           description: The Job Engine has received the Stop Execution request
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId.yaml
@@ -30,6 +30,8 @@ paths:
       responses:
         204:
           description: The Start operation has been received by the Job Engine
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -50,6 +52,8 @@ paths:
       responses:
         204:
           description: The Stop operation has been received by the Job Engine
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -74,6 +78,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobEngine.yaml#/components/schemas/isJobRunning'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId.yaml
@@ -36,6 +36,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobEngine.yaml#/components/schemas/multipleIsJobRunning'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobExecution.yaml#/components/schemas/jobExecutionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId-targets.yaml
@@ -31,6 +31,8 @@ paths:
             application/json:
               schema:
                 $ref: '../jobTarget/jobTarget.yaml#/components/schemas/jobTargetListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobExecution.yaml#/components/schemas/jobExecution'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions.yaml
@@ -45,6 +45,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobExecution.yaml#/components/schemas/jobExecutionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobStep.yaml#/components/schemas/jobStepListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-stepId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-stepId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobStep.yaml#/components/schemas/jobStep'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -60,6 +62,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobStep.yaml#/components/schemas/jobStep'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -80,6 +84,8 @@ paths:
       responses:
         204:
           description: The Job Step has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps.yaml
@@ -38,6 +38,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobStep.yaml#/components/schemas/jobStepListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -66,6 +68,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobStep.yaml#/components/schemas/jobStep'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobStepDefinition.yaml#/components/schemas/jobStepDefinitionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-jobStepDefinitionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-jobStepDefinitionId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobStepDefinition.yaml#/components/schemas/jobStepDefinition'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId.yaml
@@ -31,6 +31,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobStepDefinition.yaml#/components/schemas/jobStepDefinitionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobTarget.yaml#/components/schemas/jobTargetListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId-executions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId-executions.yaml
@@ -31,6 +31,8 @@ paths:
             application/json:
               schema:
                 $ref: '../jobExecution/jobExecution.yaml#/components/schemas/jobExecutionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId.yaml
@@ -34,6 +34,8 @@ paths:
                   $ref: './jobTarget.yaml#/components/examples/jobTargetSuccess'
                 Failed processed Job Target:
                   $ref: './jobTarget.yaml#/components/examples/jobTargetFailed'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -54,6 +56,8 @@ paths:
       responses:
         204:
           description: The Job Target has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
@@ -33,6 +33,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobTarget.yaml#/components/schemas/jobTargetListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -61,6 +63,8 @@ paths:
             application/json:
               schema:
                 $ref: '../job/job.yaml#/components/schemas/job'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobTrigger.yaml#/components/schemas/jobTriggerListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-triggerId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-triggerId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobTrigger.yaml#/components/schemas/jobTrigger'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -60,6 +62,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobTrigger.yaml#/components/schemas/jobTrigger'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -80,6 +84,8 @@ paths:
       responses:
         204:
           description: The Job Trigger has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers.yaml
@@ -38,6 +38,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobTrigger.yaml#/components/schemas/jobTriggerListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -66,6 +68,8 @@ paths:
             application/json:
               schema:
                 $ref: '../job/job.yaml#/components/schemas/job'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_count.yaml
@@ -27,6 +27,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_query.yaml
@@ -31,6 +31,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobTriggerFired.yaml#/components/schemas/firedTriggerListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
@@ -41,6 +41,8 @@ paths:
             application/json:
               schema:
                 $ref: './jobTriggerFired.yaml#/components/schemas/firedTriggerListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -775,6 +775,24 @@ components:
           - "schema=mqtt"
           - "dns=10.200.12.148"
           - "port=1883"
+    InternalUserOnlyExceptionInfo:
+      description: the operation is reserved only to users with 'userType' INTERNAL
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+      example:
+        type: "InternalUserOnlyExceptionInfo"
+        httpErrorCode: 403
+        message: "This operation is reserved only for Users of type INTERNAL."
+        kapuaErrorCode: "INTERNAL_USER_ONLY"
+    SelfManagedOnlyExceptionInfo:
+      description: the operation can only be performed on the user which is currently authenticated
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+      example:
+        type: "SelfManagedOnlyExceptionInfo"
+        httpErrorCode: 403
+        message: "This operation can be performed only on the current logged User."
+        kapuaErrorCode: "SELF_MANAGED_ONLY"
     ### Other Base Entities ###
     kapuaListResult:
       description: A container for all the Entities List
@@ -1206,7 +1224,7 @@ components:
           schema:
             $ref: '#/components/schemas/setResult'
     ### Errors - responses ###
-    kapuaError:
+    kapuaError: #Base 500 response
       description: An error occurred while performing the request
       content:
         application/json:
@@ -1215,7 +1233,7 @@ components:
         application/xml:
           schema:
             $ref: '#/components/schemas/exceptionInfo'
-    entityNotFound:
+    entityNotFound: #Base 404 response
       description: The desired entity could not be found
       content:
         application/json:
@@ -1224,7 +1242,7 @@ components:
         application/xml:
           schema:
             $ref: '#/components/schemas/entityNotFoundExceptionInfo'
-    illegalArgument:
+    illegalArgument: #Base 400 response
       description: An illegal argument has been passed to the operation
       content:
         application/json:
@@ -1239,7 +1257,7 @@ components:
               - $ref: '#/components/schemas/illegalNullArgumentExceptionInfo'
             xml:
               name: 'illegalArgumentExceptionInfo'
-    subjectUnauthorized:
+    subjectUnauthorized: #Base 403 response
       description: The user performing the operation does not have the required permissions
       content:
         application/json:
@@ -1248,9 +1266,9 @@ components:
         application/xml:
           schema:
             $ref: '#/components/schemas/subjectUnauthorizedExceptionInfo'
-    unauthenticated:
+    unauthenticated: #Base 401 response
       description: The authentication failed for some reason. If this was done via an Access Token, it could be expired or invalidated
-    entityUniqueness:
+    entityUniqueness: #Base 404 response
       description: An Entity with the same unique fields is already present in the system
       content:
         application/json:

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -622,8 +622,8 @@ components:
               type: string
           required:
             - name
-    ### Other Base Entities ###
-    kapuaError:
+    ### Errors - schemas ###
+    exceptionInfo:
       description: The base object to represent an Error
       properties:
         message:
@@ -631,7 +631,151 @@ components:
           description: An extended description of the error that occurred when performing the operation
         kapuaErrorCode:
           type: string
-          description: An human readable error code that can be used to
+          description: An human readable error code used in the platform
+        httpErrorCode:
+          type: string
+          description: The http error code for this response
+      example:
+        type: "exceptionInfo"
+        httpErrorCode: 500
+        message: "Operation not allowed: This account cannot be deleted. Delete its child first.."
+        kapuaErrorCode: "OPERATION_NOT_ALLOWED"
+    subjectUnauthorizedExceptionInfo:
+      description: The object to represent the fact that the subject requesting the resource has not the required permissions
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+        - properties:
+            permission:
+              $ref: './accessInfo/accessInfo.yaml#/components/schemas/permission'
+      example:
+        type: "subjectUnauthorizedExceptionInfo"
+        httpErrorCode: 403
+        message: "User does not have permission to perform this action. Required permission: user:read:1:*."
+        kapuaErrorCode: "SUBJECT_UNAUTHORIZED"
+        permission:
+            domain: "user"
+            action: "read"
+            targetScopeId: "AQ"
+            forwardable: false
+    entityNotFoundExceptionInfo:
+      description: The object to represent the fact that an entity has not been found
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+        - properties:
+            entityType:
+              description: The type of the entity that could not be found
+              type: string
+            entityId:
+              description: The ID of the entity that could not be found
+              type: string
+      example:
+        type: "entityNotFoundExceptionInfo"
+        httpErrorCode: 404
+        message: "The entity of type user with id/name 742 was not found."
+        kapuaErrorCode: "ENTITY_NOT_FOUND"
+        entityType: "user"
+        entityId: "AuY"
+    illegalArgumentExceptionInfo:
+      description: An illegal value has been passed to the operation
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+        - properties:
+            argumentName:
+              description: The name of the argument who holds an illegal value
+              type: string
+            argumentValue:
+              description: The illegal value passed to the operation
+              type: string
+      example:
+        type: "illegalArgumentExceptionInfo"
+        httpErrorCode: 400
+        message: "An illegal value was provided for the argument user.email: thisIsNotAnEmailAtAll"
+        kapuaErrorCode: "ILLEGAL_ARGUMENT"
+        argumentName: "user.email"
+        argumentValue: "thisIsNotAnEmailAtAll"
+    illegalNullArgumentExceptionInfo:
+      description: An illegal null argument has been passed to the operation
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+        - properties:
+            argumentName:
+              type: string
+              description: The name of the argument who holds an illegal null value
+      example:
+        type: "illegalNullArgumentExceptionInfo"
+        httpErrorCode: 400
+        message: "An illegal value was provided for the argument user.email: null"
+        kapuaErrorCode: "ILLEGAL_NULL_ARGUMENT"
+        argumentName: "user.email"
+    ServiceConfigurationLimitExceededExceptionInfo:
+      description: The update of the configuration for the service exceeds available resources of the current scope
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+        - properties:
+            scopeId:
+              description: The scope for which limit has been exceeded
+              $ref: '#/components/schemas/kapuaId'
+            servicePid:
+              type: string
+              description: The Pid of the service
+            limitExceededBy:
+              type: string
+              description: The amount of excess
+      example:
+        type: "ServiceConfigurationLimitExceededExceptionInfo"
+        httpErrorCode: 400
+        message: "The maximum of resources for the org.eclipse.kapua.service.account.AccountService service for the account 2 has been exceeded. The resource limit is exceeded by 3."
+        kapuaErrorCode: "LIMIT_EXCEEDED"
+        scopeId: 2
+        servicePid: "org.eclipse.kapua.service.account.AccountService"
+        limitExceededBy: 3
+    ServiceConfigurationParentLimitExceededExceptionInfo:
+      description: The update of the configuration for the service exceeds available resources of the parent scope
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+        - properties:
+            parentScopeId:
+              description: The parent scope for which limit has been exceeded
+              $ref: '#/components/schemas/kapuaId'
+            servicePid:
+              type: string
+              description: The Pid of the service
+            limitExceededBy:
+              type: string
+              description: The amount of excess
+      example:
+        type: "ServiceConfigurationLimitExceededExceptionInfo"
+        httpErrorCode: 400
+        message: "The maximum of resources for the org.eclipse.kapua.service.account.AccountService service for the parent account 2 has been exceeded."
+        kapuaErrorCode: "PARENT_LIMIT_EXCEEDED"
+        scopeId: 2
+        servicePid: "org.eclipse.kapua.service.account.AccountService"
+        limitExceededBy: 3
+    entityUniquenessExceptionInfo:
+      description: The object to represent the fact that an Entity with the same unique fields is already present in the system
+      allOf:
+        - $ref: '#/components/schemas/exceptionInfo'
+        - properties:
+            entityType:
+              type: string
+              description: The type of the entity
+            uniquesFieldValues:
+              type: array
+              description: map of fields and associated values that should be unique in the system
+              items:
+                type: string
+      example:
+        type: "entityUniquenessExceptionInfo"
+        httpErrorCode: 409
+        message: "Error: [scopeId=1, schema=mqtt, dns=10.200.12.148, port=1883]"
+        kapuaErrorCode: "ENTITY_UNIQUENESS"
+        entityType: "endpointInfo"
+        uniquesFieldValues:
+          - "scopeId=1"
+          - "schema=mqtt"
+          - "dns=10.200.12.148"
+          - "port=1883"
+    ### Other Base Entities ###
     kapuaListResult:
       description: A container for all the Entities List
       type: object
@@ -661,6 +805,7 @@ components:
           type: array
           items:
             type: string
+
     ### Schema used in different yaml definitions, placed here for problems with swagger reference resolution ###
     action:
       type: string
@@ -1060,67 +1205,61 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/setResult'
-    ### Errors ###
+    ### Errors - responses ###
     kapuaError:
       description: An error occurred while performing the request
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/kapuaError'
+            $ref: '#/components/schemas/exceptionInfo'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/exceptionInfo'
     entityNotFound:
       description: The desired entity could not be found
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: '#/components/responses/kapuaError/content/application~1json/schema'
-              - properties:
-                  entityType:
-                    description: The type of the entity that could not be found
-                    type: string
-                  entityId:
-                    description: The ID of the entity that could not be found
-                    type: string
+            $ref: '#/components/schemas/entityNotFoundExceptionInfo'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/entityNotFoundExceptionInfo'
     illegalArgument:
-      description: An illegal value has been passes to the operation
+      description: An illegal argument has been passed to the operation
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: '#/components/schemas/kapuaError'
-              - properties:
-                  argumentName:
-                    description: The name of the argument who holds an illegal value
-                    type: string
-                  argumentValue:
-                    description: The illegal value passed to the operation
-                    type: string
-    illegalNullArgument:
-      description: An illegal null argument has been passed to the operation
-      content:
-        application/json:
+            oneOf:
+              - $ref: '#/components/schemas/illegalArgumentExceptionInfo'
+              - $ref: '#/components/schemas/illegalNullArgumentExceptionInfo'
+        application/xml:
           schema:
-            allOf:
-              - $ref: '#/components/schemas/kapuaError'
-              - properties:
-                  argumentName:
-                    type: string
-                    description: The name of the argument who holds an illegal null value
+            oneOf:
+              - $ref: '#/components/schemas/illegalArgumentExceptionInfo'
+              - $ref: '#/components/schemas/illegalNullArgumentExceptionInfo'
+            xml:
+              name: 'illegalArgumentExceptionInfo'
     subjectUnauthorized:
       description: The user performing the operation does not have the required permissions
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: '#/components/schemas/kapuaError'
-              - properties:
-                  permission:
-                    description: The permission that is required to perform the operation, and that the current user is missing
-                    type: string
+            $ref: '#/components/schemas/subjectUnauthorizedExceptionInfo'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/subjectUnauthorizedExceptionInfo'
     unauthenticated:
-      description: The provided AccessToken could not be found, or no AccessToken has been provided
+      description: The authentication with the provided AccessToken failed for some reason. For example, it could never been issued by the platform, it could be expired or not valid
     entityUniqueness:
       description: An Entity with the same unique fields is already present in the system
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/entityUniquenessExceptionInfo'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/entityUniquenessExceptionInfo'
+  # Security schemes
   securitySchemes:
     kapuaToken:
       description: The default AccessToken Security Scheme. A [JWT](https://jwt.io) is used to represent the claims of a user

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -624,8 +624,11 @@ components:
             - name
     ### Errors - schemas ###
     exceptionInfo:
-      description: The base object to represent an Error
+      description: The base object to represent an Error. Every '*exceptionInfo' object in the codebase extends this, adding some fields if needed
       properties:
+        type:
+          type: string
+          description: the exact type of exceptionInfo object
         message:
           type: string
           description: An extended description of the error that occurred when performing the operation
@@ -1225,7 +1228,7 @@ components:
             $ref: '#/components/schemas/setResult'
     ### Errors - responses ###
     kapuaError: #Base 500 response
-      description: An error occurred while performing the request
+      description: An internal error occurred while performing the request
       content:
         application/json:
           schema:

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -1249,7 +1249,7 @@ components:
           schema:
             $ref: '#/components/schemas/subjectUnauthorizedExceptionInfo'
     unauthenticated:
-      description: The authentication with the provided AccessToken failed for some reason. For example, it could never been issued by the platform, it could be expired or not valid
+      description: The authentication failed for some reason. If this was done via an Access Token, it could be expired or invalidated
     entityUniqueness:
       description: An Entity with the same unique fields is already present in the system
       content:

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './role.yaml#/components/schemas/roleListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId-users.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId-users.yaml
@@ -32,6 +32,8 @@ paths:
             application/json:
               schema:
                 $ref: '../user/user.yaml#/components/schemas/userListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './role.yaml#/components/schemas/role'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -73,6 +75,8 @@ paths:
                 optlock: 2
                 name: new-role-2
                 description: A new Description for a new Role
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -92,6 +96,8 @@ paths:
       responses:
         204:
           description: The Role has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId.yaml
@@ -35,6 +35,8 @@ paths:
             application/json:
               schema:
                 $ref: './role.yaml#/components/schemas/roleListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -62,6 +64,8 @@ paths:
             application/json:
               schema:
                 $ref: './role.yaml#/components/schemas/role'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_count.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_query.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: './role.yaml#/components/schemas/rolePermissionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-permissionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-permissionId.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './role.yaml#/components/schemas/rolePermission'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -49,6 +51,8 @@ paths:
       responses:
         204:
           description: The RolePermission has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
@@ -43,6 +43,8 @@ paths:
             application/json:
               schema:
                 $ref: './role.yaml#/components/schemas/rolePermissionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -87,6 +89,8 @@ paths:
                   domain: domain
                   action: read
                   forwardable: true
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './serviceConfiguration.yaml#/components/schemas/componentConfigurations'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -57,6 +59,25 @@ paths:
             application/json:
               schema:
                 $ref: './serviceConfiguration.yaml#/components/schemas/componentConfiguration'
+        400:
+          description: An illegal argument has been passed to the operation OR the resource cannot be updated for limits imposed on it (in this scope or parent scope)
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationLimitExceededExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/responses/illegalArgument/content/application~1json/schema'
+                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationParentLimitExceededExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+            application/xml:
+              schema:
+                oneOf:
+                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationLimitExceededExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/responses/illegalArgument/content/application~1xml/schema'
+                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationParentLimitExceededExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+                xml:
+                  name: 'ServiceConfigurationLimitExceededExceptionInfo'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId.yaml
@@ -27,6 +27,8 @@ paths:
             application/json:
               schema:
                 $ref: './serviceConfiguration.yaml#/components/schemas/componentConfigurations'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -51,6 +53,25 @@ paths:
       responses:
         200:
           description: The list of the Configurations
+        400:
+          description: An illegal argument has been passed to the operation OR the resource cannot be updated for limits imposed on it (in this scope or parent scope)
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationLimitExceededExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/responses/illegalArgument/content/application~1json/schema'
+                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationParentLimitExceededExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+            application/xml:
+              schema:
+                oneOf:
+                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationLimitExceededExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/responses/illegalArgument/content/application~1xml/schema'
+                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationParentLimitExceededExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+                xml:
+                  name: 'ServiceConfigurationLimitExceededExceptionInfo'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/stream/stream-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/stream/stream-scopeId.yaml
@@ -56,6 +56,8 @@ paths:
       responses:
         204:
           description: The message has been sent successfully
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './tag.yaml#/components/schemas/tagListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-tagId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-tagId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './tag.yaml#/components/schemas/tag'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -73,6 +75,8 @@ paths:
                 optlock: 2
                 name: new-tag
                 description: A new Description for a new Tag
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -92,6 +96,8 @@ paths:
       responses:
         204:
           description: The Tag has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId.yaml
@@ -34,6 +34,8 @@ paths:
             application/json:
               schema:
                 $ref: './tag.yaml#/components/schemas/tagListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -61,6 +63,8 @@ paths:
             application/json:
               schema:
                 $ref: './tag.yaml#/components/schemas/tag'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './triggerDefinition.yaml#/components/schemas/triggerDefinitionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-triggerDefinitionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-triggerDefinitionId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './triggerDefinition.yaml#/components/schemas/triggerDefinition'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId.yaml
@@ -31,6 +31,8 @@ paths:
             application/json:
               schema:
                 $ref: './triggerDefinition.yaml#/components/schemas/triggerDefinitionListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-_count.yaml
@@ -25,6 +25,8 @@ paths:
       responses:
         200:
           $ref: '../openapi.yaml#/components/responses/countResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-_query.yaml
@@ -29,6 +29,8 @@ paths:
             application/json:
               schema:
                 $ref: './user.yaml#/components/schemas/userListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: './user.yaml#/components/schemas/user'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -67,6 +69,8 @@ paths:
             application/json:
               schema:
                 $ref: './user.yaml#/components/schemas/user'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -86,6 +90,8 @@ paths:
       responses:
         204:
           description: The User has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
@@ -51,6 +51,8 @@ paths:
             application/json:
               schema:
                 $ref: './user.yaml#/components/schemas/userListResult'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -106,6 +108,8 @@ paths:
                   description: An User created providing all the information
                   value:
                     $ref: './user.yaml#/components/examples/user/value'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/usersCredentials/users-credentials-scopeId-userId-password-_reset.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersCredentials/users-credentials-scopeId-userId-password-_reset.yaml
@@ -36,6 +36,8 @@ paths:
             application/json:
               schema:
                 $ref: '../credential/credential.yaml#/components/schemas/credential'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa-disableTrust.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa-disableTrust.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: '../userMfa/userMfa.yaml#/components/schemas/mfaOption'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa.yaml
@@ -60,7 +60,22 @@ paths:
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
-          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+          description: The operation is forbidden for some reason
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '../openapi.yaml#/components/schemas/InternalUserOnlyExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/responses/subjectUnauthorized/content/application~1json/schema'
+                  - $ref: '../openapi.yaml#/components/schemas/SelfManagedOnlyExceptionInfo'
+            application/xml:
+              schema:
+                oneOf:
+                  - $ref: '../openapi.yaml#/components/schemas/InternalUserOnlyExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/responses/subjectUnauthorized/content/application~1xml/schema'
+                  - $ref: '../openapi.yaml#/components/schemas/SelfManagedOnlyExceptionInfo'
+                xml:
+                  name: 'InternalUserOnlyExceptionInfo'
         404:
           $ref: '../openapi.yaml#/components/responses/entityNotFound'
         500:

--- a/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 $ref: '../userMfa/userMfa.yaml#/components/schemas/mfaOption'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -53,6 +55,8 @@ paths:
             application/json:
               schema:
                 $ref: '../userMfa/userMfa.yaml#/components/schemas/mfaOptionCreationResponse'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
@@ -72,6 +76,8 @@ paths:
       responses:
         204:
           description: The MfaOption has been deleted
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:


### PR DESCRIPTION
Brief description of the PR.
This PR improves the openApi doc. in the section regarding error responses. The openApi main document has been re-structured in order to have one section for the _schemas_ of error messages, containing the various *exceptionInfo objects we have in the code (with a lot of addition of missing exceptionInfos not documented before) and the _responses_ section, that points to the _schemas_ adding some descriptions and json/xml type operator.

In addition, some meaningful examples (aka, not automatically generated by swagger) have been added for possible errors, both for JSON and XML media types.

The 400 has been introduced here in the documentation for all the endpoints of the API.

In some auth. endpoints the 401 error code was not documented despite being thrown on some failed login attempts.

**Any side note on the changes made or further improvements**
With this work, all possible exceptionInfos mapped to error code 4xx has been documented. For error code 5xx, instead, there is no documentation of the mapped exceptionInfos, that could be added in the future. To cover this aspect, I changed a bit the documentation for the 500 error code in order to better explain that other exceptionInfos objects exists other than the simple exceptionInfo object
