### PR TITLE
:bug: (commons): fixes resolution of forwardable queries on forwardable entities when predicates are null

### DIFF
--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaEntityQueryUtilImpl.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaEntityQueryUtilImpl.java
@@ -50,7 +50,9 @@ public class KapuaEntityQueryUtilImpl implements KapuaEntityQueryUtil {
         KapuaId scopeId = query.getScopeId();
 
         // Replacement predicate root
-        AndPredicate newPred = query.andPredicate(query.getPredicate());
+        AndPredicate newPred = query.getPredicate() != null ?
+                query.andPredicate(query.getPredicate()) :
+                query.andPredicate();
 
         // Create predicate to query ancestor accounts for entities that are forwardable
         query.setScopeId(KapuaId.ANY);


### PR DESCRIPTION
This PR adds handling of `null` predicates in queries.

**Related Issue**
This PR introduces a bug introduced in #3969

**Description of the solution adopted**
Added a predicate null check and changed logic accordingly

**Screenshots**
_None_

**Any side note on the changes made**
_None_