### PR TITLE
Block credential reset for non-password credentials

### DIFF
--- a/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/KapuaRuntimeExceptionMapper.java
+++ b/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/KapuaRuntimeExceptionMapper.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.rest.errors;
 
-import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaRuntimeErrorCodes;
-import org.eclipse.kapua.commons.rest.model.errors.ExceptionInfo;
+import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.commons.rest.model.errors.ThrowableInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,33 +25,33 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 @Provider
-public class KapuaExceptionMapper implements ExceptionMapper<KapuaException> {
+public class KapuaRuntimeExceptionMapper implements ExceptionMapper<KapuaRuntimeException> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KapuaExceptionMapper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KapuaRuntimeExceptionMapper.class);
     public static final int UNPROCESSABLE_CONTENT_HTTP_CODE = 422;
 
     private final boolean showStackTrace;
 
     @Inject
-    public KapuaExceptionMapper(ExceptionConfigurationProvider exceptionConfigurationProvider) {
+    public KapuaRuntimeExceptionMapper(ExceptionConfigurationProvider exceptionConfigurationProvider) {
         this.showStackTrace = exceptionConfigurationProvider.showStackTrace();
     }
 
     @Override
-    public Response toResponse(KapuaException kapuaException) {
-        LOG.error(kapuaException.getMessage(), kapuaException);
-        if (kapuaException.getCode() instanceof KapuaRuntimeErrorCodes) {
-            switch ((KapuaRuntimeErrorCodes) kapuaException.getCode()) {
+    public Response toResponse(KapuaRuntimeException runtimeException) {
+        LOG.error(runtimeException.getMessage(), runtimeException);
+        if (runtimeException.getCode() instanceof KapuaRuntimeErrorCodes) {
+            switch ((KapuaRuntimeErrorCodes) runtimeException.getCode()) {
                 case SERVICE_OPERATION_NOT_SUPPORTED:
                     return Response
                             .status(UNPROCESSABLE_CONTENT_HTTP_CODE) //Unprocessable content.
-                            .entity(new ExceptionInfo(UNPROCESSABLE_CONTENT_HTTP_CODE, kapuaException, showStackTrace))
+                            .entity(new ThrowableInfo(UNPROCESSABLE_CONTENT_HTTP_CODE, runtimeException, showStackTrace))
                             .build();
             }
         }
         return Response
                 .serverError()
-                .entity(new ExceptionInfo(Status.INTERNAL_SERVER_ERROR.getStatusCode(), kapuaException, showStackTrace))
+                .entity(new ThrowableInfo(Status.INTERNAL_SERVER_ERROR.getStatusCode(), runtimeException, showStackTrace))
                 .build();
     }
 

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/ExceptionConfigurationProviderImpl.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/ExceptionConfigurationProviderImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.rest.errors.ExceptionConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -24,6 +25,7 @@ public class ExceptionConfigurationProviderImpl implements ExceptionConfiguratio
     private final boolean showStackTrace;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    @Inject
     public ExceptionConfigurationProviderImpl(@Named("showStackTrace") Boolean showStackTrace) {
         this.showStackTrace = showStackTrace;
         logger.debug("Initialized with showStackTrace={}", showStackTrace);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/user/shiro/UserCredentialsServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/user/shiro/UserCredentialsServiceImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.kapua.service.authentication.user.shiro;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.KapuaRuntimeErrorCodes;
 import org.eclipse.kapua.commons.model.domains.Domains;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
@@ -142,6 +143,9 @@ public class UserCredentialsServiceImpl implements UserCredentialsService {
         Credential credential = credentialRepository.find(tx, scopeId, credentialId)
                 .orElseThrow(() -> new KapuaEntityNotFoundException(Credential.TYPE, credentialId));
 
+        if (credential.getCredentialType() != CredentialType.PASSWORD) {
+            throw new KapuaException(KapuaRuntimeErrorCodes.SERVICE_OPERATION_NOT_SUPPORTED);
+        }
         String plainNewPassword = passwordResetRequest.getNewPassword();
         try {
             passwordValidator.validatePassword(tx, credential.getScopeId(), plainNewPassword);


### PR DESCRIPTION
Currently it is possible to issue a credential reset (`POST {scopeId}/user/credentials/{credentialId}/_reset`) for all types of credentials, converting them to Password Credentials and breaking the "only one password credential per user" rule.
This PR fixes the issue by returning a 422 error when _reset is invoked on a non-password credential.
