### PR TITLE
:fix: service events remove durable subscriptions

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
@@ -319,7 +319,7 @@ public class JMSServiceEventBus implements ServiceEventBus, ServiceEventBusDrive
                 final Session jmsSession = jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
                 Topic jmsTopic = jmsSession.createTopic(subscriptionStr);
                 for (int i = 0; i < consumerPoolSize; i++) {
-                    MessageConsumer jmsConsumer = jmsSession.createSharedDurableConsumer(jmsTopic, subscription.getName());
+                    MessageConsumer jmsConsumer = jmsSession.createSharedConsumer(jmsTopic, subscription.getName());
                     jmsConsumer.setMessageListener(message -> {
                         try {
                             if (message instanceof TextMessage) {


### PR DESCRIPTION
Brief description of the PR.
switch from durable to "normal" subscriptions for events.
In this way, if a container is removed, we prevent message leak and event broker crash

**Related Issue**
none

**Description of the solution adopted**
See Brief description

**Screenshots**
none

**Any side note on the changes made**
none