### PR TITLE
FIX - Function "convertToDataIndexes" throwing error when one bad format index is present

### DIFF
--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -346,11 +346,11 @@ public class DatastoreUtils {
      * the end date ON OR BEFORE the window end will be returned
      * Only indexes matching Kapua data index name pattern will be inserted inside the result list, namely this format:
      *
-     * [<prefix>-]-data-message-YYYY-ww
+     * "scopeID-data-message-YYYY-ww"
      * or
-     * [<prefix>-]-data-message-YYYY-ww-ee
+     * "scopeID-data-message-YYYY-ww-ee"
      * or
-     * [<prefix>-]-data-message-YYYY-ww-ee-HH
+     * "scopeID-data-message-YYYY-ww-ee-HH"
      *
      * @param indexes
      * @param windowStart

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -1593,7 +1593,7 @@ public class DatastoreSteps extends TestBase {
         primeException();
         try {
             String[] indexes = KapuaLocator.getInstance().getComponent(DatastoreUtils.class).convertToDataIndexes(getDataIndexesByAccount(getCurrentScopeId()), KapuaDateUtils.parseDate(fromDate).toInstant(),
-                    KapuaDateUtils.parseDate(toDate).toInstant());
+                    KapuaDateUtils.parseDate(toDate).toInstant(), null);
             elasticsearchClient.deleteIndexes(indexes);
         } catch (Exception ex) {
             verifyException(ex);

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
@@ -103,8 +103,38 @@ public class DatastoreUtilsIndexCalculatorTest {
         performTest(sdf.parse("17/12/2018 13:12 +0100"), null, buildExpectedResult("1", 52, 2018, 52, 2018, null));
 
         performNullIndexTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("09/01/2017 13:12 +0100"));
+    }
 
-        performFormatValidationTest(null, null);
+    @Test
+    public void indexesFormatValidation() throws DatastoreException, ParseException {
+        String[] indexes = {
+                "1-data-message-2017-01-02",
+                "1-data-message-2017-01-03",
+                "2-data-message-2017-01-02",
+                "asdasdasdssd",
+                "1-data-message-2021-01-01-01-01",
+                "1-data-message-2021-01",
+                "1-data-message-2021-99",
+                "1-data-message-21-01",
+                "1-data-message-2024-08-08-12",
+                "1-data-log-2024-08-08-12",
+                "1-data-message-2024-08-07-12",
+                "1-data-message-2024-23-07-17",
+                "1-data-message-2024-23-07-17_migrated"
+        };
+        String[] correctFormatIndexesWhenScopeid1 = {
+                "1-data-message-2017-01-02", //second day of first week in 2017
+                "1-data-message-2017-01-03",
+                "1-data-message-2021-01",
+                "1-data-message-2024-08-07-12",
+                "1-data-message-2024-23-07-17"
+        };
+
+        performFormatValidationTest(null, null, indexes, correctFormatIndexesWhenScopeid1);
+        performFormatValidationTest(sdf.parse("01/01/2024 13:12 +0100"), null , indexes, new String[]{"1-data-message-2024-08-07-12", "1-data-message-2024-23-07-17"});
+        performFormatValidationTest(null, sdf.parse("04/01/2017 13:12 +0100"),indexes, new String[]{"1-data-message-2017-01-02","1-data-message-2017-01-03"});
+        performFormatValidationTest(sdf.parse("01/01/2017 13:12 +0100"), sdf.parse("01/01/2018 13:12 +0100"),indexes, new String[]{"1-data-message-2017-01-02", "1-data-message-2017-01-03"});
+        performFormatValidationTest(sdf.parse("01/01/2018 13:12 +0100"), sdf.parse("01/01/2022 13:12 +0100"),indexes, new String[]{"1-data-message-2021-01"});
     }
 
     @Test
@@ -187,30 +217,9 @@ public class DatastoreUtilsIndexCalculatorTest {
         compareResult(null, index);
     }
 // // YYYY-ww-ee-HH
-    private void performFormatValidationTest(Date startDate, Date endDate) throws DatastoreException {
-        String[] indexes = {
-                "1-data-message-2017-01-02",
-                "1-data-message-2017-01-03",
-                "2-data-message-2017-01-02",
-                "asdasdasdssd",
-                "1-data-message-2021-01-01-01-01",
-                "1-data-message-2021-01",
-                "1-data-message-2021-99",
-                "1-data-message-21-01",
-                "1-data-message-2024-08-08-12",
-                "1-data-message-2024-08-07-12",
-                "1-data-message-2024-23-07-17",
-                "1-data-message-2024-23-07-17_migrated"
-        };
-        String[] expectedIndexesRes = {
-                "1-data-message-2017-01-02",
-                "1-data-message-2017-01-03",
-                "1-data-message-2021-01",
-                "1-data-message-2024-08-07-12",
-                "1-data-message-2024-23-07-17"
-        };
-        String[] index = datastoreUtils.convertToDataIndexes(indexes, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null, KapuaId.ONE);
-        compareResult(index, expectedIndexesRes);
+    private void performFormatValidationTest(Date startDate, Date endDate, String[] inputIndexes, String[] expectedIndexes) throws DatastoreException {
+        String[] index = datastoreUtils.convertToDataIndexes(inputIndexes, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null, KapuaId.ONE);
+        compareResult(index,expectedIndexes);
     }
 
     private String[] buildExpectedResult(String scopeId, int startWeek, int startYear, int endWeek, int endYear, int[] weekCountByYear) {

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
@@ -103,6 +103,8 @@ public class DatastoreUtilsIndexCalculatorTest {
         performTest(sdf.parse("17/12/2018 13:12 +0100"), null, buildExpectedResult("1", 52, 2018, 52, 2018, null));
 
         performNullIndexTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("09/01/2017 13:12 +0100"));
+
+        performFormatValidationTest(null, null);
     }
 
     @Test
@@ -183,6 +185,32 @@ public class DatastoreUtilsIndexCalculatorTest {
 
         String[] index = datastoreUtils.convertToDataIndexes(new String[]{null, null}, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null, null);
         compareResult(null, index);
+    }
+// // YYYY-ww-ee-HH
+    private void performFormatValidationTest(Date startDate, Date endDate) throws DatastoreException {
+        String[] indexes = {
+                "1-data-message-2017-01-02",
+                "1-data-message-2017-01-03",
+                "2-data-message-2017-01-02",
+                "asdasdasdssd",
+                "1-data-message-2021-01-01-01-01",
+                "1-data-message-2021-01",
+                "1-data-message-2021-99",
+                "1-data-message-21-01",
+                "1-data-message-2024-08-08-12",
+                "1-data-message-2024-08-07-12",
+                "1-data-message-2024-23-07-17",
+                "1-data-message-2024-23-07-17_migrated"
+        };
+        String[] expectedIndexesRes = {
+                "1-data-message-2017-01-02",
+                "1-data-message-2017-01-03",
+                "1-data-message-2021-01",
+                "1-data-message-2024-08-07-12",
+                "1-data-message-2024-23-07-17"
+        };
+        String[] index = datastoreUtils.convertToDataIndexes(indexes, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null, KapuaId.ONE);
+        compareResult(index, expectedIndexesRes);
     }
 
     private String[] buildExpectedResult(String scopeId, int startWeek, int startYear, int endWeek, int endYear, int[] weekCountByYear) {

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
@@ -216,7 +216,8 @@ public class DatastoreUtilsIndexCalculatorTest {
         String[] index = datastoreUtils.convertToDataIndexes(new String[]{null, null}, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null, null);
         compareResult(null, index);
     }
-// // YYYY-ww-ee-HH
+
+
     private void performFormatValidationTest(Date startDate, Date endDate, String[] inputIndexes, String[] expectedIndexes) throws DatastoreException {
         String[] index = datastoreUtils.convertToDataIndexes(inputIndexes, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null, KapuaId.ONE);
         compareResult(index,expectedIndexes);

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
@@ -159,7 +159,7 @@ public class DatastoreUtilsIndexCalculatorTest {
                 calEndDate != null ? calEndDate.get(Calendar.WEEK_OF_YEAR) : "Infinity",
                 calEndDate != null ? calEndDate.get(Calendar.DAY_OF_WEEK) : "Infinity");
 
-        String[] index = datastoreUtils.convertToDataIndexes(getDataIndexesByAccount(KapuaEid.ONE), startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null);
+        String[] index = datastoreUtils.convertToDataIndexes(getDataIndexesByAccount(KapuaEid.ONE), startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null, null);
         compareResult(expectedIndexes, index);
     }
 
@@ -181,7 +181,7 @@ public class DatastoreUtilsIndexCalculatorTest {
                 calEndDate != null ? calEndDate.get(Calendar.WEEK_OF_YEAR) : "Infinity",
                 calEndDate != null ? calEndDate.get(Calendar.DAY_OF_WEEK) : "Infinity");
 
-        String[] index = datastoreUtils.convertToDataIndexes(new String[]{null, null}, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null);
+        String[] index = datastoreUtils.convertToDataIndexes(new String[]{null, null}, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null, null);
         compareResult(null, index);
     }
 


### PR DESCRIPTION
Brief description of the PR.
The method DatastoreUtils::convertToDataIndexes, if called passing at least 1 index with a bad format (for example, 1-data-_message-2024-23-07-17_migrated_), was throwing an exception. In this PR the behavior of the function is changed to still return a list, but with those indexes with a wrong format excluded from it. This holds also when both the time windows in input are null.

This change could be useful if one calls the function when, for example, wants to perform a clean-up of expired data indexes

Furthermore, a set of tests have been added to verify the behavior of the new method

**Any side note on the changes made**
The method was not conforming to an interface so no side effects should be present
