### PR TITLE
Add OpenAPI schema and description for `JobStep` object

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
@@ -23,10 +23,33 @@ components:
         $ref: '../openapi.yaml#/components/schemas/kapuaId'
       required: true
   schemas:
+    jobStepProperty:
+      description: Property of a Job's Step
+      allOf:
+        - type: object
+          properties:
+            name:
+              type: string
+            propertyType:
+              type: string
+            propertyValue:
+              type: string
     jobStep:
+      description: Step of the Job
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaNamedEntity'
         - type: object
+          properties:
+            jobId:
+              type: string
+            jobStepDefinitionId:
+              type: string
+            stepIndex:
+              type: integer
+            stepProperties:
+              type: object
+              allOf:
+                - $ref: '#/components/schemas/jobStepProperty'
           example:
             type: jobStep
             id: BL2MaF-ldS0


### PR DESCRIPTION
This pull request introduces OpenAPI schema definitions and descriptions for the`JobStep` object, enhancing the clarity and completeness of the API documentation.

The `JobStep` object plays a critical role in defining step for various job-related activities within the system. By including detailed schema definitions and descriptions, developers and users will have better insight into the structure and purpose of the`JobStep` object, facilitating more effective utilization of the API.


After the PR:
<img width="1387" alt="Screenshot 2024-03-08 at 17 05 36" src="https://github.com/eclipse/kapua/assets/66636702/3dfa1be1-42c5-4cd5-ac57-97f37c64326a">

Before the PR:
<img width="1397" alt="Screenshot 2024-03-08 at 14 40 19" src="https://github.com/eclipse/kapua/assets/66636702/e5f9e5d8-6cb8-4a68-bd6a-eb04088aa5f3">
