### PR TITLE
:sparkles: [Messaging] Introduced configuration to optionally skip Device.id resolution for KapuaDataMessage

### DIFF
--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/KapuaKuraTranslatorsModule.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/KapuaKuraTranslatorsModule.java
@@ -64,6 +64,7 @@ import org.eclipse.kapua.translator.kura.kapua.keystore.TranslatorAppKeystoreIte
 import org.eclipse.kapua.translator.kura.kapua.keystore.TranslatorAppKeystoreItemsKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.keystore.TranslatorAppKeystoreNoContentKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.keystore.TranslatorAppKeystoresKuraKapua;
+import org.eclipse.kapua.translator.setting.TranslatorKapuaKuraSettings;
 
 public class KapuaKuraTranslatorsModule extends AbstractKapuaModule {
     @Override
@@ -122,6 +123,7 @@ public class KapuaKuraTranslatorsModule extends AbstractKapuaModule {
                 .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL));
 
+        bind(TranslatorKapuaKuraSettings.class).in(Singleton.class);
     }
 
     @Provides

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/setting/TranslatorKapuaKuraSettingKeys.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/setting/TranslatorKapuaKuraSettingKeys.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.setting;
+
+import org.eclipse.kapua.commons.setting.SettingKey;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
+import org.eclipse.kapua.service.device.registry.Device;
+
+/**
+ * {@link SettingKey}s for {@link TranslatorKapuaKuraSettings}
+ *
+ * @since 2.1.0
+ */
+public enum TranslatorKapuaKuraSettingKeys implements SettingKey {
+
+    /**
+     * Whether to resolve the {@link Device#getId()} from the {@link KuraChannel#getClientId()} when converting from {@link KuraDataMessage} to {@link KapuaDataMessage}.
+     *
+     * @since 2.1.0
+     */
+    TRANSLATOR_KURA_KAPUA_DATA_DEVICE_ID_RESOLVE("translator.kura.kapua.data.deviceId.resolve");
+
+    /**
+     * The key value of the {@link SettingKey}.
+     *
+     * @since 2.1.0
+     */
+    private final String key;
+
+    /**
+     * Constructor.
+     *
+     * @param key The key value of the {@link SettingKey}.
+     * @since 2.1.0
+     */
+    TranslatorKapuaKuraSettingKeys(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/setting/TranslatorKapuaKuraSettings.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/setting/TranslatorKapuaKuraSettings.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.setting;
+
+import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+
+/**
+ * {@link TranslatorKapuaKuraSettings} for {@code kapua-translator-kapua-kura} module.
+ *
+ * @see AbstractKapuaSetting
+ * @since 2.1.0
+ */
+public class TranslatorKapuaKuraSettings extends AbstractKapuaSetting<TranslatorKapuaKuraSettingKeys> {
+
+    /**
+     * Setting filename.
+     *
+     * @since 2.1.0
+     */
+    private static final String TRANSLATOR_KAPUA_KURA_SETTING_RESOURCE = "translator-kapua-kura-settings.properties";
+
+    /**
+     * Constructor.
+     *
+     * @since 2.1.0
+     */
+    public TranslatorKapuaKuraSettings() {
+        super(TRANSLATOR_KAPUA_KURA_SETTING_RESOURCE);
+    }
+}

--- a/translator/kapua/kura/src/main/resources/translator-kapua-kura-settings.properties
+++ b/translator/kapua/kura/src/main/resources/translator-kapua-kura-settings.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+translator.kura.kapua.data.deviceId.resolve=true


### PR DESCRIPTION
This PR intrduces a new Setting for KapuaKuraDataTranslator to skip optionally the `Device.id` resolution form the `DataChannel.clientId`

**Related Issue**
_None_

**Description of the solution adopted**
Added a new Setting to control whether the Device.id resolution will be performed or not.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
This can improve performances in certain scenarios