### PR TITLE
:arrow_up: [Docker] Bumped version of docker-maven-plugin to 0.44.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
         <checkstyle.version>7.6.1</checkstyle.version>
         <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
-        <docker-maven-plugin.version>0.40.2</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <eclipse-lifecycle-mapping.version>1.0.0</eclipse-lifecycle-mapping.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <jacoco.version>0.8.8</jacoco.version>


### PR DESCRIPTION
This PR bumps the version of `docker-maven-plugin` from `0.40.2` to `0.44.0`

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version of the `docker-maven-plugin` to the latest available

**Screenshots**
_None_

**Any side note on the changes made**
This PR has been lead to fix issue on `release-1.6.x` and `release-1.7.x` branches which are running on `0.24.0` which is no longer compatible with current Docker. 
Error shown with `0.24.0`:
```
[INFO] --- docker:0.24.0:build (build) @ kapua-assembly-java-base ---
[ERROR] DOCKER> Unable to check image [centos:7] : {"message":"client version 1.18 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version"} (Bad Request: 400) [{"message":"client version 1.18 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version"} (Bad Request: 400)]
`