### PR TITLE
:recycle: allowing attribute migration services to run without the locator

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/AbstractKapuaService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/AbstractKapuaService.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.service.internal;
 
+import javax.validation.constraints.NotNull;
+
 import org.eclipse.kapua.commons.jpa.EntityCacheFactory;
 import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
 import org.eclipse.kapua.commons.jpa.EntityManagerSession;
@@ -21,8 +23,6 @@ import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.event.ServiceEventBusListener;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.KapuaService;
-
-import javax.validation.constraints.NotNull;
 
 /**
  * {@code abstract} {@link KapuaService} implementation.
@@ -39,12 +39,13 @@ public abstract class AbstractKapuaService implements KapuaService {
     protected final EntityManagerFactory entityManagerFactory;
     protected final EntityManagerSession entityManagerSession;
     protected final EntityCache entityCache;
-    private final ServiceEventBus serviceEventBus = KapuaLocator.getInstance().getComponent(ServiceEventBus.class);
+    private final ServiceEventBus serviceEventBus;
 
     /**
      * Constructor
      *
-     * @param entityManagerFactory The {@link EntityManagerFactory}.
+     * @param entityManagerFactory
+     *         The {@link EntityManagerFactory}.
      * @since 1.0.0
      * @deprecated Since 1.2.0. Please make use of {@link #AbstractKapuaService(EntityManagerFactory, EntityCacheFactory)}. This constructor will be removed in a next release (may be).
      */
@@ -53,16 +54,23 @@ public abstract class AbstractKapuaService implements KapuaService {
         this(entityManagerFactory, null);
     }
 
+    protected AbstractKapuaService(@NotNull EntityManagerFactory entityManagerFactory, EntityCacheFactory entityCacheFactory) {
+        this(entityManagerFactory, entityCacheFactory, KapuaLocator.getInstance().getComponent(ServiceEventBus.class));
+    }
+
     /**
      * Constructor.
      *
-     * @param entityManagerFactory The {@link EntityManagerFactory}.
-     * @param entityCacheFactory   The {@link EntityCacheFactory}.
+     * @param entityManagerFactory
+     *         The {@link EntityManagerFactory}.
+     * @param entityCacheFactory
+     *         The {@link EntityCacheFactory}.
      * @since 1.2.0
      */
-    protected AbstractKapuaService(@NotNull EntityManagerFactory entityManagerFactory, EntityCacheFactory entityCacheFactory) {
+    protected AbstractKapuaService(@NotNull EntityManagerFactory entityManagerFactory, EntityCacheFactory entityCacheFactory, ServiceEventBus serviceEventBus) {
         this.entityManagerFactory = entityManagerFactory;
         this.entityManagerSession = new EntityManagerSession(entityManagerFactory);
+        this.serviceEventBus = serviceEventBus;
 
         if (entityCacheFactory != null) {
             this.entityCache = entityCacheFactory.createCache("Deprecated");
@@ -84,10 +92,14 @@ public abstract class AbstractKapuaService implements KapuaService {
     /**
      * Registers a {@link ServiceEventBusListener} into the {@link org.eclipse.kapua.event.ServiceEventBus}.
      *
-     * @param listener The {@link ServiceEventBusListener} to register.
-     * @param address  The {@link ServiceEventBus} address to subscribe to.
-     * @param clazz    The {@link KapuaService} owner of the {@link ServiceEventBusListener}.
-     * @throws ServiceEventBusException If any error occurs during subscription to the address.
+     * @param listener
+     *         The {@link ServiceEventBusListener} to register.
+     * @param address
+     *         The {@link ServiceEventBus} address to subscribe to.
+     * @param clazz
+     *         The {@link KapuaService} owner of the {@link ServiceEventBusListener}.
+     * @throws ServiceEventBusException
+     *         If any error occurs during subscription to the address.
      * @since 1.0.0kapua-sew
      */
     protected void registerEventListener(@NotNull ServiceEventBusListener listener, @NotNull String address, @NotNull Class<? extends KapuaService> clazz) throws ServiceEventBusException {

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/api/AbstractEntityAttributeMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/api/AbstractEntityAttributeMigrator.java
@@ -12,10 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.extras.migrator.encryption.api;
 
+import java.util.List;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.extras.migrator.encryption.settings.EncryptionMigrationSettingKeys;
 import org.eclipse.kapua.extras.migrator.encryption.settings.EncryptionMigrationSettings;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -25,13 +26,11 @@ import org.eclipse.kapua.service.KapuaUpdatableEntityService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-
 public abstract class AbstractEntityAttributeMigrator<E extends KapuaUpdatableEntity> implements EntitySecretAttributeMigrator<E> {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractEntityAttributeMigrator.class);
 
-    private static final Boolean DRY_RUN = KapuaLocator.getInstance().getComponent(EncryptionMigrationSettings.class).getBoolean(EncryptionMigrationSettingKeys.DRY_RUN);
+    private static final Boolean DRY_RUN = new EncryptionMigrationSettings().getBoolean(EncryptionMigrationSettingKeys.DRY_RUN);
 
     protected final KapuaEntityService<E, ?> entityService;
     protected final KapuaUpdatableEntityService<E> entityUpdatableService;

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
@@ -13,19 +13,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator;
 
+import java.lang.reflect.Type;
+import java.util.ServiceLoader;
+
 import org.eclipse.kapua.KapuaRuntimeErrorCodes;
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Type;
-import java.util.ServiceLoader;
-
 /**
- * Interface to load KapuaService instances in a given environment.<br>
- * Implementations of the KapuaServiceLocator can decide whether to return local instances or to acts as a proxy to remote instances.<br>
- * The locator is self initialized, it looks for the proper locator implementation class looking at {@link KapuaLocator#LOCATOR_CLASS_NAME_SYSTEM_PROPERTY} system property or falling back to the
- * {@link KapuaLocator#LOCATOR_CLASS_NAME_ENVIRONMENT_PROPERTY} (if the previous property is not defined).
+ * Interface to load KapuaService instances in a given environment.<br> Implementations of the KapuaServiceLocator can decide whether to return local instances or to acts as a proxy to remote
+ * instances.<br> The locator is self initialized, it looks for the proper locator implementation class looking at {@link KapuaLocator#LOCATOR_CLASS_NAME_SYSTEM_PROPERTY} system property or falling
+ * back to the {@link KapuaLocator#LOCATOR_CLASS_NAME_ENVIRONMENT_PROPERTY} (if the previous property is not defined).
  *
  * @since 1.0
  */
@@ -83,6 +82,7 @@ public abstract class KapuaLocator implements KapuaServiceLoader {
             logger.error("Error initializing locator...", e);
             throw e;
         }
+        logger.error("No locator available");
         // none returned
 
         throw new KapuaRuntimeException(KapuaRuntimeErrorCodes.SERVICE_LOCATOR_UNAVAILABLE);


### PR DESCRIPTION
This pr adds some overloads to deprecated classes in order to allow entity-fields migrators to run without the need to spawn a Locator at all.
