### PR TITLE
FIX - Incorrect exceptions on some wrong MFA login attempts

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
@@ -314,11 +314,12 @@ public class MfaOptionServiceImpl implements MfaOptionService {
             return false;
         });
         if (!res) {
-            if (tokenAuthenticationCode != null || tokenTrustKey != null) {
+            if ( (tokenAuthenticationCode != null && !tokenAuthenticationCode.isEmpty()) || (tokenTrustKey != null && !tokenTrustKey.isEmpty())) {
                 throw new IncorrectCredentialsException();
             }
             // In case both the authenticationCode and the trustKey are null, the MFA login via Rest API must be triggered.
             // Since this method only returns true or false, the MFA request via Rest API is handled through exceptions.
+            // It could also be the case that tokens are not null but empty, in this case we throw same exception...
             throw new MfaRequiredException();
         }
         return res;
@@ -326,7 +327,7 @@ public class MfaOptionServiceImpl implements MfaOptionService {
 
     private Boolean validateFromTrustKey(TxContext tx, MfaOption mfaOption, String tokenTrustKey) throws KapuaAuthenticationException {
         // Check trust machine authentication on the server side
-        if (mfaOption.getTrustKey() == null) {
+        if (mfaOption.getTrustKey() == null || tokenTrustKey.isEmpty()) {
             return false;
         }
         Date now = new Date(System.currentTimeMillis());
@@ -345,6 +346,9 @@ public class MfaOptionServiceImpl implements MfaOptionService {
     private Boolean validateFromTokenAuthenticationCode(TxContext tx, KapuaId scopeId, MfaOption mfaOption, String tokenAuthenticationCode) throws KapuaAuthenticationException {
         // Do MFA match
         try {
+            if (tokenAuthenticationCode.isEmpty()) { //Token is not a numeric value and it's empty, so for sure validation is false even considering scratch codes
+                return false;
+            }
             final int numberToken = Integer.parseInt(tokenAuthenticationCode);
             boolean isCodeValid = mfaAuthenticator.authorize(mfaOption.getMfaSecretKey(), numberToken);
             if (isCodeValid) {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
 
 import org.apache.commons.lang.time.DateUtils;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.shiro.authc.IncorrectCredentialsException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.domains.Domains;
@@ -313,6 +314,9 @@ public class MfaOptionServiceImpl implements MfaOptionService {
             return false;
         });
         if (!res) {
+            if (tokenAuthenticationCode != null || tokenTrustKey != null) {
+                throw new IncorrectCredentialsException();
+            }
             // In case both the authenticationCode and the trustKey are null, the MFA login via Rest API must be triggered.
             // Since this method only returns true or false, the MFA request via Rest API is handled through exceptions.
             throw new MfaRequiredException();


### PR DESCRIPTION
Before this PR, these 2 behaviors were in place:

1. If you perform a /user login with`authenticationCode` as an empty String, we are throwing an Internal error which results in a HTTP 500 response. 
2. Currently we are reurning MfaRequiredException if a user has MfaOption enabled and does not provide the authenticationCode upon REST API /user login, which is correct. The problem is that we are returning the same error when the authenticationCode is provided but is wrong.

**Description of the solution adopted**
I changed the first behaviour returning a MfaRequiredException and the second one an IncorrectCredentialsException, which is an example of AuthenticationException, the same exception that we throw when we provide wrong username & pw for a user login attempt

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
