### PR TITLE
:arrow_up: [CI] Update GitHub Actions components

### DIFF
--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -24,12 +24,12 @@ runs:
     - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
       run: 'npm install -g @apidevtools/swagger-cli'
       shell: bash
-    - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
+    - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
       with:
         path: ~/.m2/repository
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
     - name: Cache Maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: 11

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -24,7 +24,7 @@ jobs:
           node-version: 16
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
-      - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
+      - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
@@ -345,11 +345,11 @@ jobs:
           node-version: 16
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
-      - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
+      - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
@@ -371,11 +371,11 @@ jobs:
           node-version: 16
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
-      - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
+      - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3 # Checks out a copy of the repository on the ubuntu-latest machine
+      - uses: actions/checkout@v4 # Checks out a copy of the repository on the ubuntu-latest machine
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@brokerAcl'
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@tag'
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@broker'
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@device'
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@deviceManagement'
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@connection'
@@ -105,7 +105,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@datastore'
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@user'
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@userIntegrationBase'
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@userIntegration'
@@ -149,7 +149,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@security'
@@ -160,7 +160,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobs or @scheduler'
@@ -171,7 +171,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobsIntegrationBase'
@@ -182,7 +182,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobsIntegration'
@@ -193,7 +193,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@account or @translator'
@@ -204,7 +204,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngineStepDefinitions'
@@ -215,7 +215,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngineStartOfflineDevice'
@@ -226,7 +226,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngineStartOnlineDevice'
@@ -237,7 +237,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngineRestartOfflineDevice'
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngineRestartOnlineDevice'
@@ -259,7 +259,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngineRestartOnlineDeviceSecondPart'
@@ -270,7 +270,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngineServiceStop'
@@ -281,7 +281,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@role or @group'
@@ -292,7 +292,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@deviceRegistry'
@@ -303,7 +303,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@endpoint'
@@ -314,7 +314,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@rest_auth'
@@ -325,7 +325,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Clones Kapua repo inside the runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@rest_cors'
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
@@ -361,7 +361,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4 # Checks out a copy of the repository on the ubuntu-latest machine
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
@@ -336,7 +336,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
@@ -362,7 +362,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -31,8 +31,6 @@ jobs:
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
-      - name: Code coverage results upload
-        uses: codecov/codecov-action@v4
   test-brokerAcl:
     needs: build
     runs-on: ubuntu-latest
@@ -380,5 +378,3 @@ jobs:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
       - run: mvn -B -DskipTests install javadoc:jar
-      - name: Code coverage results upload
-        uses: codecov/codecov-action@v4

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # Checks out a copy of the repository on the ubuntu-latest machine
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'zulu'
           java-version: 11
           cache: 'maven'
-      - uses: actions/cache@v3 # Cache local Maven repository to reuse dependencies
+      - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Owasp Dependency Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3 # Checks out a copy of the repository on the ubuntu-latest machine
+      - uses: actions/checkout@v4 # Checks out a copy of the repository on the ubuntu-latest machine
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -44,7 +44,7 @@ jobs:
           git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
           git checkout ${{ github.event.workflow_run.head_branch }}
           git clean -ffdx && git reset --hard HEAD
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -2,8 +2,8 @@ name: Sonar
 
 on:
   workflow_run:
-    workflows: [pr-number-uploader]
-    types: [completed]
+    workflows: [ pr-number-uploader ]
+    types: [ completed ]
 
 jobs:
   sonar:
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout into the pr's branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
This PR updates the version of GitHub Actions components to solve warnings reported on CI builds. 
See https://github.com/eclipse/kapua/actions/runs/8924832988

Components updated are:
- actions@checkout from v3 to v4
- setup-java from v3 to v4
- cache  from v3 to v4

**Related Issue**
_None_

**Description of the solution adopted**
Updated version of GitHub Actions components

**Screenshots**
_None_

**Any side note on the changes made**
_None_