### PR TITLE
Fix/avoid nested locators

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
@@ -47,12 +47,18 @@ public abstract class KapuaLocator implements KapuaServiceLoader {
 
     // TODO do we need synchronization?
 
+    private static boolean isBeingCreated;
+
     /**
      * Creates the {@link KapuaLocator} instance,
      *
      * @return
      */
     private static KapuaLocator createInstance() {
+        if (isBeingCreated) {
+            throw new RuntimeException("Already creating a KapuaLocator, avoid nested creation");
+        }
+        isBeingCreated = true;
         try {
             logger.info("initializing Servicelocator instance... ");
             String locatorImplementation = locatorClassName();
@@ -97,6 +103,7 @@ public abstract class KapuaLocator implements KapuaServiceLoader {
     }
 
     public static void clearInstance() {
+        isBeingCreated = false;
         instance = createInstance();
     }
 


### PR DESCRIPTION
Safeguard to avoid nested creation of KapuaLocator singletons.
Without this patch, if a class instantiated within Guice's startup (part of a Module of being automatically instantiated by virtue of having a parameterless public constructor, or one annotated via @Inject) AND it referenced KapuaLocator.getInstance() in the constructor code (or in STATIC assignments), this resulted in a nested creation of a KapuaLocator instance, with duplicate objects in memory, and potential for race conditions (in case, for example, a queue consumer was instantiated).

**Description of the solution adopted**
This patch makes sure no nested instantiations are possible, failing at startup time instead of creating nested contexts.