### PR TITLE
:bug: [CI] fixed providing of CODECOV_TOKEN to CI steps

### DIFF
--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -7,6 +7,8 @@ env: #the last 2 env variables defines respectively the maven projects were cucu
   MAVEN_OPTS: "-Xmx4096m"
   TEST_PROJECTS: "org.eclipse.kapua:kapua-security-test,org.eclipse.kapua:kapua-qa-integration,org.eclipse.kapua:kapua-scheduler-test,org.eclipse.kapua:kapua-user-test,org.eclipse.kapua:kapua-system-test,org.eclipse.kapua:kapua-job-test,org.eclipse.kapua:kapua-device-registry-test,org.eclipse.kapua:kapua-account-test,org.eclipse.kapua:kapua-tag-test,org.eclipse.kapua:kapua-translator-test"
   APP_PROJECTS: "org.eclipse.kapua:kapua-service-authentication-app,org.eclipse.kapua:kapua-consumer-lifecycle-app,org.eclipse.kapua:kapua-consumer-telemetry-app"
+  # Secrets
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
   build:
@@ -354,6 +356,8 @@ jobs:
       - run: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
       - name: Code coverage results upload
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   build-javadoc:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the providing of the Codecov Access token to CI steps.

This  needs also solution of https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4612 from Eclipse Foundation

**Related Issue**
Additional fix to #4027 

**Description of the solution adopted**
Added mapping to repository secrets

**Screenshots**
_None_

**Any side note on the changes made**
_None_