### PR TITLE
🐛 [REST API] Fixed returnNotNullEntity correctly handle null KapuaEntities

### DIFF
--- a/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/WebApplicationExceptionMapper.java
+++ b/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/WebApplicationExceptionMapper.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.rest.errors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @since 2.0.0
+ */
+@Provider
+public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WebApplicationExceptionMapper.class);
+
+    @Inject
+    public WebApplicationExceptionMapper() {
+    }
+
+    @Override
+    public Response toResponse(WebApplicationException webApplicationException) {
+        LOG.error(webApplicationException.getMessage(), webApplicationException);
+        return Response
+                .fromResponse(webApplicationException.getResponse())
+                .build();
+    }
+}

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResource.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResource.java
@@ -16,39 +16,41 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.net.URI;
 
 /**
- * @author alberto.codutti
+ * @since 1.0.0
  */
 public abstract class AbstractKapuaResource {
 
     /**
-     * Checks if the given entity is {@code null}.
-     * If it is <code>null</code> a {@link WebApplicationException} is raised.
+     * Checks if the given object is {@code null}.
+     * <p>
+     * If it is {@code null} a {@link NotFoundException} {@link WebApplicationException} is raised.
+     * <p>
+     * For {@link KapuaEntity} {@link #returnNotNullEntity(KapuaEntity, String, KapuaId)} is recommended.
+     * This is meant for generic {@link Object}s.
      *
-     * @param entity The {@link KapuaEntity} to check.
-     * @return The entity given if not <code>null</code>.
-     * @throws WebApplicationException with {@link Status#NOT_FOUND} if the entity is <code>null</code>.
-     * @deprecated Since 2.0.0. To leverage {@link ExceptionMapper}s we need to throw {@link org.eclipse.kapua.KapuaEntityNotFoundException}. Please make use of {@link #returnNotNullEntity(Object, String, KapuaId)}
-     * @throws WebApplicationException if given entity is {@code null}
+     * @param object The {@link Object} to check.
+     * @return The given {@link Object} if not {@code null}
+     * @param <T> The type of the given {@link Object}
      * @since 1.0.0
+     * @throws NotFoundException if the given {@link Object} is {@code null}
      */
-    @Deprecated
-    public <T> T returnNotNullEntity(T entity) {
-        if (entity == null) {
-            throw new WebApplicationException(Response.Status.NOT_FOUND);
+    public <T> T returnNotNullEntity(T object) {
+        if (object == null) {
+            throw new NotFoundException("Requested resource not found");
         }
-        return entity;
+
+        return object;
     }
 
     /**
      * Checks id the given {@link KapuaEntity} is {@code null}.
-     * <p>
-     * It replaces {@link #returnNotNullEntity(Object)} which was throwing {@link WebApplicationException} instead of {@link KapuaEntityNotFoundException} which is handled by {@link ExceptionMapper}s.
      *
      * @param entity The {@link KapuaEntity} to check.
      * @param entityType The {@link KapuaEntity#getType()}

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResource.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResource.java
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.core.resources;
 
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.app.api.core.model.StorableEntityId;
 import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.storable.model.id.StorableId;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -31,12 +35,36 @@ public abstract class AbstractKapuaResource {
      * @param entity The {@link KapuaEntity} to check.
      * @return The entity given if not <code>null</code>.
      * @throws WebApplicationException with {@link Status#NOT_FOUND} if the entity is <code>null</code>.
+     * @deprecated Since 2.0.0. To leverage {@link ExceptionMapper}s we need to throw {@link org.eclipse.kapua.KapuaEntityNotFoundException}. Please make use of {@link #returnNotNullEntity(Object, String, KapuaId)}
+     * @throws WebApplicationException if given entity is {@code null}
      * @since 1.0.0
      */
+    @Deprecated
     public <T> T returnNotNullEntity(T entity) {
         if (entity == null) {
             throw new WebApplicationException(Response.Status.NOT_FOUND);
         }
+        return entity;
+    }
+
+    /**
+     * Checks id the given {@link KapuaEntity} is {@code null}.
+     * <p>
+     * It replaces {@link #returnNotNullEntity(Object)} which was throwing {@link WebApplicationException} instead of {@link KapuaEntityNotFoundException} which is handled by {@link ExceptionMapper}s.
+     *
+     * @param entity The {@link KapuaEntity} to check.
+     * @param entityType The {@link KapuaEntity#getType()}
+     * @param entityId The {@link KapuaEntity#getId()}
+     * @return The given entity if not {@code null}
+     * @param <T> The {@link KapuaEntity} type.
+     * @throws KapuaEntityNotFoundException if given {@link KapuaEntity} is {@code null}.
+     * @since 2.0.0
+     */
+    public <T extends KapuaEntity> T returnNotNullEntity(T entity, String entityType, KapuaId entityId) throws KapuaEntityNotFoundException {
+        if (entity == null) {
+            throw new KapuaEntityNotFoundException(entityType, entityId);
+        }
+
         return entity;
     }
 

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResource.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResource.java
@@ -13,10 +13,8 @@
 package org.eclipse.kapua.app.api.core.resources;
 
 import org.eclipse.kapua.KapuaEntityNotFoundException;
-import org.eclipse.kapua.app.api.core.model.StorableEntityId;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.storable.model.id.StorableId;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResourceTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResourceTest.java
@@ -20,15 +20,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import javax.ws.rs.NotFoundException;
 import java.math.BigInteger;
 
 
 @Category(JUnitTests.class)
 public class AbstractKapuaResourceTest {
 
-    private class AbstractKapuaResourceImpl extends AbstractKapuaResource {
+    private class TestKapuaResource extends AbstractKapuaResource {
 
     }
 
@@ -37,7 +36,7 @@ public class AbstractKapuaResourceTest {
 
     @Before
     public void initialize() {
-        abstractKapuaResource = new AbstractKapuaResourceImpl();
+        abstractKapuaResource = new TestKapuaResource();
         objects = new Object[]{new Object(), "", "string", 10, 'c', KapuaId.ONE, new Throwable(), new ScopeId(BigInteger.valueOf(111))};
     }
 
@@ -48,14 +47,9 @@ public class AbstractKapuaResourceTest {
         }
     }
 
-    @Test
+    @Test(expected = NotFoundException.class)
     public void returnNotNullEntityNullTest() {
-        try {
-            abstractKapuaResource.returnNotNullEntity(null);
-            Assert.fail("WebApplicationException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("WebApplicationException expected.", new WebApplicationException(Response.Status.NOT_FOUND).toString(), e.toString());
-        }
+        abstractKapuaResource.returnNotNullEntity(null);
     }
 
     @Test

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessInfos.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessInfos.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -168,11 +167,7 @@ public class AccessInfos extends AbstractKapuaResource {
             @PathParam("accessInfoId") EntityId accessInfoId) throws KapuaException {
         AccessInfo accessInfo = accessInfoService.find(scopeId, accessInfoId);
 
-        if (accessInfo == null) {
-            throw new KapuaEntityNotFoundException(AccessInfo.TYPE, accessInfoId);
-        }
-
-        return accessInfo;
+        return returnNotNullEntity(accessInfo, AccessInfo.TYPE, accessInfoId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessPermissions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessPermissions.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -200,11 +199,7 @@ public class AccessPermissions extends AbstractKapuaResource {
 
         AccessPermissionListResult results = accessPermissionService.query(query);
 
-        if (results.isEmpty()) {
-            throw new KapuaEntityNotFoundException(AccessPermission.TYPE, accessPermissionId);
-        }
-
-        return results.getFirstItem();
+        return returnNotNullEntity(results.getFirstItem(), AccessPermission.TYPE, accessPermissionId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessRoles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessRoles.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -179,11 +178,7 @@ public class AccessRoles extends AbstractKapuaResource {
 
         AccessRoleListResult results = accessRoleService.query(query);
 
-        if (results.isEmpty()) {
-            throw new KapuaEntityNotFoundException(AccessRole.TYPE, accessRoleId);
-        }
-
-        return results.getFirstItem();
+        return returnNotNullEntity(results.getFirstItem(), AccessRole.TYPE, accessRoleId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Account.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Account.java
@@ -23,7 +23,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
@@ -62,11 +61,7 @@ public class Account extends AbstractKapuaResource {
             @PathParam("accountId") EntityId accountId) throws KapuaException {
         org.eclipse.kapua.service.account.Account account = accountService.find(accountId);
 
-        if (account == null) {
-            throw new KapuaEntityNotFoundException(org.eclipse.kapua.service.account.Account.TYPE, accountId);
-        }
-
-        return account;
+        return returnNotNullEntity(account, org.eclipse.kapua.service.account.Account.TYPE, accountId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Credentials.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Credentials.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -163,11 +162,7 @@ public class Credentials extends AbstractKapuaResource {
             @PathParam("credentialId") EntityId credentialId) throws KapuaException {
         Credential credential = credentialService.find(scopeId, credentialId);
 
-        if (credential == null) {
-            throw new KapuaEntityNotFoundException(Credential.TYPE, credentialId);
-        }
-
-        return credential;
+        return returnNotNullEntity(credential, Credential.TYPE, credentialId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnectionOptions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnectionOptions.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
@@ -53,12 +52,7 @@ public class DeviceConnectionOptions extends AbstractKapuaResource {
             @PathParam("connectionId") EntityId connectionId) throws KapuaException {
         DeviceConnectionOption deviceConnectionOptions = deviceConnectionOptionsService.find(scopeId, connectionId);
 
-        if (deviceConnectionOptions != null) {
-            return deviceConnectionOptions;
-        } else {
-            throw new KapuaEntityNotFoundException(DeviceConnectionOption.TYPE, connectionId);
-        }
-
+        return returnNotNullEntity(deviceConnectionOptions, DeviceConnectionOption.TYPE, connectionId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnections.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnections.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -155,11 +154,7 @@ public class DeviceConnections extends AbstractKapuaResource {
             @PathParam("deviceConnectionId") EntityId deviceConnectionId) throws KapuaException {
         DeviceConnection deviceConnection = deviceConnectionService.find(scopeId, deviceConnectionId);
 
-        if (deviceConnection != null) {
-            return deviceConnection;
-        } else {
-            throw new KapuaEntityNotFoundException(DeviceConnection.TYPE, deviceConnectionId);
-        }
+        return returnNotNullEntity(deviceConnection, DeviceConnection.TYPE, deviceConnectionId);
     }
 
     @GET

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceEvents.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceEvents.java
@@ -214,11 +214,7 @@ public class DeviceEvents extends AbstractKapuaResource {
 
         DeviceEventListResult results = deviceEventService.query(query);
 
-        if (!results.isEmpty()) {
-            return results.getFirstItem();
-        } else {
-            throw new KapuaEntityNotFoundException(DeviceEvent.TYPE, deviceEventId);
-        }
+        return returnNotNullEntity(results.getFirstItem(), DeviceEvent.TYPE, deviceEventId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperationNotifications.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperationNotifications.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -173,11 +172,7 @@ public class DeviceManagementOperationNotifications extends AbstractKapuaResourc
 
         ManagementOperationNotificationListResult results = managementOperationNotificationService.query(query);
 
-        if (!results.isEmpty()) {
-            return results.getFirstItem();
-        } else {
-            throw new KapuaEntityNotFoundException(ManagementOperationNotification.TYPE, managementOperationNotificationId);
-        }
+        return returnNotNullEntity(results.getFirstItem(), ManagementOperationNotification.TYPE, managementOperationNotificationId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperations.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -169,11 +168,7 @@ public class DeviceManagementOperations extends AbstractKapuaResource {
 
         DeviceManagementOperationListResult results = deviceManagementOperationRegistryService.query(query);
 
-        if (!results.isEmpty()) {
-            return results.getFirstItem();
-        } else {
-            throw new KapuaEntityNotFoundException(DeviceManagementOperation.TYPE, deviceManagementOperationId);
-        }
+        return returnNotNullEntity(results.getFirstItem(), DeviceManagementOperation.TYPE, deviceManagementOperationId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Devices.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Devices.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -196,11 +195,7 @@ public class Devices extends AbstractKapuaResource {
             @PathParam("deviceId") EntityId deviceId) throws KapuaException {
         Device device = deviceService.find(scopeId, deviceId);
 
-        if (device != null) {
-            return device;
-        } else {
-            throw new KapuaEntityNotFoundException(Device.TYPE, deviceId);
-        }
+        return returnNotNullEntity(device, Device.TYPE, deviceId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Domains.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Domains.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -134,10 +133,6 @@ public class Domains extends AbstractKapuaResource {
             @PathParam("domainId") EntityId domainId) throws KapuaException {
         Domain domain = domainRegistryService.find(scopeId, domainId);
 
-        if (domain == null) {
-            throw new KapuaEntityNotFoundException(Domain.TYPE, domainId);
-        }
-
-        return domain;
+        return returnNotNullEntity(domain, Domain.TYPE, domainId);
     }
 }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -171,11 +170,7 @@ public class EndpointInfos extends AbstractKapuaResource {
             @PathParam("endpointInfoId") EntityId endpointInfoId) throws KapuaException {
         EndpointInfo endpointInfo = endpointInfoService.find(scopeId, endpointInfoId);
 
-        if (endpointInfo == null) {
-            throw new KapuaEntityNotFoundException(EndpointInfo.TYPE, endpointInfoId);
-        }
-
-        return endpointInfo;
+        return returnNotNullEntity(endpointInfo,EndpointInfo.TYPE, endpointInfoId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Groups.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Groups.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -161,11 +160,7 @@ public class Groups extends AbstractKapuaResource {
             @PathParam("groupId") EntityId groupId) throws KapuaException {
         Group group = groupService.find(scopeId, groupId);
 
-        if (group == null) {
-            throw new KapuaEntityNotFoundException(Group.TYPE, groupId);
-        }
-
-        return group;
+        return returnNotNullEntity(group, Group.TYPE, groupId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
@@ -24,7 +24,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.DateParam;
@@ -185,11 +184,7 @@ public class JobExecutions extends AbstractKapuaResource {
         jobExecutionQuery.setLimit(1);
         JobExecutionListResult jobExecutionListResult = jobExecutionService.query(jobExecutionQuery);
 
-        if (jobExecutionListResult.isEmpty()) {
-            throw new KapuaEntityNotFoundException(JobExecution.TYPE, executionId);
-        }
-
-        return jobExecutionListResult.getFirstItem();
+        return returnNotNullEntity(jobExecutionListResult.getFirstItem(), JobExecution.TYPE, executionId);
     }
 
     @GET

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTargets.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTargets.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -181,11 +180,7 @@ public class JobTargets extends AbstractKapuaResource {
         jobTargetQuery.setLimit(1);
         JobTargetListResult jobTargetListResult = jobTargetService.query(jobTargetQuery);
 
-        if (jobTargetListResult.isEmpty()) {
-            throw new KapuaEntityNotFoundException(JobTarget.TYPE, targetId);
-        }
-
-        return jobTargetListResult.getFirstItem();
+        return returnNotNullEntity(jobTargetListResult.getFirstItem(), JobTarget.TYPE, targetId);
     }
 
     @GET

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTriggers.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTriggers.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -186,11 +185,7 @@ public class JobTriggers extends AbstractKapuaResource {
         triggerQuery.setLimit(1);
         TriggerListResult triggerListResult = triggerService.query(triggerQuery);
 
-        if (triggerListResult.isEmpty()) {
-            throw new KapuaEntityNotFoundException(Trigger.TYPE, triggerId);
-        }
-
-        return triggerListResult.getFirstItem();
+        return returnNotNullEntity(triggerListResult.getFirstItem(), Trigger.TYPE, triggerId);
     }
 
     private AndPredicate returnJobIdPredicate(KapuaId jobId, TriggerQuery query) {

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -158,11 +157,7 @@ public class Jobs extends AbstractKapuaResource {
             @PathParam("jobId") EntityId jobId) throws KapuaException {
         Job job = jobService.find(scopeId, jobId);
 
-        if (job == null) {
-            throw new KapuaEntityNotFoundException(Job.TYPE, jobId);
-        }
-
-        return job;
+        return returnNotNullEntity(job, Job.TYPE, jobId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Roles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Roles.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -178,11 +177,7 @@ public class Roles extends AbstractKapuaResource {
             @PathParam("roleId") EntityId roleId) throws KapuaException {
         Role role = roleService.find(scopeId, roleId);
 
-        if (role == null) {
-            throw new KapuaEntityNotFoundException(Role.TYPE, roleId);
-        }
-
-        return role;
+        return returnNotNullEntity(role, Role.TYPE, roleId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/RolesPermissions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/RolesPermissions.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -211,11 +210,7 @@ public class RolesPermissions extends AbstractKapuaResource {
 
         RolePermissionListResult results = rolePermissionService.query(query);
 
-        if (results.isEmpty()) {
-            throw new KapuaEntityNotFoundException(RolePermission.TYPE, rolePermissionId);
-        }
-
-        return results.getFirstItem();
+        return returnNotNullEntity(results.getFirstItem(), RolePermission.TYPE, rolePermissionId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Tags.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Tags.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -168,11 +167,7 @@ public class Tags extends AbstractKapuaResource {
             @PathParam("tagId") EntityId tagId) throws KapuaException {
         Tag tag = tagService.find(scopeId, tagId);
 
-        if (tag == null) {
-            throw new KapuaEntityNotFoundException(Tag.TYPE, tagId);
-        }
-
-        return tag;
+        return returnNotNullEntity(tag, Tag.TYPE, tagId);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
 import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
@@ -180,11 +179,7 @@ public class Users extends AbstractKapuaResource {
             @PathParam("userId") EntityId userId) throws KapuaException {
         User user = userService.find(scopeId, userId);
 
-        if (user == null) {
-            throw new KapuaEntityNotFoundException(User.TYPE, userId);
-        }
-
-        return user;
+        return returnNotNullEntity(user, User.TYPE, userId);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the implementation of `AbstractKapuaResource.returnNotNullEntity(Object)` to correctly produce a 404 HTTP error.

**Related Issue**
_None_

**Description of the solution adopted**
Fixed the thrown exception and added a new method to properly report a KapuaEntityNotFound exception when entity is `null`

**Screenshots**
_None_

**Any side note on the changes made**
_None_