### PR TITLE
:bug: random uuid in event client id resulted in multiple instances o…

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventTransactionalModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventTransactionalModule.java
@@ -12,23 +12,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.event;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.core.ServiceModule;
 import org.eclipse.kapua.event.ServiceEventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 public abstract class ServiceEventTransactionalModule implements ServiceModule {
 
@@ -52,14 +51,6 @@ public abstract class ServiceEventTransactionalModule implements ServiceModule {
     private final String internalAddress;
     private final ServiceEventHouseKeeperFactory houseKeeperFactory;
     private final ServiceEventBus serviceEventBus;
-
-    public ServiceEventTransactionalModule(
-            ServiceEventClientConfiguration[] serviceEventClientConfigurations,
-            String internalAddress,
-            ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-            ServiceEventBus serviceEventBus) {
-        this(serviceEventClientConfigurations, internalAddress, UUID.randomUUID().toString(), serviceEventTransactionalHousekeeperFactory, serviceEventBus);
-    }
 
     public ServiceEventTransactionalModule(
             ServiceEventClientConfiguration[] serviceEventClientConfigurations,

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
@@ -12,12 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model;
 
-import org.eclipse.kapua.commons.model.id.IdGenerator;
-import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
-import org.eclipse.kapua.model.KapuaEntity;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
+import java.io.Serializable;
+import java.util.Date;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -30,8 +26,13 @@ import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import java.io.Serializable;
-import java.util.Date;
+
+import org.eclipse.kapua.commons.model.id.IdGenerator;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * {@link KapuaEntity} {@code abstract} implementation.
@@ -66,8 +67,7 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
     protected KapuaEid createdBy;
 
     /**
-     * Protected default constructor.<br>
-     * Required by JPA.
+     * Protected default constructor.<br> Required by JPA.
      *
      * @since 1.0.0
      */
@@ -78,7 +78,8 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
     /**
      * Constructor.
      *
-     * @param scopeId The scope {@link KapuaId} to set for this {@link KapuaEntity}.
+     * @param scopeId
+     *         The scope {@link KapuaId} to set for this {@link KapuaEntity}.
      * @since 1.0.0
      */
     public AbstractKapuaEntity(KapuaId scopeId) {
@@ -131,7 +132,8 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
     /**
      * Sets the date of creation.
      *
-     * @param createdOn the date of creation.
+     * @param createdOn
+     *         the date of creation.
      * @since 1.0.0
      */
     public void setCreatedOn(Date createdOn) {
@@ -146,7 +148,8 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
     /**
      * Sets the identity {@link KapuaId} who has created this {@link KapuaEntity}
      *
-     * @param createdBy the identity {@link KapuaId} who has created this {@link KapuaEntity}
+     * @param createdBy
+     *         the identity {@link KapuaId} who has created this {@link KapuaEntity}
      * @since 1.0.0
      */
     public void setCreatedBy(KapuaId createdBy) {
@@ -164,5 +167,4 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
         setCreatedBy(KapuaSecurityUtils.getSession().getUserId());
         setCreatedOn(new Date());
     }
-
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
@@ -12,10 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account.internal;
 
-import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.account.Account;
-import org.eclipse.kapua.service.account.Organization;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
@@ -32,9 +31,11 @@ import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.Organization;
 
 /**
  * {@link Account} implementation.
@@ -93,7 +94,8 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
     /**
      * Constructor.
      *
-     * @param scopeId The {@link Account#getScopeId()}.
+     * @param scopeId
+     *         The {@link Account#getScopeId()}.
      * @since 1.0.0
      */
     public AccountImpl(KapuaId scopeId) {
@@ -105,8 +107,10 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
     /**
      * Constructor.
      *
-     * @param scopeId The {@link Account#getScopeId()}.
-     * @param name    The {@link Account#getName()}
+     * @param scopeId
+     *         The {@link Account#getScopeId()}.
+     * @param name
+     *         The {@link Account#getName()}
      * @since 1.0.0
      */
     public AccountImpl(KapuaId scopeId, String name) {
@@ -178,5 +182,22 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
         this.expirationDate = expirationDate;
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof Account)) {
+            return false;
+        }
 
+        final Account that = (Account) object;
+
+        return getId() != null ? getId().equals(that.getId()) : that.getId() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return getId() != null ? getId().hashCode() : 0;
+    }
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
@@ -181,23 +181,4 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
     public void setExpirationDate(Date expirationDate) {
         this.expirationDate = expirationDate;
     }
-
-    @Override
-    public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (!(object instanceof Account)) {
-            return false;
-        }
-
-        final Account that = (Account) object;
-
-        return getId() != null ? getId().equals(that.getId()) : that.getId() == null;
-    }
-
-    @Override
-    public int hashCode() {
-        return getId() != null ? getId().hashCode() : 0;
-    }
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceModule.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceModule.java
@@ -22,8 +22,6 @@ import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.account.internal.setting.KapuaAccountSetting;
 import org.eclipse.kapua.service.account.internal.setting.KapuaAccountSettingKeys;
 
-import java.util.UUID;
-
 /**
  * {@link AccountService} {@link ServiceModule} implementation.
  *
@@ -40,7 +38,7 @@ public class AccountServiceModule extends ServiceEventTransactionalModule implem
         super(
                 ServiceInspector.getEventBusClients(accountService, AccountService.class).toArray(new ServiceEventClientConfiguration[0]),
                 kapuaAccountSetting.getString(KapuaAccountSettingKeys.ACCOUNT_EVENT_ADDRESS),
-                eventModuleName + "-" + UUID.randomUUID().toString(),
+                eventModuleName,
                 serviceEventHouseKeeperFactory,
                 serviceEventBus);
     }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceModule.java
@@ -20,16 +20,15 @@ import org.eclipse.kapua.commons.event.ServiceInspector;
 import org.eclipse.kapua.event.ServiceEventBus;
 import org.eclipse.kapua.service.device.connection.listener.DeviceConnectionEventListenerService;
 
-import java.util.UUID;
-
 public class DeviceConnectionEventListenerServiceModule extends ServiceEventTransactionalModule implements ServiceModule {
 
-    public DeviceConnectionEventListenerServiceModule(DeviceConnectionEventListenerService deviceConnectionEventListenerService, String eventAddress, ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-                                                      ServiceEventBus serviceEventBus,
-                                                      String eventModuleName) {
+    public DeviceConnectionEventListenerServiceModule(DeviceConnectionEventListenerService deviceConnectionEventListenerService, String eventAddress,
+            ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
+            ServiceEventBus serviceEventBus,
+            String eventModuleName) {
         super(ServiceInspector.getEventBusClients(deviceConnectionEventListenerService, DeviceConnectionEventListenerService.class).toArray(new ServiceEventClientConfiguration[0]),
                 eventAddress,
-                eventModuleName + "-" + UUID.randomUUID().toString(),
+                eventModuleName,
                 serviceEventTransactionalHousekeeperFactory, serviceEventBus);
     }
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
 import org.eclipse.kapua.commons.event.ServiceEventHouseKeeperFactory;
 import org.eclipse.kapua.commons.event.ServiceEventTransactionalModule;
@@ -19,18 +22,14 @@ import org.eclipse.kapua.commons.event.ServiceInspector;
 import org.eclipse.kapua.event.ServiceEventBus;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
 
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 public class DeviceServiceModule extends ServiceEventTransactionalModule {
 
     public DeviceServiceModule(DeviceConnectionService deviceConnectionService,
-                               DeviceRegistryService deviceRegistryService,
-                               KapuaDeviceRegistrySettings deviceRegistrySettings,
-                               ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-                               ServiceEventBus serviceEventBus,
-                               String eventModuleName) {
+            DeviceRegistryService deviceRegistryService,
+            KapuaDeviceRegistrySettings deviceRegistrySettings,
+            ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
+            ServiceEventBus serviceEventBus,
+            String eventModuleName) {
         super(Arrays.asList(ServiceInspector.getEventBusClients(deviceRegistryService, DeviceRegistryService.class),
                                 ServiceInspector.getEventBusClients(deviceConnectionService, DeviceConnectionService.class)
                         )
@@ -39,7 +38,7 @@ public class DeviceServiceModule extends ServiceEventTransactionalModule {
                         .collect(Collectors.toList())
                         .toArray(new ServiceEventClientConfiguration[0]),
                 deviceRegistrySettings.getString(KapuaDeviceRegistrySettingKeys.DEVICE_EVENT_ADDRESS),
-                eventModuleName + "-" + UUID.randomUUID().toString(),
+                eventModuleName,
                 serviceEventTransactionalHousekeeperFactory,
                 serviceEventBus);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceModule.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
 import org.eclipse.kapua.commons.event.ServiceEventHouseKeeperFactory;
 import org.eclipse.kapua.commons.event.ServiceEventTransactionalModule;
@@ -21,10 +24,6 @@ import org.eclipse.kapua.service.authentication.credential.CredentialService;
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSetting;
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
 import org.eclipse.kapua.service.authentication.token.AccessTokenService;
-
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class AuthenticationServiceModule extends ServiceEventTransactionalModule {
 
@@ -44,7 +43,7 @@ public class AuthenticationServiceModule extends ServiceEventTransactionalModule
                         .collect(Collectors.toList())
                         .toArray(new ServiceEventClientConfiguration[0]),
                 authenticationSetting.getString(KapuaAuthenticationSettingKeys.AUTHENTICATION_EVENT_ADDRESS),
-                eventModuleName + "-" + UUID.randomUUID().toString(),
+                eventModuleName,
                 serviceEventTransactionalHousekeeperFactory,
                 serviceEventBus);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceModule.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
 import org.eclipse.kapua.commons.event.ServiceEventHouseKeeperFactory;
 import org.eclipse.kapua.commons.event.ServiceEventTransactionalModule;
@@ -24,20 +27,16 @@ import org.eclipse.kapua.service.authorization.role.RoleService;
 import org.eclipse.kapua.service.authorization.shiro.setting.KapuaAuthorizationSetting;
 import org.eclipse.kapua.service.authorization.shiro.setting.KapuaAuthorizationSettingKeys;
 
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 public class AuthorizationServiceModule extends ServiceEventTransactionalModule {
 
     public AuthorizationServiceModule(AccessInfoService accessInfoService,
-                                      RoleService roleService,
-                                      DomainRegistryService domainRegistryService,
-                                      GroupService groupService,
-                                      KapuaAuthorizationSetting kapuaAuthorizationSettings,
-                                      ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-                                      ServiceEventBus serviceEventBus,
-                                      String eventModuleName) {
+            RoleService roleService,
+            DomainRegistryService domainRegistryService,
+            GroupService groupService,
+            KapuaAuthorizationSetting kapuaAuthorizationSettings,
+            ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
+            ServiceEventBus serviceEventBus,
+            String eventModuleName) {
         super(Arrays.asList(
                                 ServiceInspector.getEventBusClients(accessInfoService, AccessInfoService.class),
                                 ServiceInspector.getEventBusClients(roleService, RoleService.class),
@@ -49,7 +48,7 @@ public class AuthorizationServiceModule extends ServiceEventTransactionalModule 
                         .collect(Collectors.toList())
                         .toArray(new ServiceEventClientConfiguration[0]),
                 kapuaAuthorizationSettings.getString(KapuaAuthorizationSettingKeys.AUTHORIZATION_EVENT_ADDRESS),
-                eventModuleName + "-" + UUID.randomUUID().toString(),
+                eventModuleName,
                 serviceEventTransactionalHousekeeperFactory,
                 serviceEventBus);
     }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceModule.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceModule.java
@@ -21,16 +21,14 @@ import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.service.user.internal.setting.KapuaUserSetting;
 import org.eclipse.kapua.service.user.internal.setting.KapuaUserSettingKeys;
 
-import java.util.UUID;
-
 public class UserServiceModule extends ServiceEventTransactionalModule {
 
     public UserServiceModule(UserService userService, KapuaUserSetting kapuaUserSetting, ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
-                             ServiceEventBus serviceEventBus,
-                             String eventModuleName) {
+            ServiceEventBus serviceEventBus,
+            String eventModuleName) {
         super(ServiceInspector.getEventBusClients(userService, UserService.class).toArray(new ServiceEventClientConfiguration[0]),
                 kapuaUserSetting.getString(KapuaUserSettingKeys.USER_EVENT_ADDRESS),
-                eventModuleName + "-" + UUID.randomUUID().toString(),
+                eventModuleName,
                 serviceEventTransactionalHousekeeperFactory, serviceEventBus);
     }
 }


### PR DESCRIPTION
…f the same component processing the same messages, resulting in a lot of data update conflicts

Brief description of the PR.
In a previous PR a random component in event bus clients id was introduced in order to allow multiple components (e.g.: lifecycle, telemetry, etc) to consume the same event. 
Multiple instances of the same component, however, should not process the same event multiple times, as this would result in potential update conflicts on affected entities.
As the event module name (unique for each component) was already previously introduces, this PR removes the unnecessary random component which was added at configuration time.