### PR TITLE
FIX - Problem of wrong serialization of ComposedKey fields on the cache

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/ComposedKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/ComposedKey.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.service.internal.cache;
 
+import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 
 import java.io.Serializable;
@@ -26,7 +27,7 @@ public class ComposedKey implements Serializable {
     private Serializable key;
 
     public ComposedKey(KapuaId scopeId, Serializable key) {
-        this.scopeId = scopeId;
+        this.scopeId = KapuaEid.parseKapuaId(scopeId); //This is done in order to cast different implementations of KapuaId into one specific, to avoid problems with serialization
         this.key = key;
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/EntityCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/EntityCache.java
@@ -135,7 +135,7 @@ public class EntityCache {
 
     /**
      * Checks that the scopeId of the entity matches the provided one.
-     * This mimics the checks that are performed in the 'find' method of the {@link org.eclipse.kapua.commons.service.internal.ServiceDAO} class.
+     * This mimics the checks that are performed in the 'find' method of the {@link org.eclipse.kapua.commons.jpa.KapuaEntityJpaRepository} class.
      *
      * @param scopeId a {@link KapuaId} representing the scopeId
      * @param entity  the {@link KapuaEntity} to be checked
@@ -159,7 +159,7 @@ public class EntityCache {
 
     /**
      * Checks that the scopeId of the entity matches the provided one.
-     * This mimics the checks that are performed in the 'find' method of the {@link org.eclipse.kapua.commons.service.internal.ServiceDAO} class.
+     * This mimics the checks that are performed in the 'find' method of the {@link org.eclipse.kapua.commons.jpa.KapuaEntityJpaRepository} class.
      *
      * @param scopeId a {@link KapuaId} representing the scopeId
      * @param entity  the {@link KapuaListResult} entity to be checked


### PR DESCRIPTION
I discovered a bug regarding our use of ComposedKey classes and the serialization of some of their fields in the context of the Caching mechanism. One of its fields (scopeId) is of type KapuaId. The problem is that sometimes we create ComposedKeys using a ScopeId instance and then we try to perform a lookup of the same cache entry but using a KapuaEid. If this doesn’t seem a problem from an object-oriented perspective, considering that they have the same internal Id and the equals method would return true, it is from a “serialization” for the cache perspective, because the serialization of the 2 fields is different and, as so, the lookup cannot behave as want. 

I fixed the issue in the constructor of the  ComposedKey class casting the various KapuaId passed in input to be a fixed KapuaEid