### PR TITLE
🐛  (Device Registry) fixed Device.clientId and DeviceConnection.clientId being not case sensitive

### DIFF
--- a/service/device/registry/internal/src/main/resources/liquibase/2.0.0/device-client_id_binary.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/2.0.0/device-client_id_binary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -10,18 +10,21 @@
 
     Contributors:
         Eurotech - initial API and implementation
- -->
+-->
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-device-2.0.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device-add-clob-ip-if-columns.xml"/>
-    <include relativeToChangelogFile="true" file="./device_connection-add_auth_type_column.xml"/>
-    <include relativeToChangelogFile="true" file="./device_tamper-status.xml"/>
-    <include relativeToChangelogFile="true" file="./device-client_id_binary.xml"/>
-    <include relativeToChangelogFile="true" file="./device_connection-client_id_binary.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="device-client_id_binary" author="eurotech" dbms="mysql, mariadb">
+
+        <modifyDataType tableName="dvc_device" columnName="client_id" newDataType="varchar(255) BINARY"/>
+        <addNotNullConstraint tableName="dvc_device" columnDataType="varchar(255) BINARY" columnName="client_id"/>
+
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/2.0.0/device_connection-client_id_binary.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/2.0.0/device_connection-client_id_binary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2023, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -10,18 +10,21 @@
 
     Contributors:
         Eurotech - initial API and implementation
- -->
+-->
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-device-2.0.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device-add-clob-ip-if-columns.xml"/>
-    <include relativeToChangelogFile="true" file="./device_connection-add_auth_type_column.xml"/>
-    <include relativeToChangelogFile="true" file="./device_tamper-status.xml"/>
-    <include relativeToChangelogFile="true" file="./device-client_id_binary.xml"/>
-    <include relativeToChangelogFile="true" file="./device_connection-client_id_binary.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="device_connection-client-id-binary" author="eurotech" dbms="mysql, mariadb">
+
+        <modifyDataType tableName="dvc_device_connection" columnName="client_id" newDataType="varchar(255) BINARY"/>
+        <addNotNullConstraint tableName="dvc_device_connection" columnDataType="varchar(255) BINARY" columnName="client_id"/>
+
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR fixes the column definition of `Device.clientId` and `DeviceConnection.clientId` for MySQL and MariaDB databases by explicitly setting them as case sensitive.

**Related Issue**
_None_

**Description of the solution adopted**
Updated the definition of the columns to `VARCHAR(255) BINARY` 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

**Upgrade notes**

Kapua instances using H2DB:
- Should not be impacted as in this DB the fields named in the description are case sensitive by default.

Kapua instances using MariaDB or MySQL:
- Should not be impacted as well. The case is when a device initially connects with client ID 'AAA' and then, due to a change in the configuration, re-connects as 'aaa'. Before the fix the device with client ID 'aaa' can still connect but is not allowed to publish or receive messages so basically it is isolated and this should have been identified as an anomaly already.