### PR TITLE
Add missing openAPI schema and description for `JobTrigger` object

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/jobTrigger.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/jobTrigger.yaml
@@ -24,9 +24,24 @@ components:
       required: true
   schemas:
     jobTrigger:
+      description: Trigger for the Job
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaNamedEntity'
         - type: object
+          properties:
+            startsOn:
+              type: string
+              format: 'date-time'
+            endsOn:
+              type: string
+              format: 'date-time'
+            triggerDefinitionId:
+              allOf:
+                - $ref: '../openapi.yaml#/components/schemas/kapuaId'
+            triggerProperties:
+              type: array
+              items:
+                $ref: '../triggerDefinition/triggerDefinition.yaml#/components/schemas/triggerProperty'
           example:
             type: trigger
             id: OlIPEFS4MYU
@@ -51,6 +66,7 @@ components:
                 propertyType: org.eclipse.kapua.model.id.KapuaId
                 propertyValue: AQ
     jobTriggerCreator:
+      description: An object that contains the informations needed to create a Job Trigger
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaNamedEntityCreator'
         - type: object
@@ -78,6 +94,7 @@ components:
             propertyType: java.lang.String
             propertyValue: '* * * * * ? *'
     jobTriggerListResult:
+      description: List of Triggers for a Job
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaListResult'
         - type: object
@@ -152,4 +169,3 @@ components:
                   - name: scopeId
                     propertyType: org.eclipse.kapua.model.id.KapuaId
                     propertyValue: AQ
-


### PR DESCRIPTION
This pull request introduces OpenAPI schema definitions and descriptions for the `JobTrigger` object, enhancing the clarity and completeness of the API documentation.

The `JobTrigger `object plays a critical role in defining triggers for various job-related activities within the system. By including detailed schema definitions and descriptions, developers and users will have better insight into the structure and purpose of the `JobTrigger` object, facilitating more effective utilization of the API.

## Screenshots
* before the PR:
  <img width="1381" alt="Screenshot 2024-02-22 at 10 34 16" src="https://github.com/eclipse/kapua/assets/66636702/998cb5cd-9bdd-4d9b-bf0c-ecaf76dd2ab3">

* after the PR:
  <img width="1387" alt="Screenshot 2024-02-22 at 10 28 17" src="https://github.com/eclipse/kapua/assets/66636702/4fdc5eb0-b02a-4982-a621-c5f39ff39a9b">
