### PR TITLE
Fix default value handling during job step creation

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -14,10 +14,10 @@ package org.eclipse.kapua.service.job.step.internal;
 
 import java.util.List;
 import java.util.regex.Pattern;
-
 import javax.inject.Singleton;
 import javax.xml.bind.DatatypeConverter;
 
+import com.google.common.base.Strings;
 import org.eclipse.kapua.KapuaDuplicateNameException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
@@ -56,8 +56,6 @@ import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 import org.eclipse.kapua.storage.TxContext;
 import org.eclipse.kapua.storage.TxManager;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Strings;
 
 /**
  * {@link JobStepService} implementation.
@@ -421,11 +419,13 @@ public class JobStepServiceImpl implements JobStepService {
                         ArgumentValidator.notNull(jobStepProperty.getPropertyValue(), "stepProperties[]." + jobStepProperty.getName());
                     }
 
-                    ArgumentValidator.areEqual(jobStepProperty.getPropertyType(), jobStepDefinitionProperty.getPropertyType(), "stepProperties[]." + jobStepProperty.getName());
-                    ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepDefinitionProperty.getMinLength(), jobStepDefinitionProperty.getMaxLength(),
-                            "stepProperties[]." + jobStepProperty.getName());
+                    if (jobStepProperty.getPropertyValue() != null) {
+                        ArgumentValidator.areEqual(jobStepProperty.getPropertyType(), jobStepDefinitionProperty.getPropertyType(), "stepProperties[]." + jobStepProperty.getName());
+                        ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepDefinitionProperty.getMinLength(), jobStepDefinitionProperty.getMaxLength(),
+                                                      "stepProperties[]." + jobStepProperty.getName());
 
-                    validateJobStepPropertyValue(jobStepProperty, jobStepDefinitionProperty);
+                        validateJobStepPropertyValue(jobStepProperty, jobStepDefinitionProperty);
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description
This pull request addresses the issue where job step creation does not handle default values correctly. For example, when creating a job step with command execution, if only the `commandInput` parameter is set and the `timeout` parameter is left as default, the submission would fail due to the `timeout` not being set.

# Steps to Reproduce
1. Create a Job.
2. Create a Job Step with Command Execution.
3. Try to submit it by setting only the `commandInput` parameter and leaving `timeout` as default.
4. Submit.

# Current Behavior
On submission, there is an error due to the `timeout` not being set.

# Expected Behavior
Job step creation should succeed. The `JobStepProperties` in `JobStepDefinition` with a `propertyValue` should be used as a default value for the `JobStepProperties` in `JobStepCreator` that haven’t been passed from the user.
