### PR TITLE
Improve/cleanup forwardable entities

### DIFF
--- a/assembly/broker-artemis/descriptors/kapua-broker-artemis.xml
+++ b/assembly/broker-artemis/descriptors/kapua-broker-artemis.xml
@@ -130,6 +130,8 @@
                 <include>${pom.groupId}:kapua-openid-api</include>
                 <include>${pom.groupId}:kapua-openid-provider</include>
                 <include>${pom.groupId}:kapua-service-api</include>
+                <include>${pom.groupId}:kapua-service-commons-utils-api</include>
+                <include>${pom.groupId}:kapua-service-commons-utils-internal</include>
                 <include>${pom.groupId}:kapua-security-authentication-api</include>
                 <include>${pom.groupId}:kapua-security-authorization-api</include>
                 <include>${pom.groupId}:kapua-security-certificate-api</include>

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableResourceLimitedService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableResourceLimitedService.java
@@ -71,7 +71,7 @@ public abstract class AbstractKapuaConfigurableResourceLimitedService<
 
 
     //TODO: make final as soon as deprecated constructors are removed
-    private AccountChildrenFinder accountChildrenFinder;
+    private AccountRelativeFinder accountRelativeFinder;
     private F factory;
     //TODO: remove as soon as deprecated constructors are removed
     private final Class<F> factoryClass;
@@ -109,7 +109,7 @@ public abstract class AbstractKapuaConfigurableResourceLimitedService<
      * @param entityManagerFactory The {@link EntityManagerFactory} that handles persistence unit
      * @param abstractCacheFactory The {@link CacheFactory} that handles caching of the entities
      * @since 1.2.0
-     * @deprecated Since 2.0.0. Please use {@link #AbstractKapuaConfigurableResourceLimitedService(String, Domain, EntityManagerFactory, EntityCacheFactory, KapuaEntityFactory, PermissionFactory, AuthorizationService, AccountChildrenFinder, RootUserTester)} This constructor may be removed in a next release
+     * @deprecated Since 2.0.0. Please use {@link #AbstractKapuaConfigurableResourceLimitedService(String, Domain, EntityManagerFactory, EntityCacheFactory, KapuaEntityFactory, PermissionFactory, AuthorizationService, AccountRelativeFinder, RootUserTester)} This constructor may be removed in a next release
      */
     @Deprecated
     protected AbstractKapuaConfigurableResourceLimitedService(
@@ -127,7 +127,7 @@ public abstract class AbstractKapuaConfigurableResourceLimitedService<
         */
         this.factoryClass = factoryClass;
         this.factory = null;
-        this.accountChildrenFinder = null;
+        this.accountRelativeFinder = null;
     }
 
     /**
@@ -149,12 +149,12 @@ public abstract class AbstractKapuaConfigurableResourceLimitedService<
                                                               F factory,
                                                               PermissionFactory permissionFactory,
                                                               AuthorizationService authorizationService,
-                                                              AccountChildrenFinder accountChildrenFinder,
+                                                              AccountRelativeFinder accountRelativeFinder,
                                                               RootUserTester rootUserTester) {
         super(pid, domain, entityManagerFactory, abstractCacheFactory, permissionFactory, authorizationService, rootUserTester);
         this.factory = factory;
         this.factoryClass = null; //TODO: not needed for this construction path, remove as soon as the deprecated constructor is removed
-        this.accountChildrenFinder = accountChildrenFinder;
+        this.accountRelativeFinder = accountRelativeFinder;
     }
 
     @Override
@@ -244,7 +244,7 @@ public abstract class AbstractKapuaConfigurableResourceLimitedService<
             // Current used entities
             long currentUsedEntities = this.count(countQuery);
 
-            final KapuaListResult<Account> childAccounts = txManager.execute(tx -> getAccountChildrenFinder().findChildren(scopeId, Optional.ofNullable(targetScopeId)));
+            final KapuaListResult<Account> childAccounts = txManager.execute(tx -> getAccountRelativeFinder().findChildren(scopeId, Optional.ofNullable(targetScopeId)));
             // Resources assigned to children
             long childCount = 0;
             for (Account childAccount : childAccounts.getItems()) {
@@ -285,14 +285,14 @@ public abstract class AbstractKapuaConfigurableResourceLimitedService<
      * This instance should be provided by the Locator, but in most cases when this class is instantiated through the deprecated constructor the Locator is not yet ready,
      * therefore fetching of the required instance is demanded to this artificial getter.
      *
-     * @return The instantiated (hopefully) {@link AccountChildrenFinder} instance
+     * @return The instantiated (hopefully) {@link AccountRelativeFinder} instance
      */
-    private AccountChildrenFinder getAccountChildrenFinder() {
-        if (accountChildrenFinder == null) {
+    private AccountRelativeFinder getAccountRelativeFinder() {
+        if (accountRelativeFinder == null) {
             KapuaLocator locator = KapuaLocator.getInstance();
-            this.accountChildrenFinder = locator.getService(AccountChildrenFinder.class);
+            this.accountRelativeFinder = locator.getService(AccountRelativeFinder.class);
         }
 
-        return accountChildrenFinder;
+        return accountRelativeFinder;
     }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AccountRelativeFinder.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AccountRelativeFinder.java
@@ -17,14 +17,15 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.account.AccountListResult;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
- * Service to retrieve all child accounts for a given scope
+ * Service to retrieve relative accounts for a given scope
  *
  * @since 2.0.0
  */
-public interface AccountChildrenFinder extends KapuaService {
+public interface AccountRelativeFinder extends KapuaService {
 
     /**
      * @param scopeId       The scope id - must be provided
@@ -33,4 +34,11 @@ public interface AccountChildrenFinder extends KapuaService {
      * @throws KapuaException
      */
     AccountListResult findChildren(KapuaId scopeId, Optional<KapuaId> targetScopeId) throws KapuaException;
+
+    /**
+     * @param accountId    The id of the account to lookup
+     * @return             The list of parent ids for the target account
+     * @throws KapuaException
+     */
+    List<KapuaId> findParentIds(KapuaId accountId) throws KapuaException;
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ResourceLimitedServiceConfigurationManagerImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ResourceLimitedServiceConfigurationManagerImpl.java
@@ -32,17 +32,17 @@ public class ResourceLimitedServiceConfigurationManagerImpl
         extends ServiceConfigurationManagerImpl
         implements ServiceConfigurationManager {
 
-    private final AccountChildrenFinder accountChildrenFinder;
+    private final AccountRelativeFinder accountRelativeFinder;
     private final UsedEntitiesCounter usedEntitiesCounter;
 
     public ResourceLimitedServiceConfigurationManagerImpl(
             String pid,
             ServiceConfigRepository serviceConfigRepository,
             RootUserTester rootUserTester,
-            AccountChildrenFinder accountChildrenFinder,
+            AccountRelativeFinder accountRelativeFinder,
             UsedEntitiesCounter usedEntitiesCounter) {
         super(pid, serviceConfigRepository, rootUserTester);
-        this.accountChildrenFinder = accountChildrenFinder;
+        this.accountRelativeFinder = accountRelativeFinder;
         this.usedEntitiesCounter = usedEntitiesCounter;
     }
 
@@ -135,7 +135,7 @@ public class ResourceLimitedServiceConfigurationManagerImpl
             // Current used entities
             long currentUsedEntities = usedEntitiesCounter.countEntitiesInScope(txContext, scopeId);
 
-            final AccountListResult childAccounts = accountChildrenFinder.findChildren(scopeId, targetScopeId);
+            final AccountListResult childAccounts = accountRelativeFinder.findChildren(scopeId, targetScopeId);
             // Resources assigned to children
             long childCount = 0;
             for (Account childAccount : childAccounts.getItems()) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaForwardableEntityQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaForwardableEntityQuery.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.model.query;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
+import org.eclipse.kapua.model.query.KapuaQuery;
+
+public class AbstractKapuaForwardableEntityQuery extends AbstractKapuaNamedQuery implements KapuaForwardableEntityQuery {
+
+    protected Boolean includeInherited = Boolean.FALSE;
+
+    /**
+     * Constructor.
+     *
+     */
+    public AbstractKapuaForwardableEntityQuery() {
+        super();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     */
+    public AbstractKapuaForwardableEntityQuery(KapuaId scopeId) {
+        super(scopeId);
+    }
+
+    /**
+     * Clone constructor.
+     *
+     * @param query The {@link AbstractKapuaForwardableEntityQuery} to clone.
+     */
+    public AbstractKapuaForwardableEntityQuery(KapuaQuery query) {
+        super(query);
+        if(query instanceof KapuaForwardableEntityQuery) {
+            this.includeInherited = ((KapuaForwardableEntityQuery) query).getIncludeInherited();
+        }
+    }
+
+    @Override
+    public Boolean getIncludeInherited() {
+        return includeInherited;
+    }
+
+    @Override
+    public void setIncludeInherited(Boolean includeInherited) {
+        this.includeInherited = includeInherited;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1014,6 +1014,16 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-service-commons-utils-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-service-commons-utils-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-service-elasticsearch-client-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1030,6 +1040,16 @@
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-service-storable-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-service-utils-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-service-utils-internal</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountModule.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountModule.java
@@ -15,7 +15,7 @@ package org.eclipse.kapua.service.account.internal;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.multibindings.ProvidesIntoSet;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.CachingServiceConfigRepository;
 import org.eclipse.kapua.commons.configuration.ResourceLimitedServiceConfigurationManagerImpl;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
@@ -71,10 +71,10 @@ public class AccountModule extends AbstractKapuaModule implements Module {
 
     @Provides
     @Singleton
-    AccountChildrenFinder accountChildrenFinder(
+    AccountRelativeFinder accountRelativeFinder(
             AccountFactory accountFactory,
             AccountService accountService) {
-        return new AccountChildrenFinderImpl(
+        return new AccountRelativeFinderImpl(
                 accountFactory,
                 accountService);
     }
@@ -132,7 +132,7 @@ public class AccountModule extends AbstractKapuaModule implements Module {
     ServiceConfigurationManager accountServiceConfigurationManager(
             AccountFactory factory,
             RootUserTester rootUserTester,
-            AccountChildrenFinder accountChildrenFinder,
+            AccountRelativeFinder accountRelativeFinder,
             AccountRepository accountRepository,
             KapuaJpaRepositoryConfiguration jpaRepoConfig,
             EntityCacheFactory entityCacheFactory
@@ -145,7 +145,7 @@ public class AccountModule extends AbstractKapuaModule implements Module {
                                 entityCacheFactory.createCache("AbstractKapuaConfigurableServiceCacheId")
                         ),
                         rootUserTester,
-                        accountChildrenFinder,
+                        accountRelativeFinder,
                         new UsedEntitiesCounterImpl(
                                 factory,
                                 accountRepository)

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountRelativeFinderImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountRelativeFinderImpl.java
@@ -12,28 +12,35 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account.internal;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountFactory;
 import org.eclipse.kapua.service.account.AccountListResult;
 import org.eclipse.kapua.service.account.AccountQuery;
 import org.eclipse.kapua.service.account.AccountService;
 
-import javax.inject.Inject;
-import java.util.Optional;
-
-public class AccountChildrenFinderImpl implements AccountChildrenFinder, KapuaService {
+public class AccountRelativeFinderImpl implements AccountRelativeFinder, KapuaService {
 
     private final AccountFactory accountFactory;
     private final AccountService accountService;
 
     @Inject
-    public AccountChildrenFinderImpl(AccountFactory accountFactory, AccountService accountService) {
+    public AccountRelativeFinderImpl(AccountFactory accountFactory, AccountService accountService) {
         this.accountFactory = accountFactory;
         this.accountService = accountService;
     }
@@ -52,5 +59,31 @@ public class AccountChildrenFinderImpl implements AccountChildrenFinder, KapuaSe
         }
 
         return KapuaSecurityUtils.doPrivileged(() -> accountService.query(childAccountsQuery));
+    }
+
+    @Override
+    public List<KapuaId> findParentIds(KapuaId accountId) throws KapuaException {
+        Account account = KapuaSecurityUtils.doPrivileged(() -> accountService.find(accountId));
+
+        if(account == null || account.getParentAccountPath() == null) {
+            return Collections.emptyList();
+        }
+
+        ArrayList<KapuaId> parentAccountIds = new ArrayList<KapuaId>();
+
+        String[] splitIds = account.getParentAccountPath().split("/");
+        String accountIdStr = accountId.getId().toString();
+
+        // Iterate in reverse order to get parent first, then grandparent, etc
+        for(int i = splitIds.length - 1; i >= 0; i--) {
+            String id = splitIds[i];
+            if(id == null || id.isEmpty() || id.equals(accountIdStr)) {
+                // skip
+            } else {
+                parentAccountIds.add(new KapuaEid(new BigInteger(id)));
+            }
+        }
+
+        return parentAccountIds;
     }
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountRelativeFinderImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountRelativeFinderImpl.java
@@ -77,9 +77,8 @@ public class AccountRelativeFinderImpl implements AccountRelativeFinder, KapuaSe
         // Iterate in reverse order to get parent first, then grandparent, etc
         for(int i = splitIds.length - 1; i >= 0; i--) {
             String id = splitIds[i];
-            if(id == null || id.isEmpty() || id.equals(accountIdStr)) {
-                // skip
-            } else {
+
+            if(id != null && !id.isEmpty() && !id.equals(accountIdStr)) {
                 parentAccountIds.add(new KapuaEid(new BigInteger(id)));
             }
         }

--- a/service/account/test/src/test/java/org/eclipse/kapua/service/account/test/AccountLocatorConfiguration.java
+++ b/service/account/test/src/test/java/org/eclipse/kapua/service/account/test/AccountLocatorConfiguration.java
@@ -20,7 +20,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import io.cucumber.java.Before;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.ResourceLimitedServiceConfigurationManagerImpl;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
 import org.eclipse.kapua.commons.configuration.ServiceConfigImplJpaRepository;
@@ -109,7 +109,7 @@ public class AccountLocatorConfiguration {
 //                bind(AccountEntityManagerFactory.class).toInstance(entityManagerFactory);
                 final AccountFactory accountFactory = new AccountFactoryImpl();
                 bind(AccountFactory.class).toInstance(accountFactory);
-                bind(AccountChildrenFinder.class).toInstance(Mockito.mock(AccountChildrenFinder.class));
+                bind(AccountRelativeFinder.class).toInstance(Mockito.mock(AccountRelativeFinder.class));
                 final KapuaJpaRepositoryConfiguration jpaRepoConfig = new KapuaJpaRepositoryConfiguration();
                 final AccountRepository accountRepository = new AccountImplJpaRepository(jpaRepoConfig);
                 bind(AccountService.class).toInstance(new AccountServiceImpl(
@@ -121,7 +121,7 @@ public class AccountLocatorConfiguration {
                                 AccountService.class.getName(),
                                 new ServiceConfigImplJpaRepository(jpaRepoConfig),
                                 Mockito.mock(RootUserTester.class),
-                                Mockito.mock(AccountChildrenFinder.class),
+                                Mockito.mock(AccountRelativeFinder.class),
                                 new UsedEntitiesCounterImpl(
                                         accountFactory,
                                         accountRepository)

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaForwardableEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaForwardableEntity.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model;
+
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * {@link KapuaForwardableEntity} definition.
+ *
+ * @since 2.0.0
+ */
+public interface KapuaForwardableEntity extends KapuaNamedEntity {
+
+    @XmlElement(name = "forwardable")
+    Boolean getForwardable();
+
+    void setForwardable(Boolean forwardable);
+}

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaForwardableEntityAttributes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaForwardableEntityAttributes.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model;
+
+/**
+ * {@link KapuaForwardableEntityAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 2.0.0
+ */
+public class KapuaForwardableEntityAttributes extends KapuaNamedEntityAttributes {
+
+    public static final String FORWARDABLE = "forwardable";
+}

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaForwardableEntityQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaForwardableEntityQuery.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model.query;
+
+import javax.xml.bind.annotation.XmlElement;
+
+public interface KapuaForwardableEntityQuery extends KapuaQuery {
+    /**
+     * Gets whether to query for inherited entities
+     *
+     * @return {@code true} if set to query for inherited entities, {@code false} otherwise.
+     * @since 2.0.0
+     */
+    @XmlElement(name = "includeInherited")
+    Boolean getIncludeInherited();
+
+    /**
+     * Sets whether to query for inherited entities
+     *
+     * @param includeInherited {@code true} to query for inherited entities, {@code false} otherwise.
+     * @since 2.0.0
+     */
+    void setIncludeInherited(Boolean includeInherited);
+
+}

--- a/service/commons/utils/api/pom.xml
+++ b/service/commons/utils/api/pom.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -11,31 +11,25 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>kapua-security-certificate</artifactId>
+        <artifactId>kapua-service-commons-utils</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>kapua-security-certificate-internal</artifactId>
+    <artifactId>kapua-service-commons-utils-api</artifactId>
 
     <dependencies>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-security-certificate-api</artifactId>
-        </dependency>
+        <!-- Internal Dependencies-->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-commons</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-service-commons-utils-api</artifactId>
-        </dependency>
     </dependencies>
+
 </project>

--- a/service/commons/utils/api/src/main/java/org/eclipse/kapua/service/utils/KapuaEntityQueryUtil.java
+++ b/service/commons/utils/api/src/main/java/org/eclipse/kapua/service/utils/KapuaEntityQueryUtil.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.utils;
+
+import javax.validation.constraints.NotNull;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.KapuaService;
+
+/**
+ * Service to help process/transform queries
+ *
+ * @since 2.0.0
+ */
+public interface KapuaEntityQueryUtil extends KapuaService {
+
+    /**
+     * Transform the specified query for the {@link KapuaForwardableEntityQuery} getIncludeInherited() option (i.e.
+     * to also query the parent accounts).
+     * 
+     * @param query
+     * @return
+     * @throws KapuaException
+     */
+    public KapuaQuery transformInheritedQuery(@NotNull KapuaForwardableEntityQuery query) throws KapuaException;
+}

--- a/service/commons/utils/api/src/main/java/org/eclipse/kapua/service/utils/KapuaForwardableEntityRepository.java
+++ b/service/commons/utils/api/src/main/java/org/eclipse/kapua/service/utils/KapuaForwardableEntityRepository.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.utils;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.KapuaForwardableEntity;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.storage.KapuaEntityRepository;
+import org.eclipse.kapua.storage.KapuaNamedEntityRepository;
+import org.eclipse.kapua.storage.KapuaUpdatableEntityRepository;
+import org.eclipse.kapua.storage.TxContext;
+
+/**
+ * This contract builds upon {@link KapuaUpdatableEntityRepository} (and in turn {@link KapuaEntityRepository},
+ * adding functionalities specific to Kapua Entities that are implement the contract {@link KapuaNamedEntity} (as in: have a name and description fields)
+ *
+ * @param <E> The specific subclass of {@link KapuaEntity} handled by this repository
+ * @param <L> The specific subclass of {@link KapuaListResult}&lt;E&gt; meant to hold list results for the kapua entity handled by this repo
+ * @since 2.0.0
+ */
+public interface KapuaForwardableEntityRepository<E extends KapuaForwardableEntity, L extends KapuaListResult<E>>
+        extends KapuaNamedEntityRepository<E, L> {
+    L query(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException;
+
+    long count(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException;
+
+}

--- a/service/commons/utils/internal/pom.xml
+++ b/service/commons/utils/internal/pom.xml
@@ -28,7 +28,7 @@
         <!-- Implemented Interface-->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-service-utils-api</artifactId>
+            <artifactId>kapua-service-commons-utils-api</artifactId>
         </dependency>
 
         <!-- Internal Dependencies-->

--- a/service/commons/utils/internal/pom.xml
+++ b/service/commons/utils/internal/pom.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -11,31 +11,31 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>kapua-security-certificate</artifactId>
+        <artifactId>kapua-service-commons-utils</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>kapua-security-certificate-internal</artifactId>
+    <artifactId>kapua-service-commons-utils-internal</artifactId>
 
     <dependencies>
+        <!-- Implemented Interface-->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-security-certificate-api</artifactId>
+            <artifactId>kapua-service-utils-api</artifactId>
         </dependency>
+
+        <!-- Internal Dependencies-->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-commons</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-service-commons-utils-api</artifactId>
-        </dependency>
     </dependencies>
+
 </project>

--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaEntityQueryUtilImpl.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaEntityQueryUtilImpl.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.utils.internal;
+
+import javax.validation.constraints.NotNull;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
+import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.KapuaForwardableEntityAttributes;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.model.query.predicate.OrPredicate;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
+
+/**
+ * Base {@code interface} for all {@link KapuaService}s that are managing {@link KapuaNamedEntity}es.
+ *
+ * @param <E> Type of the {@link KapuaNamedEntity} being managed.
+ * @since 1.0.0
+ */
+public class KapuaEntityQueryUtilImpl implements KapuaEntityQueryUtil {
+
+    private final AccountRelativeFinder accountRelativeFinder;
+
+    public KapuaEntityQueryUtilImpl(AccountRelativeFinder accountRelativeFinder) {
+        this.accountRelativeFinder = accountRelativeFinder;
+    }
+
+    @Override
+    public KapuaQuery transformInheritedQuery(@NotNull KapuaForwardableEntityQuery query) throws KapuaException {
+        // Transform only if this option is enabled
+        if(!query.getIncludeInherited()) {
+            return query;
+        }
+
+        KapuaId scopeId = query.getScopeId();
+
+        // Replacement predicate root
+        AndPredicate newPred = query.andPredicate(query.getPredicate());
+
+        // Create predicate to query ancestor accounts for entities that are forwardable
+        query.setScopeId(KapuaId.ANY);
+        OrPredicate forwardableAncestorPreds = query.orPredicate();
+
+        for(KapuaId id : accountRelativeFinder.findParentIds(scopeId)) {
+            AndPredicate scopedForwardablePred = query.andPredicate(query.attributePredicate(KapuaEntityAttributes.SCOPE_ID, id));
+            scopedForwardablePred = scopedForwardablePred.and(query.attributePredicate(KapuaForwardableEntityAttributes.FORWARDABLE, true));
+
+            forwardableAncestorPreds = forwardableAncestorPreds.or(scopedForwardablePred);
+        }
+        // include the original scope (which doesn't need to be forwardable)
+        forwardableAncestorPreds = forwardableAncestorPreds.or(query.attributePredicate(KapuaEntityAttributes.SCOPE_ID, scopeId));
+
+        // Use the original query predicate AND the forwardable parent scopes
+        query.setPredicate(newPred.and(forwardableAncestorPreds));
+
+        // Disable this option so that it does not get transformed again in case of subsequent calls to this function
+        query.setIncludeInherited(false);
+
+        return query;
+    }
+}

--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaEntityQueryUtilImpl.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaEntityQueryUtilImpl.java
@@ -12,31 +12,30 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.utils.internal;
 
-import javax.validation.constraints.NotNull;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.KapuaForwardableEntityAttributes;
-import org.eclipse.kapua.model.KapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.model.query.predicate.OrPredicate;
-import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+
 /**
- * Base {@code interface} for all {@link KapuaService}s that are managing {@link KapuaNamedEntity}es.
+ * Implementation of converter between {@link KapuaForwardableEntityQuery} and {@link KapuaQuery}
  *
- * @param <E> Type of the {@link KapuaNamedEntity} being managed.
- * @since 1.0.0
+ * @since 2.0.0
  */
 public class KapuaEntityQueryUtilImpl implements KapuaEntityQueryUtil {
 
     private final AccountRelativeFinder accountRelativeFinder;
 
+    @Inject
     public KapuaEntityQueryUtilImpl(AccountRelativeFinder accountRelativeFinder) {
         this.accountRelativeFinder = accountRelativeFinder;
     }
@@ -44,7 +43,7 @@ public class KapuaEntityQueryUtilImpl implements KapuaEntityQueryUtil {
     @Override
     public KapuaQuery transformInheritedQuery(@NotNull KapuaForwardableEntityQuery query) throws KapuaException {
         // Transform only if this option is enabled
-        if(!query.getIncludeInherited()) {
+        if (!query.getIncludeInherited()) {
             return query;
         }
 
@@ -57,7 +56,7 @@ public class KapuaEntityQueryUtilImpl implements KapuaEntityQueryUtil {
         query.setScopeId(KapuaId.ANY);
         OrPredicate forwardableAncestorPreds = query.orPredicate();
 
-        for(KapuaId id : accountRelativeFinder.findParentIds(scopeId)) {
+        for (KapuaId id : accountRelativeFinder.findParentIds(scopeId)) {
             AndPredicate scopedForwardablePred = query.andPredicate(query.attributePredicate(KapuaEntityAttributes.SCOPE_ID, id));
             scopedForwardablePred = scopedForwardablePred.and(query.attributePredicate(KapuaForwardableEntityAttributes.FORWARDABLE, true));
 

--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaForwardableEntityJpaRepository.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaForwardableEntityJpaRepository.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.utils.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
+import org.eclipse.kapua.commons.jpa.KapuaNamedEntityJpaRepository;
+import org.eclipse.kapua.model.KapuaForwardableEntity;
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
+import org.eclipse.kapua.service.utils.KapuaForwardableEntityRepository;
+import org.eclipse.kapua.storage.TxContext;
+
+import java.util.function.Supplier;
+
+public class KapuaForwardableEntityJpaRepository<E extends KapuaForwardableEntity, C extends E, L extends KapuaListResult<E>>
+        extends KapuaNamedEntityJpaRepository<E, C, L>
+        implements KapuaForwardableEntityRepository<E, L> {
+    private final KapuaEntityQueryUtil kapuaEntityQueryUtil;
+
+    public KapuaForwardableEntityJpaRepository(
+            Class<C> concreteClass,
+            String entityName,
+            Supplier<L> listSupplier,
+            KapuaJpaRepositoryConfiguration jpaRepoConfig,
+            KapuaEntityQueryUtil kapuaEntityQueryUtil) {
+        super(concreteClass, entityName, listSupplier, jpaRepoConfig);
+        this.kapuaEntityQueryUtil = kapuaEntityQueryUtil;
+    }
+
+    @Override
+    public L query(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException {
+        return doQuery(txContext, kapuaQuery);
+    }
+
+    @Override
+    public L query(TxContext txContext, KapuaQuery listQuery) throws KapuaException {
+        // Transform the query for the includeInherited option
+        return (listQuery instanceof KapuaForwardableEntityQuery)
+                ? this.doQuery(txContext, (KapuaForwardableEntityQuery) listQuery) : super.query(txContext, listQuery);
+    }
+
+    private L doQuery(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException {
+        final KapuaQuery query = kapuaEntityQueryUtil.transformInheritedQuery(kapuaQuery);
+        return super.query(txContext, query);
+    }
+
+    @Override
+    public long count(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException {
+        return doCount(txContext, kapuaQuery);
+    }
+
+    @Override
+    public long count(TxContext txContext, KapuaQuery countQuery) throws KapuaException {
+        // Transform the query for the includeInherited option
+        return (countQuery instanceof KapuaForwardableEntityQuery)
+                ? this.count(txContext, (KapuaForwardableEntityQuery) countQuery) : super.count(txContext, countQuery);
+    }
+
+    private long doCount(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException {
+        final KapuaQuery query = kapuaEntityQueryUtil.transformInheritedQuery(kapuaQuery);
+        return super.count(txContext, query);
+    }
+}

--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaServiceUtilsModule.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaServiceUtilsModule.java
@@ -12,25 +12,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.utils.internal;
 
-import javax.inject.Singleton;
-
-import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
-import com.google.inject.Provides;
+import javax.inject.Singleton;
 
 public class KapuaServiceUtilsModule extends AbstractKapuaModule {
 
     @Override
     protected void configureModule() {
+        bind(KapuaEntityQueryUtil.class).to(KapuaEntityQueryUtilImpl.class).in(Singleton.class);
         // nothing to do here
     }
-
-    @Provides
-    @Singleton
-    KapuaEntityQueryUtil kapuaEntityQueryUtil(AccountRelativeFinder accountRelativeFinder) {
-        return new KapuaEntityQueryUtilImpl(accountRelativeFinder);
-    }
-
 }

--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaServiceUtilsModule.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaServiceUtilsModule.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.utils.internal;
+
+import javax.inject.Singleton;
+
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
+
+import com.google.inject.Provides;
+
+public class KapuaServiceUtilsModule extends AbstractKapuaModule {
+
+    @Override
+    protected void configureModule() {
+        // nothing to do here
+    }
+
+    @Provides
+    @Singleton
+    KapuaEntityQueryUtil kapuaEntityQueryUtil(AccountRelativeFinder accountRelativeFinder) {
+        return new KapuaEntityQueryUtilImpl(accountRelativeFinder);
+    }
+
+}

--- a/service/commons/utils/pom.xml
+++ b/service/commons/utils/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -17,17 +17,17 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>kapua-service</artifactId>
+        <artifactId>kapua-service-commons</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>kapua-service-commons</artifactId>
+    <artifactId>kapua-service-commons-utils</artifactId>
     <packaging>pom</packaging>
 
     <modules>
-        <module>elasticsearch</module>
-        <module>storable</module>
-        <module>utils</module>
+        <module>api</module>
+        <module>internal</module>
     </modules>
+
 </project>

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.device.registry;
 
 import com.google.inject.Provides;
 import com.google.inject.multibindings.ProvidesIntoSet;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.CachingServiceConfigRepository;
 import org.eclipse.kapua.commons.configuration.ResourceLimitedServiceConfigurationManagerImpl;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
@@ -226,7 +226,7 @@ public class DeviceRegistryModule extends AbstractKapuaModule {
     protected ServiceConfigurationManager deviceRegistryServiceConfigurationManager(
             DeviceFactory factory,
             RootUserTester rootUserTester,
-            AccountChildrenFinder accountChildrenFinder,
+            AccountRelativeFinder accountRelativeFinder,
             DeviceRepository deviceRepository,
             KapuaJpaRepositoryConfiguration jpaRepoConfig,
             EntityCacheFactory entityCacheFactory
@@ -239,7 +239,7 @@ public class DeviceRegistryModule extends AbstractKapuaModule {
                                 entityCacheFactory.createCache("AbstractKapuaConfigurableServiceCacheId")
                         ),
                         rootUserTester,
-                        accountChildrenFinder,
+                        accountRelativeFinder,
                         new UsedEntitiesCounterImpl(
                                 factory,
                                 deviceRepository)

--- a/service/device/registry/test/src/test/java/org/eclipse/kapua/service/device/registry/test/DeviceRegistryLocatorConfiguration.java
+++ b/service/device/registry/test/src/test/java/org/eclipse/kapua/service/device/registry/test/DeviceRegistryLocatorConfiguration.java
@@ -20,7 +20,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import io.cucumber.java.Before;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
@@ -128,7 +128,7 @@ public class DeviceRegistryLocatorConfiguration {
                 bind(AuthorizationService.class).toInstance(mockedAuthorization);
                 bind(CredentialsFactory.class).toInstance(credentialsFactory);
                 bind(KapuaJpaRepositoryConfiguration.class).toInstance(new KapuaJpaRepositoryConfiguration());
-                bind(AccountChildrenFinder.class).toInstance(Mockito.mock(AccountChildrenFinder.class));
+                bind(AccountRelativeFinder.class).toInstance(Mockito.mock(AccountRelativeFinder.class));
                 bind(AccountFactory.class).toInstance(Mockito.mock(AccountFactory.class));
                 bind(AccountService.class).toInstance(Mockito.mock(AccountService.class));
 

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobModule.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobModule.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.job.internal;
 
 import com.google.inject.Provides;
 import com.google.inject.multibindings.ProvidesIntoSet;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.CachingServiceConfigRepository;
 import org.eclipse.kapua.commons.configuration.ResourceLimitedServiceConfigurationManagerImpl;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
@@ -80,7 +80,7 @@ public class JobModule extends AbstractKapuaModule {
     public ServiceConfigurationManager jobServiceConfigurationManager(
             JobFactory factory,
             RootUserTester rootUserTester,
-            AccountChildrenFinder accountChildrenFinder,
+            AccountRelativeFinder accountRelativeFinder,
             JobRepository jobRepository,
             KapuaJpaRepositoryConfiguration jpaRepoConfig,
             EntityCacheFactory entityCacheFactory
@@ -93,7 +93,7 @@ public class JobModule extends AbstractKapuaModule {
                                 entityCacheFactory.createCache("AbstractKapuaConfigurableServiceCacheId")
                         ),
                         rootUserTester,
-                        accountChildrenFinder,
+                        accountRelativeFinder,
                         new UsedEntitiesCounterImpl(
                                 factory,
                                 jobRepository

--- a/service/job/test/src/test/java/org/eclipse/kapua/service/job/test/JobLocatorConfiguration.java
+++ b/service/job/test/src/test/java/org/eclipse/kapua/service/job/test/JobLocatorConfiguration.java
@@ -19,7 +19,7 @@ import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import io.cucumber.java.Before;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
@@ -121,7 +121,7 @@ public class JobLocatorConfiguration {
                 bind(QueryFactory.class).toInstance(new QueryFactoryImpl());
 
                 // Account
-                bind(AccountChildrenFinder.class).toInstance(Mockito.mock(AccountChildrenFinder.class));
+                bind(AccountRelativeFinder.class).toInstance(Mockito.mock(AccountRelativeFinder.class));
                 bind(AccountService.class).toInstance(Mockito.mock(AccountService.class));
                 bind(AccountFactory.class).toInstance(Mockito.spy(new AccountFactoryImpl()));
                 bind(KapuaJpaRepositoryConfiguration.class).toInstance(new KapuaJpaRepositoryConfiguration());

--- a/service/scheduler/test/src/test/java/org/eclipse/kapua/service/scheduler/test/SchedulerLocatorConfiguration.java
+++ b/service/scheduler/test/src/test/java/org/eclipse/kapua/service/scheduler/test/SchedulerLocatorConfiguration.java
@@ -20,7 +20,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import io.cucumber.java.Before;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
@@ -110,7 +110,7 @@ public class SchedulerLocatorConfiguration {
                 bind(KapuaMetatypeFactory.class).toInstance(new KapuaMetatypeFactoryImpl());
 
                 // binding Account related services
-                bind(AccountChildrenFinder.class).toInstance(Mockito.mock(AccountChildrenFinder.class));
+                bind(AccountRelativeFinder.class).toInstance(Mockito.mock(AccountRelativeFinder.class));
                 bind(AccountService.class).toInstance(Mockito.mock(AccountService.class));
                 bind(AccountFactory.class).toInstance(Mockito.spy(new AccountFactoryImpl()));
                 bind(RootUserTester.class).toInstance(Mockito.mock(RootUserTester.class));

--- a/service/security/certificate/api/pom.xml
+++ b/service/security/certificate/api/pom.xml
@@ -36,6 +36,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-commons-utils-api</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate;
 
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
 import org.eclipse.kapua.model.query.KapuaQuery;
-import org.eclipse.kapua.service.certificate.info.CertificateInfo;
 import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -31,8 +31,9 @@ import javax.xml.bind.annotation.XmlType;
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = CertificateXmlRegistry.class, factoryMethod = "newQuery")
-public interface CertificateQuery extends KapuaQuery {
+public interface CertificateQuery extends KapuaForwardableEntityQuery {
 
+    @Override
     /**
      * Gets whether or not to get also inherited {@link CertificateInfo}s
      *
@@ -42,6 +43,7 @@ public interface CertificateQuery extends KapuaQuery {
     @XmlElement(name = "includeInherited")
     Boolean getIncludeInherited();
 
+    @Override
     /**
      * Sets whether or not to get also inherited {@link CertificateInfo}s
      *

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateRepository.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateRepository.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate;
 
-import org.eclipse.kapua.storage.KapuaNamedEntityRepository;
+import org.eclipse.kapua.service.utils.KapuaForwardableEntityRepository;
 
 public interface CertificateRepository
-        extends KapuaNamedEntityRepository<Certificate, CertificateListResult> {
+        extends KapuaForwardableEntityRepository<Certificate, CertificateListResult> {
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
@@ -35,5 +35,13 @@ public interface CertificateService extends KapuaEntityService<Certificate, Cert
 
     Certificate generate(CertificateGenerator generator) throws KapuaException;
 
+    /**
+     * @param scopeId
+     * @param usage
+     * @return
+     * @throws KapuaException
+     * @deprecated Since 2.0.0 Use the query method with CertificateQuery.setIncludeInherited(true) instead
+     */
+    @Deprecated
     List<Certificate> findAncestorsCertificates(KapuaId scopeId, CertificateUsage usage) throws KapuaException;
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfo.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfo.java
@@ -12,7 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.info;
 
-import org.eclipse.kapua.model.KapuaNamedEntity;
+import java.util.Date;
+import java.util.Set;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.eclipse.kapua.model.KapuaForwardableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.BinaryXmlAdapter;
@@ -22,23 +33,13 @@ import org.eclipse.kapua.service.certificate.CertificateUsage;
 import org.eclipse.kapua.service.certificate.KeyUsageSetting;
 import org.eclipse.kapua.service.certificate.info.xml.CertificateInfoXmlRegistry;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.Date;
-import java.util.Set;
-
 /**
  * @since 1.1.0
  */
 @XmlRootElement(name = "certificateInfo")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = CertificateInfoXmlRegistry.class, factoryMethod = "newCertificateInfo")
-public interface CertificateInfo extends KapuaNamedEntity {
+public interface CertificateInfo extends KapuaForwardableEntity {
 
     String TYPE = "CertificateInfo";
 
@@ -139,9 +140,4 @@ public interface CertificateInfo extends KapuaNamedEntity {
     void addCertificateUsage(CertificateUsage certificateUsage);
 
     void removeCertificateUsage(CertificateUsage certificateUsage);
-
-    @XmlElement(name = "forwardable")
-    Boolean getForwardable();
-
-    void setForwardable(Boolean forwardable);
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoQuery.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoQuery.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.info;
 
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.certificate.info.xml.CertificateInfoXmlRegistry;
 
@@ -30,8 +31,9 @@ import javax.xml.bind.annotation.XmlType;
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = CertificateInfoXmlRegistry.class, factoryMethod = "newQuery")
-public interface CertificateInfoQuery extends KapuaQuery {
+public interface CertificateInfoQuery extends KapuaForwardableEntityQuery {
 
+    @Override
     /**
      * Gets whether or not to get also inherited {@link CertificateInfo}s
      *
@@ -41,6 +43,7 @@ public interface CertificateInfoQuery extends KapuaQuery {
     @XmlElement(name = "includeInherited")
     Boolean getIncludeInherited();
 
+    @Override
     /**
      * Sets whether or not to get also inherited {@link CertificateInfo}s
      *

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoRepository.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoRepository.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.info;
 
-import org.eclipse.kapua.storage.KapuaNamedEntityRepository;
+import org.eclipse.kapua.service.utils.KapuaForwardableEntityRepository;
 
 public interface CertificateInfoRepository
-        extends KapuaNamedEntityRepository<CertificateInfo, CertificateInfoListResult> {
+        extends KapuaForwardableEntityRepository<CertificateInfo, CertificateInfoListResult> {
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoService.java
@@ -36,6 +36,8 @@ public interface CertificateInfoService extends KapuaEntityService<CertificateIn
      * @return
      * @throws KapuaException
      * @since 1.1.0
+     * @deprecated Since 2.0.0 Use the query method with CertificateQuery.setIncludeInherited(true) instead
      */
+    @Deprecated
     List<CertificateInfo> findAncestorsCertificates(KapuaId scopeId, CertificateUsage usage) throws KapuaException;
 }

--- a/service/security/certificate/internal/pom.xml
+++ b/service/security/certificate/internal/pom.xml
@@ -37,5 +37,9 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-service-commons-utils-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-commons-utils-internal</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoModule.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoModule.java
@@ -12,14 +12,32 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.info.internal;
 
+import javax.inject.Singleton;
+
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.certificate.CertificateService;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoFactory;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
+import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
+
+import com.google.inject.Provides;
 
 public class CertificateInfoModule extends AbstractKapuaModule {
     @Override
     protected void configureModule() {
         bind(CertificateInfoFactory.class).to(CertificateInfoFactoryImpl.class);
-        bind(CertificateInfoService.class).to(CertificateInfoServiceImpl.class);
+    }
+
+
+    @Provides
+    @Singleton
+    CertificateInfoService certificateInfoService(
+            CertificateService certificateService,
+            KapuaEntityQueryUtil entityQueryUtil) {
+
+        return new CertificateInfoServiceImpl(
+                certificateService,
+                entityQueryUtil
+        );
     }
 }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoModule.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoModule.java
@@ -12,15 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.info.internal;
 
-import javax.inject.Singleton;
-
+import com.google.inject.Provides;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.service.certificate.CertificateService;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoFactory;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
-import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
-import com.google.inject.Provides;
+import javax.inject.Singleton;
 
 public class CertificateInfoModule extends AbstractKapuaModule {
     @Override
@@ -32,12 +30,10 @@ public class CertificateInfoModule extends AbstractKapuaModule {
     @Provides
     @Singleton
     CertificateInfoService certificateInfoService(
-            CertificateService certificateService,
-            KapuaEntityQueryUtil entityQueryUtil) {
+            CertificateService certificateService) {
 
         return new CertificateInfoServiceImpl(
-                certificateService,
-                entityQueryUtil
+                certificateService
         );
     }
 }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.kapua.service.certificate.info.CertificateInfoListResult;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoQuery;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
 import org.eclipse.kapua.service.certificate.internal.CertificateQueryImpl;
-import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -35,12 +34,10 @@ import java.util.List;
 public class CertificateInfoServiceImpl implements CertificateInfoService {
 
     private final CertificateService certificateService;
-    private final KapuaEntityQueryUtil entityQueryUtil;
 
     @Inject
-    public CertificateInfoServiceImpl(CertificateService certificateService, KapuaEntityQueryUtil entityQueryUtil) {
+    public CertificateInfoServiceImpl(CertificateService certificateService) {
         this.certificateService = certificateService;
-        this.entityQueryUtil = entityQueryUtil;
     }
 
     @Override
@@ -59,11 +56,8 @@ public class CertificateInfoServiceImpl implements CertificateInfoService {
 
         CertificateQuery certificateQuery = new CertificateQueryImpl(query);
 
-        // Transform the query for the includeInherited option
-        final KapuaQuery finalQuery = entityQueryUtil.transformInheritedQuery(certificateQuery);
-
         CertificateInfoListResult publicCertificates = new CertificateInfoListResultImpl();
-        publicCertificates.addItem(certificateService.query(finalQuery).getFirstItem());
+        publicCertificates.addItem(certificateService.query(certificateQuery).getFirstItem());
 
         return publicCertificates;
     }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.kapua.service.certificate.info.CertificateInfoListResult;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoQuery;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
 import org.eclipse.kapua.service.certificate.internal.CertificateQueryImpl;
+import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -34,10 +35,12 @@ import java.util.List;
 public class CertificateInfoServiceImpl implements CertificateInfoService {
 
     private final CertificateService certificateService;
+    private final KapuaEntityQueryUtil entityQueryUtil;
 
     @Inject
-    public CertificateInfoServiceImpl(CertificateService certificateService) {
+    public CertificateInfoServiceImpl(CertificateService certificateService, KapuaEntityQueryUtil entityQueryUtil) {
         this.certificateService = certificateService;
+        this.entityQueryUtil = entityQueryUtil;
     }
 
     @Override
@@ -55,10 +58,12 @@ public class CertificateInfoServiceImpl implements CertificateInfoService {
         ArgumentValidator.notNull(query, "query");
 
         CertificateQuery certificateQuery = new CertificateQueryImpl(query);
-        certificateQuery.setIncludeInherited(((CertificateInfoQuery) query).getIncludeInherited());
+
+        // Transform the query for the includeInherited option
+        final KapuaQuery finalQuery = entityQueryUtil.transformInheritedQuery(certificateQuery);
 
         CertificateInfoListResult publicCertificates = new CertificateInfoListResultImpl();
-        publicCertificates.addItem(certificateService.query(certificateQuery).getFirstItem());
+        publicCertificates.addItem(certificateService.query(finalQuery).getFirstItem());
 
         return publicCertificates;
     }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateQueryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateQueryImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaForwardableEntityQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.certificate.CertificateQuery;
@@ -22,9 +22,7 @@ import org.eclipse.kapua.service.certificate.CertificateQuery;
  *
  * @since 1.0.0
  */
-public class CertificateQueryImpl extends AbstractKapuaNamedQuery implements CertificateQuery {
-
-    private Boolean includeInherited = Boolean.FALSE;
+public class CertificateQueryImpl extends AbstractKapuaForwardableEntityQuery implements CertificateQuery {
 
     /**
      * Constructor.
@@ -54,15 +52,5 @@ public class CertificateQueryImpl extends AbstractKapuaNamedQuery implements Cer
      */
     public CertificateQueryImpl(KapuaQuery query) {
         super(query);
-    }
-
-    @Override
-    public Boolean getIncludeInherited() {
-        return includeInherited;
-    }
-
-    @Override
-    public void setIncludeInherited(Boolean includeInherited) {
-        this.includeInherited = includeInherited;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.authorization.shiro;
 
 import com.google.inject.Provides;
 import com.google.inject.multibindings.ProvidesIntoSet;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.CachingServiceConfigRepository;
 import org.eclipse.kapua.commons.configuration.ResourceLimitedServiceConfigurationManagerImpl;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
@@ -264,7 +264,7 @@ public class AuthorizationModule extends AbstractKapuaModule {
     public ServiceConfigurationManager roleServiceConfigurationManager(
             RoleFactory roleFactory,
             RootUserTester rootUserTester,
-            AccountChildrenFinder accountChildrenFinder,
+            AccountRelativeFinder accountRelativeFinder,
             RoleRepository roleRepository,
             KapuaJpaRepositoryConfiguration jpaRepoConfig,
             EntityCacheFactory entityCacheFactory
@@ -277,7 +277,7 @@ public class AuthorizationModule extends AbstractKapuaModule {
                                 entityCacheFactory.createCache("AbstractKapuaConfigurableServiceCacheId")
                         ),
                         rootUserTester,
-                        accountChildrenFinder,
+                        accountRelativeFinder,
                         new UsedEntitiesCounterImpl(
                                 roleFactory,
                                 roleRepository
@@ -317,7 +317,7 @@ public class AuthorizationModule extends AbstractKapuaModule {
     public ServiceConfigurationManager groupServiceConfigurationManager(
             GroupFactory factory,
             RootUserTester rootUserTester,
-            AccountChildrenFinder accountChildrenFinder,
+            AccountRelativeFinder accountRelativeFinder,
             GroupRepository groupRepository,
             KapuaJpaRepositoryConfiguration jpaRepoConfig,
             EntityCacheFactory entityCacheFactory
@@ -330,7 +330,7 @@ public class AuthorizationModule extends AbstractKapuaModule {
                                 entityCacheFactory.createCache("AbstractKapuaConfigurableServiceCacheId")
                         ),
                         rootUserTester,
-                        accountChildrenFinder,
+                        accountRelativeFinder,
                         new UsedEntitiesCounterImpl(
                                 factory,
                                 groupRepository

--- a/service/security/test/src/test/java/org/eclipse/kapua/service/security/test/SecurityLocatorConfiguration.java
+++ b/service/security/test/src/test/java/org/eclipse/kapua/service/security/test/SecurityLocatorConfiguration.java
@@ -21,7 +21,7 @@ import com.google.inject.name.Names;
 import io.cucumber.java.Before;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaRuntimeException;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
 import org.eclipse.kapua.commons.configuration.ServiceConfigImplJpaRepository;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
@@ -179,8 +179,8 @@ public class SecurityLocatorConfiguration {
                 bind(UserFactory.class).toInstance(userFactory);
                 final RootUserTester rootUserTester = Mockito.mock(RootUserTester.class);
                 bind(RootUserTester.class).toInstance(rootUserTester);
-                final AccountChildrenFinder accountChildrenFinder = Mockito.mock(AccountChildrenFinder.class);
-                bind(AccountChildrenFinder.class).toInstance(accountChildrenFinder);
+                final AccountRelativeFinder accountRelativeFinder = Mockito.mock(AccountRelativeFinder.class);
+                bind(AccountRelativeFinder.class).toInstance(accountRelativeFinder);
                 bind(UserService.class).toInstance(new UserServiceImpl(
                         Mockito.mock(ServiceConfigurationManager.class),
                         mockedAuthorization,

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagModule.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagModule.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.tag.internal;
 
 import com.google.inject.Provides;
 import com.google.inject.multibindings.ProvidesIntoSet;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.CachingServiceConfigRepository;
 import org.eclipse.kapua.commons.configuration.ResourceLimitedServiceConfigurationManagerImpl;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
@@ -71,7 +71,7 @@ public class TagModule extends AbstractKapuaModule {
     ServiceConfigurationManager tagServiceConfigurationManager(
             TagFactory factory,
             RootUserTester rootUserTester,
-            AccountChildrenFinder accountChildrenFinder,
+            AccountRelativeFinder accountRelativeFinder,
             TagRepository tagRepository,
             EntityCacheFactory entityCacheFactory
     ) {
@@ -83,7 +83,7 @@ public class TagModule extends AbstractKapuaModule {
                                 entityCacheFactory.createCache("AbstractKapuaConfigurableServiceCacheId")
                         ),
                         rootUserTester,
-                        accountChildrenFinder,
+                        accountRelativeFinder,
                         new UsedEntitiesCounterImpl(
                                 factory,
                                 tagRepository

--- a/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/TagLocatorConfiguration.java
+++ b/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/TagLocatorConfiguration.java
@@ -20,7 +20,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import io.cucumber.java.Before;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
@@ -137,7 +137,7 @@ public class TagLocatorConfiguration {
                 bind(KapuaMetatypeFactory.class).toInstance(new KapuaMetatypeFactoryImpl());
 
                 // binding Account related services
-                bind(AccountChildrenFinder.class).toInstance(Mockito.mock(AccountChildrenFinder.class));
+                bind(AccountRelativeFinder.class).toInstance(Mockito.mock(AccountRelativeFinder.class));
                 bind(AccountService.class).toInstance(Mockito.mock(AccountService.class));
                 bind(AccountFactory.class).toInstance(Mockito.spy(new AccountFactoryImpl()));
                 bind(RootUserTester.class).toInstance(Mockito.mock(RootUserTester.class));

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserModule.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserModule.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.user.internal;
 
 import com.google.inject.Provides;
 import com.google.inject.multibindings.ProvidesIntoSet;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.CachingServiceConfigRepository;
 import org.eclipse.kapua.commons.configuration.ResourceLimitedServiceConfigurationManagerImpl;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
@@ -124,7 +124,7 @@ public class UserModule extends AbstractKapuaModule {
     ServiceConfigurationManager userServiceConfigurationManager(
             UserFactory userFactory,
             RootUserTester rootUserTester,
-            AccountChildrenFinder accountChildrenFinder,
+            AccountRelativeFinder accountRelativeFinder,
             UserRepository userRepository,
             KapuaJpaRepositoryConfiguration jpaRepoConfig,
             EntityCacheFactory entityCacheFactory
@@ -136,7 +136,7 @@ public class UserModule extends AbstractKapuaModule {
                                 entityCacheFactory.createCache("AbstractKapuaConfigurableServiceCacheId")
                         ),
                         rootUserTester,
-                        accountChildrenFinder,
+                        accountRelativeFinder,
                         new UsedEntitiesCounterImpl(
                                 userFactory,
                                 userRepository

--- a/service/user/test/src/test/java/org/eclipse/kapua/service/user/test/UserLocatorConfiguration.java
+++ b/service/user/test/src/test/java/org/eclipse/kapua/service/user/test/UserLocatorConfiguration.java
@@ -20,7 +20,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import io.cucumber.java.Before;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AccountChildrenFinder;
+import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.configuration.ResourceLimitedServiceConfigurationManagerImpl;
 import org.eclipse.kapua.commons.configuration.RootUserTester;
 import org.eclipse.kapua.commons.configuration.ServiceConfigImplJpaRepository;
@@ -109,8 +109,8 @@ public class UserLocatorConfiguration {
                 bind(KapuaMetatypeFactory.class).toInstance(new KapuaMetatypeFactoryImpl());
 
                 // binding Account related services
-                final AccountChildrenFinder accountChildrenFinder = Mockito.mock(AccountChildrenFinder.class);
-                bind(AccountChildrenFinder.class).toInstance(accountChildrenFinder);
+                final AccountRelativeFinder accountRelativeFinder = Mockito.mock(AccountRelativeFinder.class);
+                bind(AccountRelativeFinder.class).toInstance(accountRelativeFinder);
 
                 // Inject actual User service related services
                 final UserFactoryImpl userFactory = new UserFactoryImpl();
@@ -122,7 +122,7 @@ public class UserLocatorConfiguration {
                 final ResourceLimitedServiceConfigurationManagerImpl userConfigurationManager = new ResourceLimitedServiceConfigurationManagerImpl(UserService.class.getName(),
                         new ServiceConfigImplJpaRepository(jpaRepoConfig),
                         Mockito.mock(RootUserTester.class),
-                        accountChildrenFinder,
+                        accountRelativeFinder,
                         new UsedEntitiesCounterImpl(
                                 userFactory,
                                 userRepository)


### PR DESCRIPTION
This makes improvements to forwardable entities to try and make them easier to use.

**Related Issue**
N/A

**Description of the solution adopted**
- Adds a `KapuaForwardableEntity` interface for entities that support forwarding.
- Adds a `KapuaForwardableEntityQuery` interface which adds an "includeInherited" option in queries.  This also allows deprecation of the separate findAncestors* methods.
- Adds a `KapuaEntityQueryUtil` service to process/convert KapuaForwardableEntityQuery (if the "includeInherited" option is enabled, then it looks up the parent ids for the query's scope and modifies the query to also include those accounts).

**Screenshots**
N/A

**Any side note on the changes made**
It renames the `AccountChildrenFinder` service to `AccountRelativeFinder` and adds the method to lookup the parent ids there.
