### PR TITLE
:bug: Fixed HTTP error code for DeviceNotConnectedException from 400 to 409

### DIFF
--- a/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/DeviceNotConnectedExceptionMapper.java
+++ b/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/DeviceNotConnectedExceptionMapper.java
@@ -40,7 +40,7 @@ public class DeviceNotConnectedExceptionMapper implements ExceptionMapper<Device
         LOG.error(managementRequestContentException.getMessage(), managementRequestContentException);
 
         return Response
-                .status(Status.BAD_REQUEST)
+                .status(Status.CONFLICT)
                 .entity(new DeviceNotConnectedExceptionInfo(managementRequestContentException, showStackTrace))
                 .build();
     }

--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/DeviceNotConnectedExceptionInfo.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/DeviceNotConnectedExceptionInfo.java
@@ -50,7 +50,7 @@ public class DeviceNotConnectedExceptionInfo extends ExceptionInfo {
      * @since 1.0.0
      */
     public DeviceNotConnectedExceptionInfo(DeviceNotConnectedException deviceNotConnectedException, boolean showStackTrace) {
-        super(400/*Response.Status.BAD_REQUEST*/, deviceNotConnectedException, showStackTrace);
+        super(409/*Response.Status.CONFLICT*/, deviceNotConnectedException, showStackTrace);
 
         this.deviceId = deviceNotConnectedException.getDeviceId();
         this.connectionStatus = deviceNotConnectedException.getCurrentConnectionStatus();


### PR DESCRIPTION
This PR changes the HTTP error code from 400 to 409.
This is an additional change to PR https://github.com/eclipse/kapua/pull/4047 and it returns a more appropriate HTTP error code.

**Related Issue**
Additional fixes to PR https://github.com/eclipse/kapua/pull/4047

**Description of the solution adopted**
Changed the HTTP Error code

**Screenshots**
_None_

**Any side note on the changes made**
_None_