### PR TITLE
:fix: when mapping between strings, consider empty strings as null

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/mappers/KapuaBaseMapper.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/mappers/KapuaBaseMapper.java
@@ -70,7 +70,7 @@ public interface KapuaBaseMapper {
     }
 
     default String map(String value) {
-        return Optional.ofNullable(value).map(String::trim).orElse(null);
+        return Optional.ofNullable(value).map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
     }
 
     default String map(int value) {


### PR DESCRIPTION
As per description.