### PR TITLE
⬆️ Bump `commons-configuration2` from `2.9.0` to `2.10.1` - `CVE-2024-29131`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-configuration.version>1.9</commons-configuration.version>
-        <commons-configuration2.version>2.9.0</commons-configuration2.version>
+        <commons-configuration2.version>2.10.1</commons-configuration2.version>
         <commons-compress.version>1.24.0</commons-compress.version>
         <commons-fileupload.versison>1.5</commons-fileupload.versison>
         <commons-imaging.version>1.0-alpha3</commons-imaging.version>


### PR DESCRIPTION
This pull request addresses `CVE-2024-29131` by updating the `org.apache.commons:commons-configuration2` library to the `2.10.1` version.
The vulnerability posed a risk, and this update mitigates it effectively.