### PR TITLE
Add parsing for `tamper_status` property in birth message

### DIFF
--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -373,6 +373,7 @@ devEsfVersion=KURA/ESF Version
 devNumProc=Number of Processors
 devRamTot=Total RAM
 devRamFree=Free RAM
+devTamperStatus=Tamper status
 
 netConnIface=Network Interface
 netConnIfaceIp=Network Interface IP Address

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceServiceImpl.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.server;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
 import com.extjs.gxt.ui.client.data.BaseListLoadResult;
 import com.extjs.gxt.ui.client.data.BasePagingLoadConfig;
 import com.extjs.gxt.ui.client.data.BasePagingLoadResult;
@@ -71,12 +77,6 @@ import org.eclipse.kapua.service.tag.Tag;
 import org.eclipse.kapua.service.tag.TagService;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Callable;
 
 /**
  * The server side implementation of the Device RPC service.
@@ -254,6 +254,7 @@ public class GwtDeviceServiceImpl extends KapuaRemoteServiceServlet implements G
                 pairs.add(new GwtGroupedNVPair(DEV_HW, "devModelId", device.getModelId()));
                 pairs.add(new GwtGroupedNVPair(DEV_HW, "devModelName", device.getModelName()));
                 pairs.add(new GwtGroupedNVPair(DEV_HW, "devSerialNumber", device.getSerialNumber()));
+                pairs.add(new GwtGroupedNVPair(DEV_HW, "devTamperStatus", device.getTamperStatus()));
 
                 pairs.add(new GwtGroupedNVPair(DEV_SW, "devFirmwareVersion", device.getFirmwareVersion()));
                 pairs.add(new GwtGroupedNVPair(DEV_SW, "devBiosVersion", device.getBiosVersion()));

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthPayload.java
@@ -498,4 +498,20 @@ public interface KapuaBirthPayload extends KapuaLifecyclePayload {
      * @since 1.5.0
      */
     void setExtendedProperties(String extendedProperties);
+
+    /**
+     * Gets the tamper status
+     *
+     * @return The tamper status.
+     * @since 2.0.0
+     */
+    String getTamperStatus();
+
+    /**
+     * Sets the tamper status.
+     *
+     * @param tamperStatus The tamper status.
+     * @since 1.5.0
+     */
+    void setTamperStatus(String tamperStatus);
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthPayloadAttibutes.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthPayloadAttibutes.java
@@ -173,4 +173,9 @@ public class KapuaBirthPayloadAttibutes {
      * @since 1.5.0
      */
     public static final String EXTENDED_PROPERTIES = "extendedProperties";
+
+    /**
+     * @since 2.0.0
+     */
+    public static final String TAMPER_STATUS = "tamperStatus";
 }

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsPayloadImpl.java
@@ -66,7 +66,8 @@ public class KapuaAppsPayloadImpl extends KapuaBirthPayloadImpl implements Kapua
                                 String modemImei,
                                 String modemImsi,
                                 String modemIccid,
-                                String extendedProperties) {
+                                String extendedProperties,
+                                String tamperStatus) {
         super(uptime,
                 displayName,
                 modelName,
@@ -96,6 +97,7 @@ public class KapuaAppsPayloadImpl extends KapuaBirthPayloadImpl implements Kapua
                 modemImei,
                 modemImsi,
                 modemIccid,
-                extendedProperties);
+                extendedProperties,
+                tamperStatus);
     }
 }

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthPayloadImpl.java
@@ -69,6 +69,7 @@ public class KapuaBirthPayloadImpl extends AbstractLifecyclePayloadImpl implemen
      * @param modemImsi                   The {@link KapuaBirthPayloadAttibutes#MODEM_IMSI} of the {@link KapuaBirthMessage}
      * @param modemIccid                  The {@link KapuaBirthPayloadAttibutes#MODEM_ICCID} of the {@link KapuaBirthMessage}
      * @param extendedProperties          The {@link KapuaBirthPayloadAttibutes#EXTENDED_PROPERTIES} of the {@link KapuaBirthMessage}
+     * @param tamperStatus                The {@link KapuaBirthPayloadAttibutes#TAMPER_STATUS} of the {@link KapuaBirthMessage}
      * @since 1.0.0
      */
     public KapuaBirthPayloadImpl(String uptime,
@@ -100,7 +101,8 @@ public class KapuaBirthPayloadImpl extends AbstractLifecyclePayloadImpl implemen
                                  String modemImei,
                                  String modemImsi,
                                  String modemIccid,
-                                 String extendedProperties) {
+                                 String extendedProperties,
+                                 String tamperStatus) {
 
         setUptime(uptime);
         setDisplayName(displayName);
@@ -132,6 +134,7 @@ public class KapuaBirthPayloadImpl extends AbstractLifecyclePayloadImpl implemen
         setModemImsi(modemImsi);
         setModemIccid(modemIccid);
         setExtendedProperties(extendedProperties);
+        setTamperStatus(tamperStatus);
     }
 
     @Override
@@ -432,5 +435,15 @@ public class KapuaBirthPayloadImpl extends AbstractLifecyclePayloadImpl implemen
     @Override
     public void setExtendedProperties(String extendedProperties) {
         getMetrics().put(KapuaBirthPayloadAttibutes.EXTENDED_PROPERTIES, extendedProperties);
+    }
+
+    @Override
+    public String getTamperStatus() {
+        return (String) getMetrics().get(KapuaBirthPayloadAttibutes.TAMPER_STATUS);
+    }
+
+    @Override
+    public void setTamperStatus(String temperStatus) {
+        getMetrics().put(KapuaBirthPayloadAttibutes.TAMPER_STATUS, temperStatus);
     }
 }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
@@ -56,6 +56,7 @@ public class KapuaAppsMessageTest {
             "~~osVersion=osV-1" +
             "~~partNumber=part-1" +
             "~~serialNumber=SN-123" +
+            "~~tamperStatus=NOT_TAMPERED" +
             "~~totalMemory=4" +
             "~~uptime=12";
 
@@ -161,7 +162,8 @@ public class KapuaAppsMessageTest {
                         "      \"propertyName\": \"propertyValue\"\n" +
                         "    }\n" +
                         "  }\n" +
-                        "}"
+                        "}",
+                "NOT_TAMPERED"
         );
     }
 }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
@@ -52,6 +52,7 @@ public class KapuaBirthMessageTest {
             "~~osVersion=osV-1" +
             "~~partNumber=part-1" +
             "~~serialNumber=SN-123" +
+            "~~tamperStatus=NOT_TAMPERED" +
             "~~totalMemory=4" +
             "~~uptime=12";
 
@@ -165,7 +166,8 @@ public class KapuaBirthMessageTest {
                         "      \"propertyName\": \"propertyValue\"\n" +
                         "    }\n" +
                         "  }\n" +
-                        "}"
+                        "}",
+                "NOT_TAMPERED"
         );
     }
 }

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.qa.common;
 
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import javax.inject.Inject;
+
 import com.google.common.base.Strings;
 import com.google.inject.Singleton;
 import io.cucumber.java.After;
@@ -56,11 +61,6 @@ import org.eclipse.kapua.transport.message.jms.JmsTopic;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import java.time.Duration;
-import java.util.Date;
-import java.util.Map;
 
 @Singleton
 public class BasicSteps extends TestBase {

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
@@ -73,6 +73,7 @@ paths:
                   groupName: Hardware Info
                   name: CPU Cores
                   value: 4
+              tamperStatus: NOT_TAMPERED
               tagIds: [ ]
         required: true
       responses:

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
@@ -94,6 +94,7 @@ paths:
                         connectionIp: 127.0.0.1
                         applicationIdentifiers: heaterPROV-V2DEPLOY-V2VPNCLIENT-V2CONF-V1CERT-V1ASSET-V1CMD-V1
                         acceptEncoding: gzip
+                        tamperStatus: NOT_TAMPERED
                         tagIds: []
                 with-fetch-attributes:
                   value:
@@ -158,6 +159,7 @@ paths:
                           connectionIp: 127.0.0.1
                           applicationIdentifiers: heaterPROV-V2DEPLOY-V2VPNCLIENT-V2CONF-V1CERT-V1ASSET-V1CMD-V1
                           acceptEncoding: gzip
+                          tamperStatus: NOT_TAMPERED
                           tagIds: []
 
         401:

--- a/rest-api/resources/src/main/resources/openapi/device/device.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device.yaml
@@ -138,6 +138,9 @@ components:
             customAttribute5:
               description: A Custom Attribute of this Device - 5
               type: string
+            tamperStatus:
+              description: The tamper status of the Device
+              type: string
             extendedProperties:
               type: array
               items:
@@ -177,6 +180,7 @@ components:
             groupName: Hardware Info
             name: CPU Cores
             value: 4
+        tamperStatus: NOT_TAMPERED
         tagIds: [ ]
     deviceCreator:
       allOf:
@@ -264,6 +268,9 @@ components:
             customAttribute5:
               description: A Custom Attirbute of this Device - 5
               type: string
+            tamperStatus:
+              description: The tamper status of the Device
+              type: string
             tagIds:
               description: A list of tag ID to link to the Device
               type: array
@@ -285,6 +292,7 @@ components:
             osgiFrameworkVersion: 1.7.0
             acceptEncoding: gzip
             deviceCredentialsMode: LOOSE
+            tamperStatus: NOT_TAMPERED
             tagIds: []
     deviceListResult:
       allOf:

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/AbstractKuraAppsBirthPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/AbstractKuraAppsBirthPayload.java
@@ -240,6 +240,14 @@ public class AbstractKuraAppsBirthPayload extends AbstractKuraLifecyclePayload i
      * @since 1.0.0
      */
     protected static final String DEFAULT_APPLICATION_FRAMEWORK = "Kura";
+
+    /**
+     * {@link Device} tamper status.
+     *
+     * @since 2.0.0
+     */
+    protected static final String TAMPER_STATUS = "tamper_status";
+
     private static final long serialVersionUID = 5490945197263668115L;
 
 
@@ -283,6 +291,7 @@ public class AbstractKuraAppsBirthPayload extends AbstractKuraLifecyclePayload i
      * @param modemImsi                   {@link Device} modem IMSI.
      * @param modemIccid                  {@link Device} modem ICCID.
      * @param extendedProperties          {@link Device} extended properties.
+     * @param tamperStatus                {@link Device} tamper status.
      * @since 1.0.0
      */
     public AbstractKuraAppsBirthPayload(String uptime,
@@ -312,7 +321,8 @@ public class AbstractKuraAppsBirthPayload extends AbstractKuraLifecyclePayload i
                                         String modemImei,
                                         String modemImsi,
                                         String modemIccid,
-                                        String extendedProperties) {
+                                        String extendedProperties,
+                                        String tamperStatus) {
         super();
 
         if (uptime != null) {
@@ -398,6 +408,9 @@ public class AbstractKuraAppsBirthPayload extends AbstractKuraLifecyclePayload i
         }
         if (extendedProperties != null) {
             getMetrics().put(EXTENDED_PROPERTIES, extendedProperties);
+        }
+        if (tamperStatus != null) {
+            getMetrics().put(TAMPER_STATUS, tamperStatus);
         }
     }
 
@@ -711,6 +724,16 @@ public class AbstractKuraAppsBirthPayload extends AbstractKuraLifecyclePayload i
      */
     public String getExtendedProperties() {
         return (String) getMetrics().get(EXTENDED_PROPERTIES);
+    }
+
+    /**
+     * Gets the {@link Device} tamper status.
+     *
+     * @return The {@link Device} extended properties.
+     * @since 2.0.0
+     */
+    public String getTamperStatus() {
+        return (String) getMetrics().get(TAMPER_STATUS);
     }
 
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
@@ -69,6 +69,7 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
         "customAttribute4",
         "customAttribute5",
         "extendedProperties",
+        "tamperStatus",
         "tagIds"
 }, factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDevice")
 public interface Device extends KapuaUpdatableEntity {
@@ -603,4 +604,21 @@ public interface Device extends KapuaUpdatableEntity {
      * @since 1.5.0
      */
     void setExtendedProperties(List<DeviceExtendedProperty> extendedProperties);
+
+    /**
+     * Gets the tamper status.
+     *
+     * @return The tamper status.
+     * @since 2.0.0
+     */
+    @XmlElement(name = "tamperStatus")
+    String getTamperStatus();
+
+    /**
+     * Sets the tamper status.
+     *
+     * @param tamperStatus The tamper status.
+     * @since 2.0.0
+     */
+    void setTamperStatus(String tamperStatus);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
@@ -69,7 +69,8 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
         "customAttribute4",
         "customAttribute5",
         "extendedProperties",
-        "tagIds"
+        "tagIds",
+        "tamperStatus"
 }, factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDeviceCreator")
 public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
 
@@ -559,6 +560,23 @@ public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
      * @since 1.5.0
      */
     void setExtendedProperties(List<DeviceExtendedProperty> extendedProperties);
+
+    /**
+     * Gets the tamper status.
+     *
+     * @return The application tamper status.
+     * @since 2.0.0
+     */
+    @XmlElement(name = "tamperStatus")
+    String getTamperStatus();
+
+    /**
+     * Sets the tamper status.
+     *
+     * @param tamperStatus The tamper status.
+     * @since 2.0.0
+     */
+    void setTamperStatus(String tamperStatus);
 
 
     /**

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
@@ -61,6 +61,7 @@ public class DeviceCreatorImpl extends AbstractKapuaUpdatableEntityCreator<Devic
     private String customAttribute4;
     private String customAttribute5;
     private List<DeviceExtendedProperty> extendedProperties;
+    private String tamperStatus;
     private Set<KapuaId> tagIds;
 
     /**
@@ -360,6 +361,16 @@ public class DeviceCreatorImpl extends AbstractKapuaUpdatableEntityCreator<Devic
     @Override
     public void setExtendedProperties(List<DeviceExtendedProperty> extendedProperties) {
         this.extendedProperties = extendedProperties;
+    }
+
+    @Override
+    public String getTamperStatus() {
+        return tamperStatus;
+    }
+
+    @Override
+    public void setTamperStatus(String tamperStatus) {
+        this.tamperStatus = tamperStatus;
     }
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImpl.java
@@ -12,20 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.internal;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
-import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.device.registry.Device;
-import org.eclipse.kapua.service.device.registry.DeviceExtendedProperty;
-import org.eclipse.kapua.service.device.registry.DeviceStatus;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
-import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionImpl;
-import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
-import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventImpl;
-import org.eclipse.kapua.service.tag.Taggable;
-
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
 import javax.persistence.Basic;
@@ -40,10 +30,20 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceExtendedProperty;
+import org.eclipse.kapua.service.device.registry.DeviceStatus;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionImpl;
+import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventImpl;
+import org.eclipse.kapua.service.tag.Taggable;
 
 /**
  * {@link Device} implementation.
@@ -196,6 +196,10 @@ public class DeviceImpl extends AbstractKapuaUpdatableEntity implements Device, 
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "dvc_device_extended_properties", joinColumns = @JoinColumn(name = "device_id", referencedColumnName = "id"))
     private List<DeviceExtendedPropertyImpl> extendedProperties;
+
+    @Basic
+    @Column(name = "tamper_status")
+    private String tamperStatus;
 
     /**
      * Constructor
@@ -652,6 +656,16 @@ public class DeviceImpl extends AbstractKapuaUpdatableEntity implements Device, 
         if (extendedProperties != null) {
             extendedProperties.forEach(dep -> this.extendedProperties.add(DeviceExtendedPropertyImpl.parse(dep)));
         }
+    }
+
+    @Override
+    public String getTamperStatus() {
+        return tamperStatus;
+    }
+
+    @Override
+    public void setTamperStatus(String tamperStatus) {
+        this.tamperStatus = tamperStatus;
     }
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
@@ -12,6 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.lifecycle.internal;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.validation.constraints.NotNull;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
@@ -48,15 +57,6 @@ import org.eclipse.kapua.service.device.registry.internal.DeviceExtendedProperty
 import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
 
 /**
  * {@link DeviceLifeCycleService} implementation.
@@ -125,6 +125,8 @@ public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
             deviceCreator.setAcceptEncoding(birthPayload.getAcceptEncoding());
 
             deviceCreator.setExtendedProperties(buildDeviceExtendedPropertyFromBirth(birthPayload.getExtendedProperties()));
+
+            deviceCreator.setTamperStatus(birthPayload.getTamperStatus());
 
             // issue #57
             deviceCreator.setConnectionId(connectionId);
@@ -212,6 +214,8 @@ public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
                 device.setAcceptEncoding(birthPayload.getAcceptEncoding());
 
                 device.setExtendedProperties(buildDeviceExtendedPropertyFromBirth(birthPayload.getExtendedProperties()));
+
+                device.setTamperStatus(birthPayload.getTamperStatus());
 
                 // issue #57
                 device.setConnectionId(connectionId);

--- a/service/device/registry/internal/src/main/resources/liquibase/2.0.0/device_tamper-status.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/2.0.0/device_tamper-status.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -10,16 +10,19 @@
 
     Contributors:
         Eurotech - initial API and implementation
- -->
+-->
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-device-2.0.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device-add-clob-ip-if-columns.xml"/>
-    <include relativeToChangelogFile="true" file="./device_connection-add_auth_type_column.xml"/>
-    <include relativeToChangelogFile="true" file="./device_tamper-status.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
+    <changeSet id="changelog-add-tamper-column" author="eurotech">
+        <addColumn tableName="dvc_device">
+            <column name="tamper_status" type="varchar(64)"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeAppsKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeAppsKuraKapua.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.translator.kura.kapua;
 
+import javax.inject.Inject;
+
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage;
@@ -31,8 +33,6 @@ import org.eclipse.kapua.translator.exception.InvalidChannelException;
 import org.eclipse.kapua.translator.exception.InvalidMessageException;
 import org.eclipse.kapua.translator.exception.InvalidPayloadException;
 import org.eclipse.kapua.translator.exception.TranslateException;
-
-import javax.inject.Inject;
 
 /**
  * {@link Translator} implementation from {@link KuraAppsMessage} to {@link KapuaAppsMessage}
@@ -117,7 +117,8 @@ public class TranslatorLifeAppsKuraKapua extends Translator<KuraAppsMessage, Kap
                 kuraAppsPayload.getModemImei(),
                 kuraAppsPayload.getModemImsi(),
                 kuraAppsPayload.getModemIccid(),
-                kuraAppsPayload.getExtendedProperties());
+                kuraAppsPayload.getExtendedProperties(),
+                kuraAppsPayload.getTamperStatus());
     }
 
     @Override

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeBirthKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeBirthKuraKapua.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.translator.kura.kapua;
 
+import javax.inject.Inject;
+
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage;
@@ -31,8 +33,6 @@ import org.eclipse.kapua.translator.exception.InvalidChannelException;
 import org.eclipse.kapua.translator.exception.InvalidMessageException;
 import org.eclipse.kapua.translator.exception.InvalidPayloadException;
 import org.eclipse.kapua.translator.exception.TranslateException;
-
-import javax.inject.Inject;
 
 /**
  * {@link Translator} implementation from {@link KuraBirthMessage} to {@link KapuaBirthMessage}
@@ -118,7 +118,8 @@ public class TranslatorLifeBirthKuraKapua extends Translator<KuraBirthMessage, K
                 kuraBirthPayload.getModemImei(),
                 kuraBirthPayload.getModemImsi(),
                 kuraBirthPayload.getModemIccid(),
-                kuraBirthPayload.getExtendedProperties());
+                kuraBirthPayload.getExtendedProperties(),
+                kuraBirthPayload.getTamperStatus());
     }
 
     @Override


### PR DESCRIPTION
This pull request enhances the functionality by adding parsing support for the `tamper_status` property within the birth message. The `tamper_status` property provides crucial information about the status of tampering with the device, enabling more comprehensive monitoring and management of devices in the system.

This addition ensures that the birth message processing mechanism accurately captures and interprets the `tamper_status` property, allowing for seamless integration with downstream processes that rely on this information.

Also updated the documentation in order to reflect the new feature.