### PR TITLE
FIX - Retrieval of specific componentID configuration from cache

### DIFF
--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -145,7 +145,14 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
         } else {
             if (deviceConfigurationStoreService.isServiceEnabled(scopeId) &&
                     deviceConfigurationStoreService.isApplicationEnabled(scopeId, deviceId)) {
-                return deviceConfigurationStoreService.getConfigurations(scopeId, deviceId);
+                if (configurationComponentPid == null) {
+                    return deviceConfigurationStoreService.getConfigurations(scopeId, deviceId);
+                } else {
+                    DeviceConfiguration deviceConfigurationReturned = deviceConfigurationFactory.newConfigurationInstance();
+                    DeviceComponentConfiguration componentConfiguration = deviceConfigurationStoreService.getConfigurations(scopeId, deviceId, configurationComponentPid);
+                    deviceConfigurationReturned.addComponentConfiguration(componentConfiguration);
+                    return deviceConfigurationReturned;
+                }
             } else {
                 throw new DeviceNeverConnectedException(deviceId);
             }


### PR DESCRIPTION
Brief description of the PR.
the rest-api /{scopeId}/devices/{deviceId}/configurations/{componentId} was returning the whole configuration of a device when the cache was used (i.e. device was offline, assuming that a functioning implementation of the configuration cache class was used)

**Description of the solution adopted**
Now the componentPid is correctly taken into consideration, returning a DeviceConfiguration that contains the precise requested service from the cache. The DeviceConfiguration is returned in order to maintain the same interface and contract in the rest-api
