### PR TITLE
:bug: [Job] Fixed serialization of JobStepDefinition.stepProperties via REST API

### DIFF
--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinition.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinition.java
@@ -12,14 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition;
 
-import java.util.List;
+import org.eclipse.kapua.model.KapuaNamedEntity;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaNamedEntity;
+import java.util.List;
 
 /**
  * {@link JobStepDefinition} {@link org.eclipse.kapua.model.KapuaEntity} definition.
@@ -54,8 +53,9 @@ public interface JobStepDefinition extends KapuaNamedEntity {
 
     void setWriterName(String writesName);
 
-    <P extends JobStepProperty> List<P> getStepProperties();
+    List<JobStepProperty> getStepProperties();
 
     JobStepProperty getStepProperty(String name);
 
+    void setStepProperties(List<JobStepProperty> jobStepProperties);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionRecord.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionRecord.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
-
 import org.eclipse.kapua.entity.EntityPropertiesReadException;
 import org.eclipse.kapua.entity.EntityPropertiesWriteException;
 import org.eclipse.kapua.model.id.KapuaId;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
 
 public abstract class JobStepDefinitionRecord implements JobStepDefinition {
 
@@ -33,13 +33,13 @@ public abstract class JobStepDefinitionRecord implements JobStepDefinition {
     private List<JobStepProperty> jobStepProperties;
 
     public JobStepDefinitionRecord(KapuaId scopeId,
-            String name,
-            String description,
-            JobStepType stepType,
-            String readerName,
-            String processorName,
-            String writerName,
-            List<JobStepProperty> jobStepProperties) {
+                                   String name,
+                                   String description,
+                                   JobStepType stepType,
+                                   String readerName,
+                                   String processorName,
+                                   String writerName,
+                                   List<JobStepProperty> jobStepProperties) {
         this.scopeId = scopeId;
         this.name = name;
         this.description = description;
@@ -56,18 +56,8 @@ public abstract class JobStepDefinitionRecord implements JobStepDefinition {
     }
 
     @Override
-    public void setScopeId(KapuaId scopeId) {
-        this.scopeId = scopeId;
-    }
-
-    @Override
     public String getName() {
         return name;
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
     }
 
     @Override
@@ -76,18 +66,8 @@ public abstract class JobStepDefinitionRecord implements JobStepDefinition {
     }
 
     @Override
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    @Override
     public JobStepType getStepType() {
         return stepType;
-    }
-
-    @Override
-    public void setStepType(JobStepType stepType) {
-        this.stepType = stepType;
     }
 
     @Override
@@ -96,18 +76,8 @@ public abstract class JobStepDefinitionRecord implements JobStepDefinition {
     }
 
     @Override
-    public void setReaderName(String readerName) {
-        this.readerName = readerName;
-    }
-
-    @Override
     public String getProcessorName() {
         return processorName;
-    }
-
-    @Override
-    public void setProcessorName(String processorName) {
-        this.processorName = processorName;
     }
 
     @Override
@@ -116,13 +86,8 @@ public abstract class JobStepDefinitionRecord implements JobStepDefinition {
     }
 
     @Override
-    public void setWriterName(String writerName) {
-        this.writerName = writerName;
-    }
-
-    @Override
-    public <P extends JobStepProperty> List<P> getStepProperties() {
-        return (List<P>) jobStepProperties;
+    public List<JobStepProperty> getStepProperties() {
+        return jobStepProperties;
     }
 
     @Override
@@ -193,5 +158,47 @@ public abstract class JobStepDefinitionRecord implements JobStepDefinition {
     public void setEntityProperties(Properties props) throws EntityPropertiesWriteException {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void setScopeId(KapuaId scopeId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setName(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDescription(String description) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStepType(JobStepType stepType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setReaderName(String readerName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setProcessorName(String processorName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setWriterName(String writerName) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
+    public void setStepProperties(List<JobStepProperty> jobStepProperties) {
+        throw new UnsupportedOperationException();
+    }
+
 
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionImpl.java
@@ -181,10 +181,6 @@ public class JobStepDefinitionImpl extends AbstractKapuaNamedEntity implements J
         this.writerName = writesName;
     }
 
-    public List<JobStepDefinitionPropertyImpl> getJobStepProperties() {
-        return jobStepProperties;
-    }
-
     @Override
     public List<JobStepProperty> getStepProperties() {
         if (jobStepProperties == null) {
@@ -196,18 +192,6 @@ public class JobStepDefinitionImpl extends AbstractKapuaNamedEntity implements J
                 .collect(Collectors.toList());
     }
 
-    public List<JobStepDefinitionPropertyImpl> getStepPropertiesEntitites() {
-        return jobStepProperties;
-    }
-
-    public void setStepProperties(List<JobStepProperty> jobStepProperties) {
-        this.jobStepProperties = new ArrayList<>();
-
-        for (JobStepProperty jobStepProperty : jobStepProperties) {
-            this.jobStepProperties.add(JobStepDefinitionPropertyImpl.parse(this, jobStepProperty));
-        }
-    }
-
     @Override
     public JobStepProperty getStepProperty(String name) {
         return Optional.ofNullable(getStepProperties())
@@ -216,6 +200,23 @@ public class JobStepDefinitionImpl extends AbstractKapuaNamedEntity implements J
                         .filter(jobStepProperty -> jobStepProperty.getName().equals(name))
                         .findAny())
                 .orElse(null);
+    }
+
+    @Override
+    public void setStepProperties(List<JobStepProperty> jobStepProperties) {
+        this.jobStepProperties = new ArrayList<>();
+
+        for (JobStepProperty jobStepProperty : jobStepProperties) {
+            this.jobStepProperties.add(JobStepDefinitionPropertyImpl.parse(this, jobStepProperty));
+        }
+    }
+
+    public List<JobStepDefinitionPropertyImpl> getStepPropertiesEntitites() {
+        return jobStepProperties;
+    }
+
+    public List<JobStepDefinitionPropertyImpl> getJobStepProperties() {
+        return jobStepProperties;
     }
 
     /**


### PR DESCRIPTION
This PR fixes the serialization of the JobStepDefinition via REST API.

This bug was introduced in https://github.com/eclipse/kapua/pull/3996/files#diff-192bd7bf065bc9a164960def70baba61fd6f6e4276d845a26cf82041f9bd9d5a

**Related Issue**
This PR fixes a bug introduced with #3996 

**Description of the solution adopted**
Re-introduced removed setter of `stepProperties`

**Screenshots**
_None_

**Any side note on the changes made**
JobStepDefinitionRecord setters have been modified to be UnsupportedOperations since it is a read-only entity