### PR TITLE
:fix: add publish counter for internal messages

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
@@ -258,6 +258,13 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
                         break;
                 }
             } else {
+                switch (checkType) {
+                case SEND:
+                    publishMetric.getAllowedMessagesInternal().inc();
+                    break;
+                default:
+                    break;
+                }
                 allowed = true;
             }
         }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -242,15 +242,16 @@ public class ServerPlugin implements ActiveMQServerPlugin {
                 logger.info("Published message size over threshold. size: {} - destination: {} - account id: {} - username: {} - clientId: {}",
                         messageSize, address, sessionContext.getAccountName(), sessionContext.getUsername(), sessionContext.getClientId());
             }
+            publishMetric.getMessageSizeAllowed().update(messageSize);
         } else {
             if (publishInfoMessageSizeLimit < messageSize) {
                 logger.info("Published message size over threshold. size: {} - destination: {}",
                         messageSize, address);
             }
             message.putBooleanProperty(MessageConstants.HEADER_KAPUA_BROKER_CONTEXT, true);
+            publishMetric.getMessageSizeAllowedInternal().update(messageSize);
         }
         message.putStringProperty(MessageConstants.PROPERTY_ORIGINAL_TOPIC, address);
-        publishMetric.getMessageSizeAllowed().update(messageSize);
         serverContext.getAddressAccessTracker().update(address);
         logger.debug("Published message on address {} from clientId: {} - clientIp: {}", address, sessionContext.getClientId(), sessionContext.getClientIp());
         ActiveMQServerPlugin.super.beforeSend(session, tx, message, direct, noAutoCreateQueue);

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/metric/PublishMetric.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/metric/PublishMetric.java
@@ -28,13 +28,16 @@ public class PublishMetric {
     public static final String PUBLISH = "publish";
 
     public static final String ALLOWED = "allowed";
+    public static final String INTERNAL = "internal";
     public static final String NOT_ALLOWED = "not_allowed";
 
     private final Counter allowedMessages;
+    private final Counter allowedMessagesInternal;
     private final Counter notAllowedMessages;
     private final Timer time;
     // message size
     private final Histogram messageSizeAllowed;
+    private final Histogram messageSizeAllowedInternal;
 
     @Inject
     private PublishMetric(MetricsService metricsService,
@@ -42,10 +45,16 @@ public class PublishMetric {
                           String metricModuleName) {
         // publish/subscribe
         allowedMessages = metricsService.getCounter(metricModuleName, PUBLISH, ALLOWED);
+        allowedMessagesInternal = metricsService.getCounter(metricModuleName, PUBLISH, INTERNAL, ALLOWED);
         notAllowedMessages = metricsService.getCounter(metricModuleName, PUBLISH, NOT_ALLOWED);
         time = metricsService.getTimer(metricModuleName, PUBLISH, MetricsLabel.TIME, MetricsLabel.SECONDS);
         // message size
         messageSizeAllowed = metricsService.getHistogram(metricModuleName, PUBLISH, ALLOWED, MetricsLabel.SIZE, MetricsLabel.BYTES);
+        messageSizeAllowedInternal = metricsService.getHistogram(metricModuleName, PUBLISH, INTERNAL, ALLOWED, MetricsLabel.SIZE, MetricsLabel.BYTES);
+    }
+
+    public Counter getAllowedMessagesInternal() {
+        return allowedMessagesInternal;
     }
 
     public Counter getAllowedMessages() {
@@ -60,8 +69,11 @@ public class PublishMetric {
         return time;
     }
 
+    public Histogram getMessageSizeAllowedInternal() {
+        return messageSizeAllowedInternal;
+    }
+
     public Histogram getMessageSizeAllowed() {
         return messageSizeAllowed;
     }
-
 }


### PR DESCRIPTION
Brief description of the PR.
Add a counter to count the messages published through the internal connector

**Related Issue**
none

**Description of the solution adopted**
just create a new counter in the right place

**Screenshots**
none

**Any side note on the changes made**
none
