### PR TITLE
FIX - Added tests for CORS filtering logic

### DIFF
--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -318,6 +318,17 @@ jobs:
         with:
           tag: '@rest_auth'
           needs-docker-images: 'true'
+  test-api-corsfilter:
+    needs: test-endpoint # test suite dependent on the endpoint service (if it has failings it's useless to perform these tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/runTestsTaggedAs
+        with:
+          tag: '@rest_cors'
+          needs-docker-images: 'true'
   junit-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -47,6 +47,7 @@ ENV JAVA_OPTS "-Dapi.cors.origins.allowed=\${API_CORS_ORIGINS_ALLOWED} \
                -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
                -Dauthentication.token.expire.after=\${AUTH_TOKEN_TTL} \
                -Dauthentication.refresh.token.expire.after=\${REFRESH_AUTH_TOKEN_TTL} \
+               -Dapi.cors.refresh.interval=\${CORS_ENDPOINTS_REFRESH_INTERVAL} \
                \${JETTY_DEBUG_OPTS} \
                \${JETTY_JMX_OPTS}"
 

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -110,6 +110,7 @@ services:
       - SWAGGER=${KAPUA_SWAGGER_ENABLE:-true}
       - AUTH_TOKEN_TTL=${AUTH_TOKEN_TTL:-1800000}
       - REFRESH_AUTH_TOKEN_TTL=${REFRESH_AUTH_TOKEN_TTL:-18000000}
+      - CORS_ENDPOINTS_REFRESH_INTERVAL=${CORS_ENDPOINTS_REFRESH_INTERVAL:-60}
   job-engine:
     container_name: job-engine
     image: kapua/kapua-job-engine:${IMAGE_VERSION}

--- a/qa/common/src/main/resources/sql/all_delete.sql
+++ b/qa/common/src/main/resources/sql/all_delete.sql
@@ -109,3 +109,6 @@ FROM schdl_trigger;
 
 DELETE
 FROM schdl_trigger_properties;
+
+DELETE
+FROM endp_endpoint_info;

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestClientSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestClientSteps.java
@@ -185,7 +185,6 @@ public class RestClientSteps {
             }
         }
 
-
         // Create an HttpRequest object
         HttpRequest request = baseBuilder
                 .build();
@@ -211,12 +210,19 @@ public class RestClientSteps {
         }
     }
 
-    @When("I try to authenticate with a cross-origin call with origin {string}")
-    public void createCustomCrossOriginCall(String origin) throws Exception {
+    @When("I try to authenticate with a cross-site call with origin {string}")
+    public void createCustomCrossSiteCall(String origin) throws Exception {
         restCallInternal("POST", "/v1/authentication/user",
                 "{\"password\": \"kapua-password\", \"username\": \"kapua-sys\"}", false,
                 com.google.common.net.HttpHeaders.ORIGIN, origin,
                 com.google.common.net.HttpHeaders.SEC_FETCH_SITE, "cross-site");
+    }
+
+    @When("I try to authenticate with a same-site call")
+    public void createSameOriginCall() throws Exception {
+        restCallInternal("POST", "/v1/authentication/user",
+                "{\"password\": \"kapua-password\", \"username\": \"kapua-sys\"}", false,
+                com.google.common.net.HttpHeaders.SEC_FETCH_SITE, "same-site");
     }
 
     @When("I refresh last access token")

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestClientSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestClientSteps.java
@@ -146,6 +146,13 @@ public class RestClientSteps {
         restCallInternal(method, resource, json, true);
     }
 
+    @When("REST {string} call at {string} with JSON {string} in cross-site mode with origin {string}")
+    public void restCallCrossSite(String method, String resource, String json, String origin) throws Exception {
+        restCallInternal(method, resource, json, true,
+                com.google.common.net.HttpHeaders.ORIGIN, origin,
+                com.google.common.net.HttpHeaders.SEC_FETCH_SITE, "cross-site");
+    }
+
     public void restCallInternal(String method, String resource, String json, boolean authenticateCall, String... additionalHeaders) throws Exception {
         // Create an instance of HttpClient
         HttpClient httpClient = HttpClient.newHttpClient();
@@ -210,10 +217,10 @@ public class RestClientSteps {
         }
     }
 
-    @When("I try to authenticate with a cross-site call with origin {string}")
-    public void createCustomCrossSiteCall(String origin) throws Exception {
+    @When("I try to authenticate with a cross-site call with origin {string} using json {string}")
+    public void createCustomCrossSiteCall(String origin, String authJson) throws Exception {
         restCallInternal("POST", "/v1/authentication/user",
-                "{\"password\": \"kapua-password\", \"username\": \"kapua-sys\"}", false,
+                authJson, false,
                 com.google.common.net.HttpHeaders.ORIGIN, origin,
                 com.google.common.net.HttpHeaders.SEC_FETCH_SITE, "cross-site");
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/rest/RunRestCorsFilterTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/rest/RunRestCorsFilterTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.integration.rest;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = "classpath:features/rest/cors/RestCORSFilter.feature",
+        glue = {"org.eclipse.kapua.qa.common",
+                "org.eclipse.kapua.qa.integration.steps",
+                "org.eclipse.kapua.service.endpoint.steps",
+                "org.eclipse.kapua.service.account.steps",
+                "org.eclipse.kapua.service.user.steps"
+        },
+        plugin = { "pretty",
+                "html:target/cucumber/RestCors",
+                "json:target/RestCors_cucumber.json"
+        },
+        monochrome = true)
+
+public class RunRestCorsFilterTest {
+}

--- a/qa/integration/src/test/resources/features/rest/authentication/RestAuth.feature
+++ b/qa/integration/src/test/resources/features/rest/authentication/RestAuth.feature
@@ -21,7 +21,7 @@ Feature: REST API tests for User
     Given Init Jaxb Context
     And Init Security Context
     #NB: be aware that sub-sequent tests depends on the value of TTL that you set here
-    And start rest-API container and dependencies with auth token TTL "3000"ms and refresh token TTL "2000"ms
+    And start rest-API container and dependencies with auth token TTL "3000"ms and refresh token TTL "2000"ms and cors endpoint refresh interval 60s
 
   Scenario: Simple login with username-pw works and I can call another API endpoint without errors
   First, the authentication via login-pw is tested.

--- a/qa/integration/src/test/resources/features/rest/cors/RestCORSFilter.feature
+++ b/qa/integration/src/test/resources/features/rest/cors/RestCORSFilter.feature
@@ -11,7 +11,9 @@
 #     Eurotech - initial API and implementation
 ###############################################################################
 @env_docker_base
-@rest
+@rest_cors
+
+  #NB: this test depends on tests tagged as @endpoint
 
 Feature: REST API tests for User
   REST API test of Kapua User API.
@@ -21,21 +23,28 @@ Feature: REST API tests for User
     Given Init Jaxb Context
     And Init Security Context
     #NB: be aware that sub-sequent tests depends on the value of TTL that you set here
-    And start rest-API container and dependencies with auth token TTL "10000"ms and refresh token TTL "20000"ms
+#    And start rest-API container and dependencies with auth token TTL "10000"ms and refresh token TTL "20000"ms
 
-  Scenario: asdasdsds
+  Scenario: The auth from a "same-origin" call
 
     Given Server with host "127.0.0.1" on port "8081"
-    Given I try to authenticate with a cross-origin call with origin "https://api-sbx.everyware.io"
+    Given I try to authenticate with a same-site call
     Then I expect no "Access-Control-Allow-Origin" header in the response
+    Then I expect no "Access-Control-Allow-Credentials" header in the response
+
+  Scenario: The success of an authentication attempt from a 'Cross-origin' request depends on the presence of the CORS endpoint used in the 'origin' header in the scope
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io"
+    Then I expect no "Access-Control-Allow-Origin" header in the response
+    Then I expect no "Access-Control-Allow-Credentials" header in the response
     Given I login as user with name "kapua-sys" and password "kapua-password"
     When I create a CORS filter with schema "https", domain "api-sbx.everyware.io" and port 443
-    Then I wait 60 seconds
-    Given I try to authenticate with a cross-origin call with origin "https://api-sbx.everyware.io"
+    Then I wait 3 seconds
+    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io"
     Then I expect "Access-Control-Allow-Origin" header in the response with value "https://api-sbx.everyware.io"
     Then I expect "Access-Control-Allow-Credentials" header in the response with value "true"
     When I delete all CORS filters
-    Then I wait 60 seconds
-    Given I try to authenticate with a cross-origin call with origin "https://api-sbx.everyware.io"
+    Then I wait 3 seconds
+    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io"
     Then I expect no "Access-Control-Allow-Origin" header in the response
-

--- a/qa/integration/src/test/resources/features/rest/cors/RestCORSFilter.feature
+++ b/qa/integration/src/test/resources/features/rest/cors/RestCORSFilter.feature
@@ -16,35 +16,96 @@
   #NB: this test depends on tests tagged as @endpoint
 
 Feature: REST API tests for User
-  REST API test of Kapua User API.
+  REST API tests of Kapua CORS filter logic.
 
   @setup
-  Scenario: Start event broker for all scenarios
+  Scenario: Initialize Jaxb and security context, then start rest-api container and dependencies
     Given Init Jaxb Context
     And Init Security Context
-    #NB: be aware that sub-sequent tests depends on the value of TTL that you set here
-#    And start rest-API container and dependencies with auth token TTL "10000"ms and refresh token TTL "20000"ms
+    #NB: be aware that sub-sequent tests depends on the value of cors endpoint refresh interval that you set here
+    And start rest-API container and dependencies with auth token TTL "10000000"ms and refresh token TTL "20000"ms and cors endpoint refresh interval 1s
 
-  Scenario: The auth from a "same-origin" call
+  Scenario: The auth from a "same-origin" call should not present, in the response headers fields, the values that represent a "success CORS filter auth. attempt"
 
     Given Server with host "127.0.0.1" on port "8081"
     Given I try to authenticate with a same-site call
-    Then I expect no "Access-Control-Allow-Origin" header in the response
-    Then I expect no "Access-Control-Allow-Credentials" header in the response
+    Then REST response code is 200
+    And REST response containing AccessToken
+    And I expect no "Access-Control-Allow-Origin" header in the response
+    And I expect no "Access-Control-Allow-Credentials" header in the response
 
   Scenario: The success of an authentication attempt from a 'Cross-origin' request depends on the presence of the CORS endpoint used in the 'origin' header in the scope
 
     Given Server with host "127.0.0.1" on port "8081"
-    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io"
+    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io" using json "{\"password\": \"kapua-password\", \"username\": \"kapua-sys\"}"
+    #auth is "formally" right (response code 200) but...
+    Then REST response code is 200
+    #...CORS headers are not present
     Then I expect no "Access-Control-Allow-Origin" header in the response
     Then I expect no "Access-Control-Allow-Credentials" header in the response
+    #now I insert the CORS endpoint, using directly services and not rest-API because here I want to test ONLY CORS logic and not other rest APIs. Also, this 'endpoint service' has been tested previously on @endpoint tests
     Given I login as user with name "kapua-sys" and password "kapua-password"
     When I create a CORS filter with schema "https", domain "api-sbx.everyware.io" and port 443
-    Then I wait 3 seconds
-    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io"
+    Then I wait 2 seconds
+    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io" using json "{\"password\": \"kapua-password\", \"username\": \"kapua-sys\"}"
+    Then REST response code is 200
     Then I expect "Access-Control-Allow-Origin" header in the response with value "https://api-sbx.everyware.io"
     Then I expect "Access-Control-Allow-Credentials" header in the response with value "true"
     When I delete all CORS filters
-    Then I wait 3 seconds
-    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io"
+    Then I wait 2 seconds
+    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io" using json "{\"password\": \"kapua-password\", \"username\": \"kapua-sys\"}"
+    Then REST response code is 200
+    Then I expect no "Access-Control-Allow-Credentials" header in the response
     Then I expect no "Access-Control-Allow-Origin" header in the response
+
+
+  Scenario: Trying to define CORS endpoints in child account and seeing if they mask the ones defined in the father
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I create a CORS filter with schema "https", domain "api-sbx.everyware.io" and port 443
+    Then I wait 2 seconds
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    When A generic user
+      | name  | displayName | email             | phoneNumber     | status  | userType |
+      | user1 | Test User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I add credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain | action |
+      | endpoint_info   | read   |
+      | endpoint_info   | write  |
+      | user            | read   |
+    Then I logout
+    When REST POST call at "/v1/authentication/user" with JSON "{\"password\": \"ToManySecrets123#\", \"username\": \"user1\"}"
+    Then REST response code is 200
+    Then REST response containing AccessToken
+    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io" using json "{\"password\": \"ToManySecrets123#\", \"username\": \"user1\"}"
+    Then REST response code is 200
+    Then I expect "Access-Control-Allow-Origin" header in the response with value "https://api-sbx.everyware.io"
+    Then I expect "Access-Control-Allow-Credentials" header in the response with value "true"
+    #now I mask the parent account CORS endpoints creating a new one in this child account
+    Given I login as user with name "user1" and password "ToManySecrets123#"
+    When I create a CORS filter with schema "https", domain "api-sbx.asdsadas.io" and port 443
+    Then I wait 2 seconds
+    Given I try to authenticate with a cross-site call with origin "https://api-sbx.everyware.io" using json "{\"password\": \"ToManySecrets123#\", \"username\": \"user1\"}"
+    Then REST response code is 200
+    And REST response containing AccessToken
+    #Authentication has no defined scopeID in session so parent CORS is used in CORS filter matching...
+    And I expect "Access-Control-Allow-Origin" header in the response with value "https://api-sbx.everyware.io"
+    And I expect "Access-Control-Allow-Credentials" header in the response with value "true"
+    #...but for this call there is a scopeID in session (after auth) so there is masking of CORS endpoint
+    When REST "GET" call at "/v1/_/users?offset=0&limit=50" with JSON "" in cross-site mode with origin "https://api-sbx.everyware.io"
+    Then REST response code is 200
+    And I expect no "Access-Control-Allow-Origin" header in the response
+    And I expect no "Access-Control-Allow-Credentials" header in the response
+
+
+
+
+

--- a/qa/integration/src/test/resources/features/rest/cors/RestCORSFilter.feature
+++ b/qa/integration/src/test/resources/features/rest/cors/RestCORSFilter.feature
@@ -1,0 +1,41 @@
+###############################################################################
+# Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@env_docker_base
+@rest
+
+Feature: REST API tests for User
+  REST API test of Kapua User API.
+
+  @setup
+  Scenario: Start event broker for all scenarios
+    Given Init Jaxb Context
+    And Init Security Context
+    #NB: be aware that sub-sequent tests depends on the value of TTL that you set here
+    And start rest-API container and dependencies with auth token TTL "10000"ms and refresh token TTL "20000"ms
+
+  Scenario: asdasdsds
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given I try to authenticate with a cross-origin call with origin "https://api-sbx.everyware.io"
+    Then I expect no "Access-Control-Allow-Origin" header in the response
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I create a CORS filter with schema "https", domain "api-sbx.everyware.io" and port 443
+    Then I wait 60 seconds
+    Given I try to authenticate with a cross-origin call with origin "https://api-sbx.everyware.io"
+    Then I expect "Access-Control-Allow-Origin" header in the response with value "https://api-sbx.everyware.io"
+    Then I expect "Access-Control-Allow-Credentials" header in the response with value "true"
+    When I delete all CORS filters
+    Then I wait 60 seconds
+    Given I try to authenticate with a cross-origin call with origin "https://api-sbx.everyware.io"
+    Then I expect no "Access-Control-Allow-Origin" header in the response
+


### PR DESCRIPTION
Brief description of the PR.
I created a batch of scenarios for the CORS filtering that uses my latest functions for the rest API client. here, I added them along with a proper job in the ci configuration. This PR fills a gap in the tests for CORS filtering 

**Description of the solution adopted**
a bunch of scenarios have been added for the CORS filtering testing, similar to what done in the "restAuth.feature" file. 
In order to test for the CORS origins list refresh, I needed to tweak the refresh time to a small amount so, just like done in the past, I added an env. variable to set this value and I set it to a very low value (to speed-up execution time of tests). This env. value could be used in the future if we want to tweak this setting for other reasons
