### PR TITLE
:fix: was caching the wrong list

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCachingRepository.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCachingRepository.java
@@ -63,7 +63,7 @@ public class RolePermissionCachingRepository
         }
         final RolePermissionListResult fromWrapped = wrapped.findByRoleId(tx, scopeId, roleId);
 
-        entityCache.putList(scopeId, roleId, listResult);
+        entityCache.putList(scopeId, roleId, fromWrapped);
         return fromWrapped;
     }
 


### PR DESCRIPTION
Fix for the following stacktrace:
```
2024-02-07 08:32:19,592 [qtp1027007693-184] ERROR o.e.k.c.s.internal.cache.EntityCache - Cache exception
java.lang.NullPointerException: null
at org.redisson.jcache.JCache.putAsync(JCache.java:1064)
at org.redisson.jcache.JCache.put(JCache.java:1187)
at org.eclipse.kapua.commons.service.internal.cache.EntityCache.putList(EntityCache.java:92)
at org.eclipse.kapua.service.authorization.role.shiro.RolePermissionCachingRepository.findByRoleId(RolePermissionCachingRepository.java:66)
at org.eclipse.kapua.service.authorization.role.shiro.RolePermissionServiceImpl.lambda$findByRoleId$4(RolePermissionServiceImpl.java:162)
at org.eclipse.kapua.storage.TxManagerImpl.execute(TxManagerImpl.java:50)
at org.eclipse.kapua.service.authorization.role.shiro.RolePermissionServiceImpl.findByRoleId(RolePermissionServiceImpl.java:162)
at org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm.lambda$doGetAuthorizationInfo$5(KapuaAuthorizingRealm.java:167)
at org.eclipse.kapua.commons.security.KapuaSecurityUtils.doPrivileged(KapuaSecurityUtils.java:116)
at org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm.doGetAuthorizationInfo(KapuaAuthorizingRealm.java:167)
at org.apache.shiro.realm.AuthorizingRealm.getAuthorizationInfo(AuthorizingRealm.java:342)
at org.apache.shiro.realm.AuthorizingRealm.isPermitted(AuthorizingRealm.java:465)
at org.apache.shiro.authz.ModularRealmAuthorizer.isPermitted(ModularRealmAuthorizer.java:239)
at org.apache.shiro.mgt.AuthorizingSecurityManager.isPermitted(AuthorizingSecurityManager.java:117)
```