### PR TITLE
:fix: Making sure the event listeners are unique

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/AppModule.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/AppModule.java
@@ -52,6 +52,12 @@ public class AppModule extends AbstractKapuaModule {
     }
 
     @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "telemetry";
+    }
+
+    @Provides
     @Singleton
     @Named("brokerHost")
     String brokerHost(BrokerHostResolver brokerHostResolver) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/RaiseServiceEventInterceptor.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/RaiseServiceEventInterceptor.java
@@ -136,7 +136,7 @@ public class RaiseServiceEventInterceptor implements MethodInterceptor {
             Class<?> wrappedClass = ((KapuaService) invocation.getThis()).getClass().getSuperclass(); // this object should be not null
             Class<?>[] implementedClass = wrappedClass.getInterfaces();
             // assuming that the KapuaService implemented is specified by the first implementing interface
-            String serviceInterfaceName = implementedClass[0].getName();
+            String serviceInterfaceName = implementedClass[0].getSimpleName();
             // String splittedServiceInterfaceName[] = serviceInterfaceName.split("\\.");
             // String serviceName = splittedServiceInterfaceName.length > 0 ? splittedServiceInterfaceName[splittedServiceInterfaceName.length-1] : "";
             // String cleanedServiceName = serviceName.substring(0, serviceName.length()-"Service".length()).toLowerCase();

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventTransactionalModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventTransactionalModule.java
@@ -157,7 +157,7 @@ public abstract class ServiceEventTransactionalModule implements ServiceModule {
                 return config;
             } else {
                 // config for @ListenServiceEvent
-                String subscriberName = config.getClientName() + (clientId == null ? "" : "_" + clientId);
+                String subscriberName = config.getClientName() + (clientId == null ? "" : "-" + clientId);
                 LOGGER.debug("Adding config for @ListenServiceEvent - address: {}, name: {}, listener: {}", config.getAddress(), subscriberName, config.getEventListener());
                 return new ServiceEventClientConfiguration(config.getAddress(), subscriberName, config.getEventListener());
             }

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventTransactionalModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventTransactionalModule.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -57,12 +58,20 @@ public abstract class ServiceEventTransactionalModule implements ServiceModule {
             String internalAddress,
             ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
             ServiceEventBus serviceEventBus) {
-        this.serviceEventClientConfigurations = serviceEventClientConfigurations;
-        this.internalAddress = internalAddress;
-        this.houseKeeperFactory = serviceEventTransactionalHousekeeperFactory;
-        this.serviceEventBus = serviceEventBus;
+        this(serviceEventClientConfigurations, internalAddress, UUID.randomUUID().toString(), serviceEventTransactionalHousekeeperFactory, serviceEventBus);
     }
 
+    public ServiceEventTransactionalModule(
+            ServiceEventClientConfiguration[] serviceEventClientConfigurations,
+            String internalAddress,
+            String uniqueClientId,
+            ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
+            ServiceEventBus serviceEventBus) {
+        this.serviceEventBus = serviceEventBus;
+        this.serviceEventClientConfigurations = appendClientId(uniqueClientId, serviceEventClientConfigurations);
+        this.internalAddress = internalAddress;
+        this.houseKeeperFactory = serviceEventTransactionalHousekeeperFactory;
+    }
 
     @Override
     public void start() throws KapuaException {

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
@@ -12,28 +12,28 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.event;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
+import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.event.ListenServiceEvent;
 import org.eclipse.kapua.event.RaiseServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.service.KapuaService;
-
-import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class ServiceInspector {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceInspector.class);
 
-    private ServiceInspector() {}
+    private ServiceInspector() {
+    }
 
     public static <T extends KapuaService> List<ServiceEventClientConfiguration> getEventBusClients(KapuaService aService, Class<T> clazz) {
 
@@ -83,26 +83,26 @@ public class ServiceInspector {
                     KapuaRuntimeException.internalError(e1, String.format("Unable to get the annotated method: annotation %s", ListenServiceEvent.class));
                 }
 
-                for (ListenServiceEvent listenAnnotation:listenAnnotations) {
+                for (ListenServiceEvent listenAnnotation : listenAnnotations) {
                     final Method listenerMethod = enhancedMethod;
                     configurations.add(
-                        new ServiceEventClientConfiguration(
-                                listenAnnotation.fromAddress(),
-                                clazz.getName(),
-                                serviceEvent -> {
-                                    try {
-                                        listenerMethod.invoke(aService, serviceEvent);
-                                    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-                                        throw KapuaException.internalError(e, String.format("Error invoking method %s", method.getName()));
-                                    }
-                                }));
+                            new ServiceEventClientConfiguration(
+                                    listenAnnotation.fromAddress(),
+                                    clazz.getSimpleName(),
+                                    serviceEvent -> {
+                                        try {
+                                            listenerMethod.invoke(aService, serviceEvent);
+                                        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                                            throw KapuaException.internalError(e, String.format("Error invoking method %s", method.getName()));
+                                        }
+                                    }));
                 }
             }
             if (!ArrayUtils.isEmpty(raiseAnnotations)) {
                 configurations.add(
                         new ServiceEventClientConfiguration(
                                 null,
-                                clazz.getName(),
+                                clazz.getSimpleName(),
                                 null));
             }
         }
@@ -122,7 +122,7 @@ public class ServiceInspector {
                 if (!candidate.getReturnType().equals(method.getReturnType())) {
                     continue;
                 }
-                if(!Arrays.equals(method.getParameterTypes(), candidate.getParameterTypes())) {
+                if (!Arrays.equals(method.getParameterTypes(), candidate.getParameterTypes())) {
                     continue;
                 }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
@@ -303,9 +303,9 @@ public class JMSServiceEventBus implements ServiceEventBus, ServiceEventBusDrive
                 String subscriptionStr = String.format("$SYS/EVT/%s", subscription.getAddress());
                 // create a bunch of sessions to allow parallel event processing
                 LOGGER.info("Subscribing to address {} - name {} ...", subscriptionStr, subscription.getName());
+                final Session jmsSession = jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                Topic jmsTopic = jmsSession.createTopic(subscriptionStr);
                 for (int i = 0; i < consumerPoolSize; i++) {
-                    final Session jmsSession = jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                    Topic jmsTopic = jmsSession.createTopic(subscriptionStr);
                     MessageConsumer jmsConsumer = jmsSession.createSharedDurableConsumer(jmsTopic, subscription.getName());
                     jmsConsumer.setMessageListener(message -> {
                         try {

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -95,7 +95,7 @@ commons.eventbus.producerPool.minSize=5
 commons.eventbus.producerPool.maxSize=5
 commons.eventbus.producerPool.maxWaitOnBorrow=100
 commons.eventbus.producerPool.evictionInterval=600000
-commons.eventbus.consumerPool.size=10
+commons.eventbus.consumerPool.size=2
 commons.eventbus.messageSerializer=org.eclipse.kapua.commons.event.XmlServiceEventMarshaler
 commons.eventbus.transport.useEpoll=true
 

--- a/console/web/src/main/java/org/eclipse/kapua/app/console/AppModule.java
+++ b/console/web/src/main/java/org/eclipse/kapua/app/console/AppModule.java
@@ -28,4 +28,10 @@ public class AppModule extends AbstractKapuaModule {
     String metricModuleName() {
         return "web-console";
     }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "console";
+    }
 }

--- a/consumer/lifecycle-app/src/main/java/org/eclipse/kapua/consumer/lifecycle/AppModule.java
+++ b/consumer/lifecycle-app/src/main/java/org/eclipse/kapua/consumer/lifecycle/AppModule.java
@@ -34,4 +34,11 @@ public class AppModule extends AbstractKapuaModule {
     String metricModuleName() {
         return MetricsLifecycle.CONSUMER_LIFECYCLE;
     }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "lifecycle";
+    }
+
 }

--- a/consumer/telemetry-app/src/main/java/org/eclipse/kapua/consumer/telemetry/AppModule.java
+++ b/consumer/telemetry-app/src/main/java/org/eclipse/kapua/consumer/telemetry/AppModule.java
@@ -34,4 +34,11 @@ public class AppModule extends AbstractKapuaModule {
     String metricModuleName() {
         return MetricsTelemetry.CONSUMER_TELEMETRY;
     }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "telemetry";
+    }
+
 }

--- a/job-engine/app/web/src/main/java/org/eclipse/kapua/job/engine/app/web/AppModule.java
+++ b/job-engine/app/web/src/main/java/org/eclipse/kapua/job/engine/app/web/AppModule.java
@@ -29,4 +29,11 @@ public class AppModule extends AbstractKapuaModule {
     String metricModuleName() {
         return "job-engine";
     }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "job_engine";
+    }
+
 }

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
@@ -21,7 +21,6 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.matcher.AbstractMatcher;
 import com.google.inject.matcher.Matcher;
 import com.google.inject.matcher.Matchers;
-import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.google.inject.spi.InjectionListener;
 import com.google.inject.spi.TypeEncounter;
@@ -62,8 +61,6 @@ public class KapuaModule extends AbstractKapuaModule {
     private static final String SERVICE_RESOURCE = "locator.xml";
 
     private final String resourceName;
-
-    private Multibinder<ServiceModule> serviceModulesBindings;
 
     public KapuaModule(final String resourceName) {
         this.resourceName = resourceName;

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/TestModule.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/TestModule.java
@@ -38,6 +38,12 @@ public class TestModule extends AbstractKapuaModule {
     }
 
     @Provides
+    @Named(value = "eventsModuleName")
+    String eventsModuleName() {
+        return "test";
+    }
+
+    @Provides
     @Singleton
     ServiceEventBusDriver serviceEventBusDriver() {
         return new ServiceEventBusDriver() {

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/TestConfigModule.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/TestConfigModule.java
@@ -23,10 +23,15 @@ public class TestConfigModule extends AbstractKapuaModule {
 
     }
 
-
     @Provides
     @Named("metricModuleName")
     String metricModuleName() {
         return "qa-tests";
+    }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "qa_tests";
     }
 }

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -96,7 +96,7 @@ commons.eventbus.producerPool.minSize=5
 commons.eventbus.producerPool.maxSize=5
 commons.eventbus.producerPool.maxWaitOnBorrow=100
 commons.eventbus.producerPool.evictionInterval=600000
-commons.eventbus.consumerPool.size=10
+commons.eventbus.consumerPool.size=2
 commons.eventbus.messageSerializer=org.eclipse.kapua.commons.event.XmlServiceEventMarshaler
 commons.eventbus.transport.useEpoll=true
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/TestModule.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/TestModule.java
@@ -37,4 +37,11 @@ public class TestModule extends AbstractKapuaModule {
     String metricModuleName() {
         return "unit-tests";
     }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "unit_tests";
+    }
+
 }

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/AppModule.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/AppModule.java
@@ -39,4 +39,11 @@ public class AppModule extends AbstractKapuaModule {
     String metricModuleName() {
         return "rest-api";
     }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "rest_api";
+    }
+
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountModule.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountModule.java
@@ -87,7 +87,8 @@ public class AccountModule extends AbstractKapuaModule implements Module {
                                        EventStoreFactory eventStoreFactory,
                                        EventStoreRecordRepository eventStoreRecordRepository,
                                        ServiceEventBus serviceEventBus,
-                                       KapuaAccountSetting kapuaAccountSetting
+                                       KapuaAccountSetting kapuaAccountSetting,
+                                       @Named("eventsModuleName") String eventModuleName
     ) throws ServiceEventBusException {
         return new AccountServiceModule(
                 accountService,
@@ -103,7 +104,8 @@ public class AccountModule extends AbstractKapuaModule implements Module {
                         txManagerFactory.create("kapua-account"),
                         serviceEventBus
                 ),
-                serviceEventBus);
+                serviceEventBus,
+                eventModuleName);
     }
 
     @Provides

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceModule.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceModule.java
@@ -22,6 +22,8 @@ import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.account.internal.setting.KapuaAccountSetting;
 import org.eclipse.kapua.service.account.internal.setting.KapuaAccountSettingKeys;
 
+import java.util.UUID;
+
 /**
  * {@link AccountService} {@link ServiceModule} implementation.
  *
@@ -33,10 +35,12 @@ public class AccountServiceModule extends ServiceEventTransactionalModule implem
             AccountService accountService,
             KapuaAccountSetting kapuaAccountSetting,
             ServiceEventHouseKeeperFactory serviceEventHouseKeeperFactory,
-            ServiceEventBus serviceEventBus) {
+            ServiceEventBus serviceEventBus,
+            String eventModuleName) {
         super(
                 ServiceInspector.getEventBusClients(accountService, AccountService.class).toArray(new ServiceEventClientConfiguration[0]),
                 kapuaAccountSetting.getString(KapuaAccountSettingKeys.ACCOUNT_EVENT_ADDRESS),
+                eventModuleName + "-" + UUID.randomUUID().toString(),
                 serviceEventHouseKeeperFactory,
                 serviceEventBus);
     }

--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/xml/TestConfigModule.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/xml/TestConfigModule.java
@@ -23,10 +23,15 @@ public class TestConfigModule extends AbstractKapuaModule {
 
     }
 
-
     @Provides
     @Named("metricModuleName")
     String metricModuleName() {
         return "qa-tests";
+    }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "qa_tests";
     }
 }

--- a/service/authentication-app/src/main/java/org/eclipse/kapua/service/authentication/AppModule.java
+++ b/service/authentication-app/src/main/java/org/eclipse/kapua/service/authentication/AppModule.java
@@ -34,4 +34,11 @@ public class AppModule extends AbstractKapuaModule {
     String metricModuleName() {
         return MetricsAuthentication.SERVICE_AUTHENTICATION;
     }
+
+    @Provides
+    @Named("eventsModuleName")
+    String eventModuleName() {
+        return "authentication";
+    }
+
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerModule.java
@@ -51,7 +51,8 @@ public class DeviceConnectionEventListenerModule extends AbstractKapuaModule imp
                                                                        @Named("DeviceRegistryTransactionManager") TxManager txManager,
                                                                        EventStoreFactory eventStoreFactory,
                                                                        EventStoreRecordRepository eventStoreRecordRepository,
-                                                                       ServiceEventBus serviceEventBus
+                                                                       ServiceEventBus serviceEventBus,
+                                                                       @Named("eventsModuleName") String eventModuleName
     ) throws ServiceEventBusException {
 
         String address = kapuaDeviceRegistrySettings.getString(KapuaDeviceRegistrySettingKeys.DEVICE_EVENT_ADDRESS);
@@ -69,6 +70,7 @@ public class DeviceConnectionEventListenerModule extends AbstractKapuaModule imp
                         txManager,
                         serviceEventBus
                 ),
-                serviceEventBus);
+                serviceEventBus,
+                eventModuleName);
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceModule.java
@@ -20,12 +20,16 @@ import org.eclipse.kapua.commons.event.ServiceInspector;
 import org.eclipse.kapua.event.ServiceEventBus;
 import org.eclipse.kapua.service.device.connection.listener.DeviceConnectionEventListenerService;
 
+import java.util.UUID;
+
 public class DeviceConnectionEventListenerServiceModule extends ServiceEventTransactionalModule implements ServiceModule {
 
     public DeviceConnectionEventListenerServiceModule(DeviceConnectionEventListenerService deviceConnectionEventListenerService, String eventAddress, ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-                                                      ServiceEventBus serviceEventBus) {
+                                                      ServiceEventBus serviceEventBus,
+                                                      String eventModuleName) {
         super(ServiceInspector.getEventBusClients(deviceConnectionEventListenerService, DeviceConnectionEventListenerService.class).toArray(new ServiceEventClientConfiguration[0]),
                 eventAddress,
+                eventModuleName + "-" + UUID.randomUUID().toString(),
                 serviceEventTransactionalHousekeeperFactory, serviceEventBus);
     }
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
@@ -134,7 +134,8 @@ public class DeviceRegistryModule extends AbstractKapuaModule {
                                        EventStoreRecordRepository eventStoreRecordRepository,
                                        ServiceEventBus serviceEventBus,
                                        KapuaDeviceRegistrySettings kapuaDeviceRegistrySettings,
-                                       KapuaJpaTxManagerFactory jpaTxManagerFactory
+                                       KapuaJpaTxManagerFactory jpaTxManagerFactory,
+                                       @Named("eventsModuleName") String eventModuleName
     ) throws ServiceEventBusException {
         return new DeviceServiceModule(
                 deviceConnectionService,
@@ -151,7 +152,8 @@ public class DeviceRegistryModule extends AbstractKapuaModule {
                         jpaTxManagerFactory.create("kapua-device"),
                         serviceEventBus
                 ),
-                serviceEventBus);
+                serviceEventBus,
+                eventModuleName);
     }
 
     @Provides

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
 import org.eclipse.kapua.commons.event.ServiceEventHouseKeeperFactory;
 import org.eclipse.kapua.commons.event.ServiceEventTransactionalModule;
@@ -22,13 +19,18 @@ import org.eclipse.kapua.commons.event.ServiceInspector;
 import org.eclipse.kapua.event.ServiceEventBus;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
 
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 public class DeviceServiceModule extends ServiceEventTransactionalModule {
 
     public DeviceServiceModule(DeviceConnectionService deviceConnectionService,
                                DeviceRegistryService deviceRegistryService,
                                KapuaDeviceRegistrySettings deviceRegistrySettings,
                                ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-                               ServiceEventBus serviceEventBus) {
+                               ServiceEventBus serviceEventBus,
+                               String eventModuleName) {
         super(Arrays.asList(ServiceInspector.getEventBusClients(deviceRegistryService, DeviceRegistryService.class),
                                 ServiceInspector.getEventBusClients(deviceConnectionService, DeviceConnectionService.class)
                         )
@@ -37,6 +39,7 @@ public class DeviceServiceModule extends ServiceEventTransactionalModule {
                         .collect(Collectors.toList())
                         .toArray(new ServiceEventClientConfiguration[0]),
                 deviceRegistrySettings.getString(KapuaDeviceRegistrySettingKeys.DEVICE_EVENT_ADDRESS),
+                eventModuleName + "-" + UUID.randomUUID().toString(),
                 serviceEventTransactionalHousekeeperFactory,
                 serviceEventBus);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationModule.java
@@ -90,6 +90,7 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.storage.TxContext;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -143,7 +144,8 @@ public class AuthenticationModule extends AbstractKapuaModule {
                                                      EventStoreFactory eventStoreFactory,
                                                      EventStoreRecordRepository eventStoreRecordRepository,
                                                      ServiceEventBus serviceEventBus,
-                                                     KapuaAuthenticationSetting kapuaAuthenticationSetting
+                                                     KapuaAuthenticationSetting kapuaAuthenticationSetting,
+                                                     @Named("eventsModuleName") String eventModuleName
     ) throws ServiceEventBusException {
         return new AuthenticationServiceModule(
                 credentialService,
@@ -160,7 +162,8 @@ public class AuthenticationModule extends AbstractKapuaModule {
                         txManagerFactory.create("kapua-authentication"),
                         serviceEventBus
                 ),
-                serviceEventBus);
+                serviceEventBus,
+                eventModuleName);
     }
 
     @ProvidesIntoSet

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceModule.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticatio
 import org.eclipse.kapua.service.authentication.token.AccessTokenService;
 
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class AuthenticationServiceModule extends ServiceEventTransactionalModule {
@@ -32,7 +33,8 @@ public class AuthenticationServiceModule extends ServiceEventTransactionalModule
             AccessTokenService accessTokenService,
             KapuaAuthenticationSetting authenticationSetting,
             ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-            ServiceEventBus serviceEventBus) {
+            ServiceEventBus serviceEventBus,
+            String eventModuleName) {
         super(Arrays.asList(
                                 ServiceInspector.getEventBusClients(credentialService, CredentialService.class),
                                 ServiceInspector.getEventBusClients(accessTokenService, AccessTokenService.class)
@@ -42,6 +44,7 @@ public class AuthenticationServiceModule extends ServiceEventTransactionalModule
                         .collect(Collectors.toList())
                         .toArray(new ServiceEventClientConfiguration[0]),
                 authenticationSetting.getString(KapuaAuthenticationSettingKeys.AUTHENTICATION_EVENT_ADDRESS),
+                eventModuleName + "-" + UUID.randomUUID().toString(),
                 serviceEventTransactionalHousekeeperFactory,
                 serviceEventBus);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
@@ -155,7 +155,8 @@ public class AuthorizationModule extends AbstractKapuaModule {
                                              EventStoreFactory eventStoreFactory,
                                              EventStoreRecordRepository eventStoreRecordRepository,
                                              ServiceEventBus serviceEventBus,
-                                             KapuaAuthorizationSetting kapuaAuthorizationSetting
+                                             KapuaAuthorizationSetting kapuaAuthorizationSetting,
+                                             @Named("eventsModuleName") String eventModuleName
     ) throws ServiceEventBusException {
         return new AuthorizationServiceModule(
                 accessInfoService,
@@ -173,7 +174,8 @@ public class AuthorizationModule extends AbstractKapuaModule {
                         ),
                         txManagerFactory.create("kapua-authorization"),
                         serviceEventBus
-                ), serviceEventBus);
+                ), serviceEventBus,
+                eventModuleName);
     }
 
     @ProvidesIntoSet

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceModule.java
@@ -25,6 +25,7 @@ import org.eclipse.kapua.service.authorization.shiro.setting.KapuaAuthorizationS
 import org.eclipse.kapua.service.authorization.shiro.setting.KapuaAuthorizationSettingKeys;
 
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class AuthorizationServiceModule extends ServiceEventTransactionalModule {
@@ -35,7 +36,8 @@ public class AuthorizationServiceModule extends ServiceEventTransactionalModule 
                                       GroupService groupService,
                                       KapuaAuthorizationSetting kapuaAuthorizationSettings,
                                       ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-                                      ServiceEventBus serviceEventBus) {
+                                      ServiceEventBus serviceEventBus,
+                                      String eventModuleName) {
         super(Arrays.asList(
                                 ServiceInspector.getEventBusClients(accessInfoService, AccessInfoService.class),
                                 ServiceInspector.getEventBusClients(roleService, RoleService.class),
@@ -47,6 +49,7 @@ public class AuthorizationServiceModule extends ServiceEventTransactionalModule 
                         .collect(Collectors.toList())
                         .toArray(new ServiceEventClientConfiguration[0]),
                 kapuaAuthorizationSettings.getString(KapuaAuthorizationSettingKeys.AUTHORIZATION_EVENT_ADDRESS),
+                eventModuleName + "-" + UUID.randomUUID().toString(),
                 serviceEventTransactionalHousekeeperFactory,
                 serviceEventBus);
     }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/TestModule.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/TestModule.java
@@ -28,4 +28,10 @@ public class TestModule extends AbstractKapuaModule {
     String metricModuleName() {
         return "test";
     }
+
+    @Provides
+    @Named(value = "eventsModuleName")
+    String eventsModuleName() {
+        return "test";
+    }
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserModule.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserModule.java
@@ -98,7 +98,8 @@ public class UserModule extends AbstractKapuaModule {
                                            EventStoreFactory eventStoreFactory,
                                            EventStoreRecordRepository eventStoreRecordRepository,
                                            ServiceEventBus serviceEventBus,
-                                           KapuaUserSetting kapuaUserSetting
+                                           KapuaUserSetting kapuaUserSetting,
+                                           @Named("eventsModuleName") String eventModuleName
     ) throws ServiceEventBusException {
         return new UserServiceModule(
                 userService,
@@ -113,7 +114,8 @@ public class UserModule extends AbstractKapuaModule {
                         ),
                         txManagerFactory.create("kapua-user"),
                         serviceEventBus
-                ), serviceEventBus);
+                ), serviceEventBus,
+                eventModuleName);
     }
 
     @Provides

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceModule.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceModule.java
@@ -21,12 +21,16 @@ import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.service.user.internal.setting.KapuaUserSetting;
 import org.eclipse.kapua.service.user.internal.setting.KapuaUserSettingKeys;
 
+import java.util.UUID;
+
 public class UserServiceModule extends ServiceEventTransactionalModule {
 
     public UserServiceModule(UserService userService, KapuaUserSetting kapuaUserSetting, ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-                             ServiceEventBus serviceEventBus) {
+                             ServiceEventBus serviceEventBus,
+                             String eventModuleName) {
         super(ServiceInspector.getEventBusClients(userService, UserService.class).toArray(new ServiceEventClientConfiguration[0]),
                 kapuaUserSetting.getString(KapuaUserSettingKeys.USER_EVENT_ADDRESS),
+                eventModuleName + "-" + UUID.randomUUID().toString(),
                 serviceEventTransactionalHousekeeperFactory, serviceEventBus);
     }
 }


### PR DESCRIPTION
Brief description of the PR.
Fixes events not being correctly received when multiple components (e.g.: message broker and/or consumers) instantiate the same event listener.
A the same time, event topics now include the name of the module receiving the event, as well as the service processing it. 
 
**Description of the solution adopted**
This actually restores code which was orphaned in some merge, making sure the client id is unique per instance of an event listener. 
This introduces the need to specify an eventModuleName variable somewhere in your wiring:

    @Provides
    @Named(value = "eventsModuleName")
    String eventsModuleName() {
        return "test";
    }