### PR TITLE
FEATURE - Added the "status" query parameter for api endpoint "/{scopeId}/jobs/{jobId}/targets"

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
@@ -21,6 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../jobTarget/jobTarget.yaml#/components/parameters/jobTargetStatus'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/jobTarget.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/jobTarget.yaml
@@ -22,6 +22,13 @@ components:
       schema:
         $ref: '../openapi.yaml#/components/schemas/kapuaId'
       required: true
+    jobTargetStatus:
+      name: status
+      in: query
+      description: the status of the job target
+      schema:
+        $ref: '#/components/schemas/jobTargetStatus'
+      required: false
   schemas:
     jobTargetCreator:
       allOf:


### PR DESCRIPTION
Brief description of the PR.
It is now possible to filter job targets based on the "jobTargetStatus" field

Besides, with this change:

![Screenshot 2024-03-22 at 14 49 10](https://github.com/eclipse/kapua/assets/39708353/5e7dd0f5-04bb-430e-9483-f335a84b11e3)

I fixed a problem where the predicate of the query to this endpoint "/{scopeId}/jobs/{jobId}/targets" was substituted by the predicate set in the "query" method of this class (see line 131 where _query.setPredicate(query.attributePredicate(JobTargetAttributes.JOB_ID, jobId)_)

