### PR TITLE
:arrow_up: [CI] Updated GitHub Actions for test coverage reports from Codecov Bash Uploader to codecov-action v4

### DIFF
--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -48,6 +48,5 @@ runs:
     - name: Test execution step
       run: mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify
       shell: bash
-    - name: Code-coverage results
-      run: bash <(curl -s https://codecov.io/bash)
-      shell: bash
+    - name: Code coverage results upload
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -31,7 +31,8 @@ jobs:
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
-      - run: bash <(curl -s https://codecov.io/bash)
+      - name: Code coverage results upload
+        uses: codecov/codecov-action@v4
   test-brokerAcl:
     needs: build
     runs-on: ubuntu-latest
@@ -353,7 +354,8 @@ jobs:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
-      - run: bash <(curl -s https://codecov.io/bash)
+      - name: Code coverage results upload
+        uses: codecov/codecov-action@v4
   build-javadoc:
     needs: build
     runs-on: ubuntu-latest
@@ -378,4 +380,5 @@ jobs:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: mvn -B -DskipTests install javadoc:jar
-      - run: bash <(curl -s https://codecov.io/bash)
+      - name: Code coverage results upload
+        uses: codecov/codecov-action@v4


### PR DESCRIPTION
:arrow_up: [CI] Updated GitHub Actions for test coverage reports from Codecov Bash Uploader to codecov-action v4
This fixes GitHub Actions integration with Codecov coverage report upload

**Related Issue**
_None_

**Description of the solution adopted**
Updated the component that uploads the result from the [deprecated Bash Uploader](https://docs.codecov.com/docs/about-the-codecov-bash-uploader) to the new [Codecov CLI](https://docs.codecov.com/docs/codecov-uploader) wrapped by the Codecov CLI Github Action step.

**Screenshots**
_None_

**Any side note on the changes made**
_None_