### PR TITLE
⬆️ Bump `logback` from `1.2.11` to `1.2.13` - `CVE-2023-6481`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <liquibase.version>3.6.3</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
-        <logback.version>1.2.11</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
+        <logback.version>1.2.13</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
         <mockito.version>1.10.19</mockito.version>
         <netty.version>4.1.100.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>


### PR DESCRIPTION
This pull request addresses `CVE-2023-6481` by updating the `logback` library to the `1.2.13` version.
The vulnerability posed a risk, and this update mitigates it effectively.