### PR TITLE
Removing download of NPM and Swagger CLI for each build

### DIFF
--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -17,6 +17,17 @@ runs:
       with:
         distribution: 'zulu'
         java-version: 11
+    - name: Setup Node
+      uses: actions/setup-node@v4 # Installs Node and NPM
+      with:
+        node-version: 16
+    - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
+      run: 'npm install -g @apidevtools/swagger-cli'
+      shell: bash
+    - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
+      with:
+        path: ~/.m2/repository
+        key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
     - name: Cache Maven repository
       uses: actions/cache@v3
       with:

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -19,6 +19,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+      - uses: actions/setup-node@v4 # Installs Node and NPM
+        with:
+          node-version: 16
+      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
+        run: 'npm install -g @apidevtools/swagger-cli'
       - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository
@@ -312,6 +317,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+      - uses: actions/setup-node@v4 # Installs Node and NPM
+        with:
+          node-version: 16
+      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
+        run: 'npm install -g @apidevtools/swagger-cli'
+      - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
+        with:
+          path: ~/.m2/repository
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -328,6 +342,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+      - uses: actions/setup-node@v4 # Installs Node and NPM
+        with:
+          node-version: 16
+      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
+        run: 'npm install -g @apidevtools/swagger-cli'
+      - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
+        with:
+          path: ~/.m2/repository
+          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ Before starting, check that your environment has the following prerequisites:
 
 * 64 bit architecture
 * Java VM Version 8
+* Java VM Version 11
 * Docker Version 1.2+
+* Swagger CLI 4+ (Installed via NPM or separately)
+* Node 16+ 
 * Internet Access (needed to download the artifacts)
 
 ### Demo Setup

--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -224,7 +224,7 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack-swagger-ui</id>
+                        <id>Unpack Swagger UI</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
@@ -242,7 +242,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>unpack-openapi</id>
+                        <id>Unpack OpenAPI definitions</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
@@ -267,24 +267,24 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-openapi</id>
+                        <id>Bundle OpenAPI definitions</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>
-                        <phase>prepare-package</phase>
+                        <configuration>
+                            <executable>${swagger-cli.executable}</executable>
+                            <arguments>
+                                <argument>bundle</argument>
+                                <argument>-t</argument>
+                                <argument>yaml</argument>
+                                <argument>-o</argument>
+                                <argument>${project.build.directory}/tmp/openapi.yaml</argument>
+                                <argument>${project.build.directory}/tmp/openapi/openapi.yaml</argument>
+                            </arguments>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <executable>${swagger-cli.executable}</executable>
-                    <arguments>
-                        <argument>bundle</argument>
-                        <argument>-t</argument>
-                        <argument>yaml</argument>
-                        <argument>-o</argument>
-                        <argument>${project.build.directory}/tmp/openapi.yaml</argument>
-                        <argument>${project.build.directory}/tmp/openapi/openapi.yaml</argument>
-                    </arguments>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -26,9 +26,7 @@
     <artifactId>kapua-assembly-api</artifactId>
 
     <properties>
-        <nodejs.version>17.9.1</nodejs.version>
-        <swagger-cli.executable>${project.build.directory}/bin/swagger-cli</swagger-cli.executable>
-        <swagger-cli.version>4.0.4</swagger-cli.version>
+        <swagger-cli.executable>swagger-cli</swagger-cli.executable>
     </properties>
 
     <dependencies>
@@ -222,31 +220,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>install-node-and-npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>install-swagger-cli</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>install -g @apidevtools/swagger-cli@${swagger-cli.version}</arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <nodeVersion>v${nodejs.version}</nodeVersion>
-                    <installDirectory>target</installDirectory>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -303,9 +276,6 @@
                 </executions>
                 <configuration>
                     <executable>${swagger-cli.executable}</executable>
-                    <environmentVariables>
-                        <PATH>$PATH:${project.build.directory}/node</PATH>
-                    </environmentVariables>
                     <arguments>
                         <argument>bundle</argument>
                         <argument>-t</argument>
@@ -374,17 +344,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>swagger-cli-windows</id>
-            <activation>
-                <os>
-                    <family>Windows</family>
-                </os>
-            </activation>
-            <properties>
-                <swagger-cli.executable>${project.build.directory}/node/swagger-cli.cmd</swagger-cli.executable>
-            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
This PR removes the download of NPM, Node and Swagger CLI for each build, which sometimes fails due to NPM server truncating the download.

Now you'll have to install Swagger CLI and Node separately.

```
brew install npm
brew install node
npm install -g @apidevtools/swagger-cli
```

**Related Issue**
_None_

**Description of the solution adopted**
Removed installation of NPM for each build and set OpenAPI build to use Swagger CLI and Node form the local machine (given they are configured and available in PATH)

**Screenshots**
_None_

**Any side note on the changes made**
_None_