### PR TITLE
Fix OpenAPI schema for `StepProperties` of a `Job`

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
@@ -47,9 +47,9 @@ components:
             stepIndex:
               type: integer
             stepProperties:
-              type: object
-              allOf:
-                - $ref: '#/components/schemas/jobStepProperty'
+              type: array
+              items:
+                $ref: '#/components/schemas/jobStepProperty'
           example:
             type: jobStep
             id: BL2MaF-ldS0


### PR DESCRIPTION
This pull request fixes the OpenAPI schema definitions and  for `StepProperties` of a `Job`, enhancing the clarity and completeness of the API documentation.
Before the PR the `StepProperties` field was defined as object instead of array.