### PR TITLE
:bug: [OpenAPI] Fix OpenAPI definitions for Account and User MFA resources

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/account/account.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account.yaml
@@ -23,44 +23,10 @@ components:
           $ref: '../openapi.yaml#/components/schemas/optlock'
         organization:
           type: object
-          required:
-            name
-            email
-          properties:
-            name:
-              type: string
-              description: The Name of the Organization
-            personName:
-              type: string
-              description: The Name of the Person listed as a Contact for the Organization
-            email:
-              type: string
-              format: email
-              description: The Email Address of the Person listed as a Contact for the Organization
-            phoneNumber:
-              type: string
-              description: The Phone Number of the Person listed as a Contact for the Organization
-            addressLine1:
-              type: string
-              description: First line of the Address for the Organization
-            addressLine2:
-              type: string
-              description: Second line of the Address for the Organization
-            addressLine3:
-              type: string
-              description: Third line of the Address for the Organization
-            zipPostCode:
-              type: string
-              description: The Zip / Postcode for the Organization
-            city:
-              type: string
-              description: The City of the Organization
-            stateProvinceCounty:
-              type: string
-              description: The State / Province / County of the Organization
-            country:
-              type: string
-              description: The Country of the Organization
+          $ref: '../accounts/accounts.yaml#/components/schemas/organization'
+      required:
+        - optlock
+        - organization
       example:
         description: Acme Inc.'s Account
         optlock: 2

--- a/rest-api/resources/src/main/resources/openapi/accounts/accounts.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accounts/accounts.yaml
@@ -11,7 +11,7 @@ info:
     name: Eclipse Public License 2.0
     url: https://www.eclipse.org/legal/epl-2.0
 
-paths: { }
+paths: {}
 
 components:
   parameters:
@@ -75,9 +75,6 @@ components:
     organization:
       type: object
       description: An object with all the information needed to create a new Account
-      required:
-        name
-        email
       properties:
         name:
           type: string
@@ -113,6 +110,9 @@ components:
         country:
           type: string
           description: The Country of the Organization
+      required:
+        - name
+        - email
       example:
         name: ACME Inc.
         personName: Wile Ethelbert Coyote

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -664,10 +664,10 @@ components:
         message: "User does not have permission to perform this action. Required permission: user:read:1:*."
         kapuaErrorCode: "SUBJECT_UNAUTHORIZED"
         permission:
-            domain: "user"
-            action: "read"
-            targetScopeId: "AQ"
-            forwardable: false
+          domain: "user"
+          action: "read"
+          targetScopeId: "AQ"
+          forwardable: false
     entityNotFoundExceptionInfo:
       description: The object to represent the fact that an entity has not been found
       allOf:
@@ -880,12 +880,18 @@ components:
     accessRoleListResult:
       $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessRoleListResult'
     ### Account Entities ###
+    organization:
+      $ref: './accounts/accounts.yaml#/components/schemas/organization'
     account:
       $ref: './accounts/accounts.yaml#/components/schemas/account'
     accountCreator:
       $ref: './accounts/accounts.yaml#/components/schemas/accountCreator'
     accountListResult:
       $ref: './accounts/accounts.yaml#/components/schemas/accountListResult'
+    accountUpdateRequest:
+      $ref: './accounts/accounts.yaml#/components/schemas/accountUpdateRequest'
+    currentAccountUpdateRequest:
+      $ref: './account/account.yaml#/components/schemas/currentAccountUpdateRequest'
     ### Authentication Entities ###
     accessToken:
       $ref: './authentication/authentication.yaml#/components/schemas/accessToken'

--- a/rest-api/resources/src/main/resources/openapi/userMfa/userMfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userMfa/userMfa.yaml
@@ -33,11 +33,12 @@ components:
       allOf:
         - $ref: '#/components/schemas/mfaOption'
         - type: object
-        - scratchCodes:
-          description: A list of one-use-only tokens to be used for authentication
-          type: array
-          items:
-            $ref: '#/components/schemas/scratchCode'
+          properties:
+            scratchCodes:
+              description: A list of one-use-only tokens to be used for authentication
+              type: array
+              items:
+                $ref: '#/components/schemas/scratchCode'
       example:
         $ref: '#/components/examples/mfaOptionCreationResponse/value'
     scratchCode:


### PR DESCRIPTION
This PR fixes the OpenAPI definitions for Account and User MFA resources after the recent refactoring

**Related Issue**
This PR fixes following PRs:
- https://github.com/eclipse/kapua/pull/3993
- https://github.com/eclipse/kapua/pull/3986

**Description of the solution adopted**
Fixed error in the definitions

**Screenshots**
_None_

**Any side note on the changes made**
_None_