### PR TITLE
Display Custom Version and Build Number in Swagger UI

### DIFF
--- a/assembly/api/descriptors/kapua-api-jetty.xml
+++ b/assembly/api/descriptors/kapua-api-jetty.xml
@@ -69,5 +69,10 @@
             <source>${project.build.directory}/tmp/openapi.yaml</source>
             <outputDirectory>var/opt/jetty/webapps/root/doc</outputDirectory>
         </file>
+        <file>
+            <source>${project.basedir}/entrypoint/run-api</source>
+            <outputDirectory>var/opt/jetty</outputDirectory>
+            <fileMode>0777</fileMode>
+        </file>
     </files>
 </assembly>

--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -57,3 +57,5 @@ RUN chown -R 1000:0 /opt/jetty /var/opt/jetty && \
     chmod -R g=u /opt/jetty /var/opt/jetty
 
 USER 1000
+
+ENTRYPOINT /var/opt/jetty/run-api

--- a/assembly/api/entrypoint/run-api
+++ b/assembly/api/entrypoint/run-api
@@ -1,0 +1,44 @@
+#!/bin/sh
+################################################################################
+#    Copyright (c) 2024, 2022 Red Hat Inc and others
+#
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#    SPDX-License-Identifier: EPL-2.0
+#
+#    Contributors:
+#        Red Hat Inc - initial API and implementation
+#        Eurotech
+################################################################################
+
+openapiFile=webapps/root/doc/openapi.yaml;
+
+if [ -n "$COMMONS_VERSION" ]; then
+  # Replace the version and the build number in the openapi file
+  awk -v version="$COMMONS_VERSION" -v build_number="$COMMONS_BUILD_NUMBER" '{
+      if (!subbed && /version:/) {
+          gsub(/version: .*/, "version: " version "-" build_number)
+          subbed = 1
+      }
+      print
+  }' "$openapiFile" > "$openapiFile.tmp";
+
+  mv "$openapiFile.tmp" "$openapiFile";
+fi;
+
+# Append the Java option for commons.version if defined
+if [ -n "$COMMONS_VERSION" ]; then
+  echo "Using commons version: $COMMONS_VERSION";
+  JAVA_OPTS="${JAVA_OPTS} -Dcommons.version=$COMMONS_VERSION"
+fi
+
+# Append the Java option for commons.build.number if defined
+if [ -n "$COMMONS_BUILD_NUMBER" ]; then
+  echo "Using commons build number: $COMMONS_BUILD_NUMBER";
+  JAVA_OPTS="${JAVA_OPTS} -Dcommons.build.number=$COMMONS_BUILD_NUMBER";
+fi
+
+# Continue with startup
+exec /var/opt/jetty/run-jetty "$@";

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -92,8 +92,7 @@
             <artifactId>kapua-security-certificate-internal</artifactId>
         </dependency>
 
-        <!-- dependencies added otherwise the unix assembly doesn't know the arctifact
-            to add -->
+        <!-- dependencies added otherwise the unix assembly doesn't know the artifact to add -->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-management-all-api</artifactId>

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -111,6 +111,8 @@ services:
       - AUTH_TOKEN_TTL=${AUTH_TOKEN_TTL:-1800000}
       - REFRESH_AUTH_TOKEN_TTL=${REFRESH_AUTH_TOKEN_TTL:-18000000}
       - CORS_ENDPOINTS_REFRESH_INTERVAL=${CORS_ENDPOINTS_REFRESH_INTERVAL:-60}
+      - COMMONS_VERSION
+      - COMMONS_BUILD_NUMBER
   job-engine:
     container_name: job-engine
     image: kapua/kapua-job-engine:${IMAGE_VERSION}


### PR DESCRIPTION
## Description
This pull request resolves an issue where the version number displayed in the Swagger UI was always retrieved from the `pom.xml` file, regardless of any custom version and build number specified during the project build process.

Prior to this PR, users were unable to customize the version and build number displayed in the Swagger UI, as it solely relied on the information stored in the `pom.xml` file. However, with this enhancement, users can now specify custom version and build number values during project builds using the `-Dcommons.version=custom-version -Dcommons.build.number=custom-build-number` flags. These custom values are then accurately reflected not only in the container environment but also in the Swagger UI.

## Usage
If the project is build using `mvn clean install` then the version displayed in the Swagger UI will be the one defined in the `project.version` followed by the build number placeholder `unknown`.
If the project is build using `mvn clean install -Dcommons.version=foo -Dcommons.build.number=bar` then the version displayed in the Swagger UI will be `foo-bar`.