### PR TITLE
Fix issue with job execution filtering in REST API for start date

### DIFF
--- a/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
@@ -128,6 +128,26 @@ Scenario: Query for executions of a specific job
     When I query for the execution items for the current job
     Then I count 3
 
+
+Scenario: Query for executions of a specific job using start date
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    * I configure the job service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+    * I create a job with the name "TestJob"
+    * A regular job execution item
+    * A regular job execution item
+    * A regular job execution item
+    * A regular job execution item
+
+    When I query for the execution items for the current job starting from date in the future
+    Then I count 0
+
+    When I query for the execution items for the current job starting from date in the past
+    Then I count 4
+
 Scenario: Job execution factory sanity checks
 
     And I test the sanity of the job execution factory

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
@@ -12,6 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
 import com.google.common.base.Strings;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
@@ -36,17 +47,6 @@ import org.eclipse.kapua.service.job.targets.JobTargetFactory;
 import org.eclipse.kapua.service.job.targets.JobTargetListResult;
 import org.eclipse.kapua.service.job.targets.JobTargetQuery;
 import org.eclipse.kapua.service.job.targets.JobTargetService;
-
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 
 @Path("{scopeId}/jobs/{jobId}/executions")
 public class JobExecutions extends AbstractKapuaResource {
@@ -128,7 +128,11 @@ public class JobExecutions extends AbstractKapuaResource {
             @PathParam("jobId") EntityId jobId,
             JobExecutionQuery query) throws KapuaException {
         query.setScopeId(scopeId);
-        query.setPredicate(query.attributePredicate(JobExecutionAttributes.JOB_ID, jobId));
+        final AndPredicate andPredicate = query.andPredicate(
+            query.attributePredicate(JobExecutionAttributes.JOB_ID, jobId),
+            query.getPredicate()
+        );
+        query.setPredicate(andPredicate);
         return jobExecutionService.query(query);
     }
 


### PR DESCRIPTION
This pull request addresses an issue with the REST API related to job executions. Previously, job executions could not be filtered based on their start date, causing limitations in querying and retrieving specific execution records.

The fix implemented in this PR enables the filtering of job executions by their start date through the REST API. By resolving this issue, users will now have the ability to precisely query and retrieve job execution records based on their start date, enhancing the flexibility and functionality of the API.