### PR TITLE
Fixed Broker communication handling with Broker Service Authentication 

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
@@ -144,7 +144,7 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
         try {
             if (usernameToCompare == null || !usernameToCompare.equals(username) ||
                     passToCompare == null || !passToCompare.equals(password)) {
-                throw new ActiveMQException(ActiveMQExceptionType.SECURITY_EXCEPTION, "User not authorized!");
+                throw new ActiveMQException(ActiveMQExceptionType.SECURITY_EXCEPTION, "User not authorized! Internal connection credential did not match!");
             }
             logger.info("Authenticate internal: user: {} - clientId: {} - connectionIp: {} - connectionId: {} - remoteIP: {} - isOpen: {}",
                     username, connectionInfo.getClientId(), connectionInfo.getClientIp(), remotingConnection.getID(),
@@ -285,7 +285,7 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
     //
     private void validateAuthResponse(AuthResponse authResponse) throws CredentialException, ActiveMQException {
         if (authResponse == null) {
-            throw new ActiveMQException(ActiveMQExceptionType.SECURITY_EXCEPTION, "User not authorized!");
+            throw new ActiveMQException(ActiveMQExceptionType.SECURITY_EXCEPTION, "User not authorized! Authentication response is empty!");
         } else if (authResponse.getErrorCode() != null) {
             //analyze response code
             String errorCode = authResponse.getErrorCode();
@@ -302,11 +302,11 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
                 logger.warn("User {} not authorized ({})", authResponse.getUsername(), errorCode);
                 //TODO check if it's still valid with Artemis
                 // activeMQ-MQ will map SecurityException into a CONNECTION_REFUSED_NOT_AUTHORIZED message (see javadoc on top of this method)
-                throw new SecurityException("User not authorized!");
+                throw new SecurityException("User not authorized! Credentials provided are either locked, disabled or expired");
             } else {
                 //KapuaAuthenticationErrorCodes.AUTHENTICATION_ERROR - ILLEGAL_ACCESS etc
                 //TODO throw other exception?
-                throw new SecurityException("User not authorized!");
+                throw new SecurityException("User not authorized! Error returned from the Broker Authentication Service: " + errorCode);
             }
         }
     }
@@ -376,7 +376,7 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
         if (accountResponse != null) {
             return new AccountInfo(KapuaEid.parseCompactId(accountResponse.getId()), accountResponse.getName());
         }
-        throw new SecurityException("User not authorized!");
+        throw new SecurityException("User not authorized! Cannot get Admin Account info!");
     }
 
     /**
@@ -400,7 +400,7 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
         if (userResponse != null && userResponse.getScopeId() != null) {
             return KapuaEid.parseCompactId(userResponse.getScopeId());
         }
-        throw new SecurityException("User not authorized!");
+        throw new SecurityException("User not authorized! Cannot get scopeId for username:" + username);
     }
 
 }

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/MessageListener.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/MessageListener.java
@@ -38,7 +38,7 @@ public class MessageListener extends ClientMessageListener {
 
     protected static Logger logger = LoggerFactory.getLogger(MessageListener.class);
 
-    private final Map<String, ResponseContainer<?>> callbacks = new ConcurrentHashMap<>();//is not needed the synchronization
+    private static final Map<String, ResponseContainer<?>> CALLBACKS = new ConcurrentHashMap<>();//is not needed the synchronization
     private static ObjectMapper mapper = new ObjectMapper();
     private static ObjectReader reader = mapper.reader();//check if it's thread safe
 
@@ -73,7 +73,7 @@ public class MessageListener extends ClientMessageListener {
     }
 
     private <R extends Response> void updateResponseContainer(R response) throws JMSException, IOException {
-        ResponseContainer<R> responseContainer = (ResponseContainer<R>) callbacks.get(response.getRequestId());
+        ResponseContainer<R> responseContainer = (ResponseContainer<R>) CALLBACKS.get(response.getRequestId());
         if (responseContainer == null) {
             //internal error
             logger.error("Cannot find request container for requestId {}", response.getRequestId());
@@ -97,11 +97,11 @@ public class MessageListener extends ClientMessageListener {
     }
 
     public void registerCallback(String requestId, ResponseContainer<?> responseContainer) {
-        callbacks.put(requestId, responseContainer);
+        CALLBACKS.put(requestId, responseContainer);
     }
 
     public void removeCallback(String requestId) {
-        callbacks.remove(requestId);
+        CALLBACKS.remove(requestId);
     }
 
 }

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/MessageListener.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/MessageListener.java
@@ -28,12 +28,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+@Singleton
 public class MessageListener extends ClientMessageListener {
 
     protected static Logger logger = LoggerFactory.getLogger(MessageListener.class);

--- a/service/authentication/src/main/java/org/eclipse/kapua/service/authentication/authentication/AuthenticationLogic.java
+++ b/service/authentication/src/main/java/org/eclipse/kapua/service/authentication/authentication/AuthenticationLogic.java
@@ -193,13 +193,13 @@ public abstract class AuthenticationLogic {
                 if (deviceConnection.getReservedUserId() == null) {
                     checkConnectionCountByReservedUserId(scopeId, userId, 0);
                     if (!deviceConnection.getAllowUserChange() && !userId.equals(deviceConnection.getUserId())) {
-                        throw new SecurityException(USER_NOT_AUTHORIZED);
+                        throw new SecurityException(USER_NOT_AUTHORIZED + " DeviceConnection cannot change the user to connect!");
                         // TODO manage the error message. is it better to throw a more specific exception or keep it obfuscated for security reason?
                     }
                 } else {
                     checkConnectionCountByReservedUserId(scopeId, deviceConnection.getReservedUserId(), 1);
                     if (!userId.equals(deviceConnection.getReservedUserId())) {
-                        throw new SecurityException(USER_NOT_AUTHORIZED);
+                        throw new SecurityException(USER_NOT_AUTHORIZED + " DeviceConnection must use the Reserved User assigned to connect!");
                         // TODO manage the error message. is it better to throw a more specific exception or keep it obfuscated for security reason?
                     }
                 }
@@ -230,7 +230,7 @@ public abstract class AuthenticationLogic {
 
         Long connectionCountByReservedUserId = KapuaSecurityUtils.doPrivileged(() -> deviceConnectionOptionService.count(query));
         if (connectionCountByReservedUserId != null && connectionCountByReservedUserId > count) {
-            throw new SecurityException(USER_NOT_AUTHORIZED);
+            throw new SecurityException(USER_NOT_AUTHORIZED + " DeviceConnection cannot use this user because its reserved for another DeviceConnection");
             // TODO manage the error message. is it better to throw a more specific exception or keep it obfuscated for security reason?
         }
     }


### PR DESCRIPTION
This PR fixes a bug in the handling of communications with the Broker Authentication Service which was causing issues when performing login operations

**Related Issue**
_None_

**Description of the solution adopted**
Reverted back a change which was preventing correct tracking of callbacks between Message Broker and Broker Service Authentication

**Screenshots**
_None_

**Any side note on the changes made**
Improved log messages in case of errors