### PR TITLE
FEATURE - Added "match term" parameter for jobs 

### DIFF
--- a/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
@@ -222,6 +222,31 @@ Feature: Job service CRUD tests
     Then I count 15
     Then I logout
 
+  Scenario: Query for jobs using match term parameter
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I prepare a job with name "job1" and description "descriptionjob"
+    When I create a new job entity from the existing creator
+    Given I prepare a job with name "thisisajob" and description "foo"
+    When I create a new job entity from the existing creator
+    Given I prepare a job with name "blow" and description "job"
+    When I create a new job entity from the existing creator
+    And I query for the job with term match "job"
+    Then I count 2
+    Given I prepare a job with name "job2" and description "descriptionjob2"
+    When I create a new job entity from the existing creator
+    And I query for the job with term match "description"
+    Then I count 2
+    Given I prepare a job with name "job3" and description "descriptionjob3"
+    When I create a new job entity from the existing creator
+    And I query for the job with term match "job"
+    Then I count 4
+    Then I logout
+
   Scenario: Job factory sanity checks
 
     When I test the sanity of the job factory

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
@@ -71,6 +71,7 @@ public class Jobs extends AbstractKapuaResource {
     public JobListResult simpleQuery(
             @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("name") String name,
+            @QueryParam("matchTerm") String matchTerm,
             @QueryParam("sortParam") String sortParam,
             @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("askTotalCount") boolean askTotalCount,
@@ -81,6 +82,9 @@ public class Jobs extends AbstractKapuaResource {
         AndPredicate andPredicate = query.andPredicate();
         if (!Strings.isNullOrEmpty(name)) {
             andPredicate.and(query.attributePredicate(KapuaNamedEntityAttributes.NAME, name));
+        }
+        if (matchTerm != null && !matchTerm.isEmpty()) {
+            andPredicate.and(query.matchPredicate(matchTerm));
         }
         query.setPredicate(andPredicate);
 

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId.yaml
@@ -25,6 +25,16 @@ paths:
           description: The job name to filter results
           schema:
             type: string
+        - name: matchTerm
+          in: query
+          description: |
+            A term to match on different fields. Every entity whose at least one of the specified fields starts with this value will be matched.
+            Matches on the following fields:
+
+            - NAME
+            - DESCRIPTION
+          schema:
+            type: string
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobMatchPredicate.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobMatchPredicate.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job;
+
+import org.eclipse.kapua.model.query.predicate.MatchPredicate;
+
+public interface JobMatchPredicate<T> extends MatchPredicate<T> {
+
+}

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobQuery.java
@@ -29,4 +29,15 @@ import javax.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobXmlRegistry.class, factoryMethod = "newQuery")
 public interface JobQuery extends KapuaQuery {
+
+    /**
+     * Instantiates a new {@link JobMatchPredicate}.
+     *
+     * @param matchTerm The term to use to match.
+     * @param <T>       The type of the term
+     * @return The newly instantiated {@link JobMatchPredicate}.
+     * @since 2.0.0
+     */
+    <T> JobMatchPredicate<T> matchPredicate(T matchTerm);
+
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobMatchPredicateImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobMatchPredicateImpl.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.internal;
+
+import org.eclipse.kapua.commons.model.query.predicate.AbstractMatchPredicate;
+import org.eclipse.kapua.service.job.JobAttributes;
+import org.eclipse.kapua.service.job.JobMatchPredicate;
+
+import java.util.Arrays;
+
+public class JobMatchPredicateImpl<T> extends AbstractMatchPredicate<T> implements JobMatchPredicate<T> {
+
+    /**
+     * Constructor.
+     *
+     * @param matchTerm
+     * @since 2.0.0
+     */
+    public JobMatchPredicateImpl(T matchTerm) {
+        this.attributeNames = Arrays.asList(
+                JobAttributes.NAME,
+                JobAttributes.DESCRIPTION
+        );
+        this.matchTerm = matchTerm;
+    }
+
+}

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobQueryImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.job.internal;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.JobMatchPredicate;
 import org.eclipse.kapua.service.job.JobQuery;
 
 /**
@@ -31,5 +32,10 @@ public class JobQueryImpl extends AbstractKapuaNamedQuery implements JobQuery {
      */
     public JobQueryImpl(KapuaId scopeId) {
         super(scopeId);
+    }
+
+    @Override
+    public <T> JobMatchPredicate<T> matchPredicate(T matchTerm) {
+        return new JobMatchPredicateImpl<>(matchTerm);
     }
 }

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobServiceSteps.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobServiceSteps.java
@@ -390,6 +390,15 @@ public class JobServiceSteps extends JobServiceTestBase {
         }
     }
 
+    @When("I query for the job with term match {string}")
+    public void iQueryForTheJobMatchTerm(String matchTerm) throws Exception {
+        JobQuery tmpQuery = jobFactory.newQuery(getCurrentScopeId());
+
+        tmpQuery.setPredicate(tmpQuery.matchPredicate(matchTerm));
+
+        updateCount(() -> jobService.query(tmpQuery).getSize());
+    }
+
     @Given("I prepare a job with name {string} and description {string}")
     public void iPrepareAJobWithNameAndDescription(String name, String description) {
         JobCreator jobCreator = jobFactory.newCreator(SYS_SCOPE_ID);


### PR DESCRIPTION
Brief description of the PR.
The "match term" query parameter has been added to the "Jobs" API, just like it's implemented, for example, in the "User" API.
A test has been also included to verify that the feature is working properly
