### PR TITLE
:bug: KapuaLocator cleanup on failed startup

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
@@ -77,7 +77,9 @@ public abstract class KapuaLocator implements KapuaServiceLoader {
                 logger.info("initialize Servicelocator with the default instance... DONE");
                 return locator;
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
+            instance = null;
+            isBeingCreated = false;
             logger.error("Error initializing locator...", e);
             throw e;
         }


### PR DESCRIPTION
given incorrect credentials, artemis startup connection toward the event broker was eating the exception and leaving the locator half-initialized, failing on a second attempt. To circumvent this, we clean the locator initialization state (could lead to initialization attempts loops, instead of a clean fail, but cannot be avoided at the moment)
