### PR TITLE
:bug: [REST API] Fixed DeviceNotConnectedException mapped HTTP error code to be 400

### DIFF
--- a/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/DeviceNotConnectedExceptionMapper.java
+++ b/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/DeviceNotConnectedExceptionMapper.java
@@ -40,7 +40,7 @@ public class DeviceNotConnectedExceptionMapper implements ExceptionMapper<Device
         LOG.error(managementRequestContentException.getMessage(), managementRequestContentException);
 
         return Response
-                .status(Status.INTERNAL_SERVER_ERROR)
+                .status(Status.BAD_REQUEST)
                 .entity(new DeviceNotConnectedExceptionInfo(managementRequestContentException, showStackTrace))
                 .build();
     }

--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/DeviceNotConnectedExceptionInfo.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/DeviceNotConnectedExceptionInfo.java
@@ -50,7 +50,7 @@ public class DeviceNotConnectedExceptionInfo extends ExceptionInfo {
      * @since 1.0.0
      */
     public DeviceNotConnectedExceptionInfo(DeviceNotConnectedException deviceNotConnectedException, boolean showStackTrace) {
-        super(500/*Response.Status.INTERNAL_SERVER_ERROR*/, deviceNotConnectedException, showStackTrace);
+        super(400/*Response.Status.BAD_REQUEST*/, deviceNotConnectedException, showStackTrace);
 
         this.deviceId = deviceNotConnectedException.getDeviceId();
         this.connectionStatus = deviceNotConnectedException.getCurrentConnectionStatus();


### PR DESCRIPTION
This PR changes the DeviceNotConnectedException REST HTTP error code from 500 to 400

**Related Issue**
_None_

**Description of the solution adopted**
Changed HTTP error code

**Screenshots**
_None_

**Any side note on the changes made**
_None_