### PR TITLE
fix(deviceManagementConfiguration): fixed serialization of DeviceConfiguration of Password properties

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/ClassBasedXmlPropertyAdapterBase.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/ClassBasedXmlPropertyAdapterBase.java
@@ -33,13 +33,19 @@ public abstract class ClassBasedXmlPropertyAdapterBase<T> implements XmlProperty
     }
 
     @Override
+    public boolean doesEncrypt() {
+        return false;
+    }
+
+    @Override
     public void marshallValues(XmlPropertyAdapted<?> property, Object value) {
         if (!value.getClass().isArray()) {
             property.setArray(false);
-            property.setEncrypted(false);
+            property.setEncrypted(doesEncrypt());
             property.setValues(new String[]{marshallValue(value)});
         } else {
             property.setArray(true);
+            property.setEncrypted(doesEncrypt());
             Object[] nativeValues = (Object[]) value;
             String[] stringValues = new String[nativeValues.length];
             for (int i = 0; i < nativeValues.length; i++) {

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertyAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertyAdapter.java
@@ -17,6 +17,8 @@ import org.eclipse.kapua.model.xml.XmlPropertyAdapted;
 public interface XmlPropertyAdapter {
     boolean canMarshall(Class<?> objectClass);
 
+    boolean doesEncrypt();
+
     void marshallValues(XmlPropertyAdapted<?> property, Object value);
 
     Object unmarshallValues(XmlPropertyAdapted<?> property);

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraPasswordPropertyAdapter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraPasswordPropertyAdapter.java
@@ -10,26 +10,27 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.configuration.metatype;
+package org.eclipse.kapua.service.device.call.kura.model.configuration.xml;
 
 import org.eclipse.kapua.commons.crypto.CryptoUtil;
 import org.eclipse.kapua.model.xml.XmlPropertyAdapted;
 import org.eclipse.kapua.model.xml.adapters.ClassBasedXmlPropertyAdapterBase;
+import org.eclipse.kapua.service.device.call.kura.model.configuration.KuraPassword;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class PasswordPropertyAdapter extends ClassBasedXmlPropertyAdapterBase<Password> {
+public class KuraPasswordPropertyAdapter extends ClassBasedXmlPropertyAdapterBase<KuraPassword> {
     private final CryptoUtil cryptoUtil;
 
-    public PasswordPropertyAdapter(CryptoUtil cryptoUtil) {
-        super(Password.class);
+    public KuraPasswordPropertyAdapter(CryptoUtil cryptoUtil) {
+        super(KuraPassword.class);
         this.cryptoUtil = cryptoUtil;
     }
 
     @Override
     public boolean canMarshall(Class objectClass) {
-        return Password.class.equals(objectClass);
+        return KuraPassword.class.equals(objectClass);
     }
 
     @Override
@@ -43,18 +44,18 @@ public class PasswordPropertyAdapter extends ClassBasedXmlPropertyAdapterBase<Pa
     }
 
     @Override
-    public Password unmarshallValue(String value) {
-        return new Password(cryptoUtil.decodeBase64(value));
+    public KuraPassword unmarshallValue(String value) {
+        return new KuraPassword(cryptoUtil.decodeBase64(value));
     }
 
     @Override
     public Object unmarshallValues(XmlPropertyAdapted<?> property) {
         if (!property.getArray()) {
-            return property.isEncrypted() ? unmarshallValue(property.getValues()[0]) : new Password(property.getValues()[0]);
+            return property.isEncrypted() ? unmarshallValue(property.getValues()[0]) : new KuraPassword(property.getValues()[0]);
         } else {
             return Arrays
                     .stream(property.getValues())
-                    .map(value -> property.isEncrypted() ? unmarshallValue(value) : new Password(value))
+                    .map(value -> property.isEncrypted() ? unmarshallValue(value) : new KuraPassword(value))
                     .collect(Collectors.toList()).toArray();
         }
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapter.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.model.configuration.xml;
 
-import org.eclipse.kapua.commons.configuration.metatype.PasswordPropertyAdapter;
 import org.eclipse.kapua.commons.crypto.CryptoUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.xml.adapters.BooleanPropertyAdapter;
@@ -50,7 +49,7 @@ public class KuraXmlConfigPropertiesAdapter extends XmlAdapter<KuraXmlConfigProp
             put(ConfigPropertyType.charType, new CharPropertyAdapter());
             put(ConfigPropertyType.booleanType, new BooleanPropertyAdapter());
             put(ConfigPropertyType.shortType, new ShortPropertyAdapter());
-            put(ConfigPropertyType.passwordType, new PasswordPropertyAdapter(KapuaLocator.getInstance().getComponent(CryptoUtil.class)));
+            put(ConfigPropertyType.passwordType, new KuraPasswordPropertyAdapter(KapuaLocator.getInstance().getComponent(CryptoUtil.class)));
         }
     });
 


### PR DESCRIPTION
This PR fixes the handling of the Password (and KuraPassword) properties of the DeviceConfiguration

**Related Issue**
This is an issue introduced #3837 

**Description of the solution adopted**
Added missing handling of KuraPassword attributes.
Added handling of `encrypted` attribute for Password/KuraPassword properties

**Screenshots**
_None_

**Any side note on the changes made**
_None_