### PR TITLE
:bug: (Jobs) fixed JobStep.jobStepDefinitionId not being editable

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepImpl.java
@@ -52,7 +52,7 @@ public class JobStepImpl extends AbstractKapuaNamedEntity implements JobStep {
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "eid", column = @Column(name = "job_step_definition_id", nullable = false, updatable = false))
+            @AttributeOverride(name = "eid", column = @Column(name = "job_step_definition_id", nullable = false, updatable = true))
     })
     private KapuaEid jobStepDefinitionId;
 


### PR DESCRIPTION
This PR fixes the `JobStep.jobStepDefinitionId` not being editable.

**Related Issue**
_None_

**Description of the solution adopted**
Defined `job_step_definition_id` column editable

**Screenshots**
_None_

**Any side note on the changes made**
_None_