### PR TITLE
:fix: ScopeId bypass fix

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Account.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Account.java
@@ -38,7 +38,7 @@ accidentally exposed under:
 Where the scopeId has no meaning when dealing with a specific account
 Remove the match with /{scopeId}/... in the next release
  */
-@Path("{scopeId: (\\w+)?}{path:|/}accounts/{accountId}")
+@Path("{scopeId: ([\\w-]+)?}{path:|/}accounts/{accountId}")
 public class Account extends AbstractKapuaResource {
 
     @Inject

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserCredentials.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserCredentials.java
@@ -37,7 +37,7 @@ import javax.ws.rs.core.MediaType;
  Where the scopeId has no meaning of the current user (the one from the session will always be used)
  Remove the match with /{scopeId}/... in the next release
  */
-@Path("{scopeId: (\\w+)?}{path:|/}user/credentials")
+@Path("{scopeId: ([\\w-]+)?}{path:|/}user/credentials")
 public class UserCredentials extends AbstractKapuaResource {
 
     @Inject

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserProfiles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/UserProfiles.java
@@ -33,7 +33,7 @@ import javax.ws.rs.core.Response;
  Where the scopeId has no meaning of the current user (the one from the session will always be used)
  Remove the match with /{scopeId}/... in the next release
  */
-@Path("{scopeId: (\\w+)?}{path:|/}user/profile")
+@Path("{scopeId: ([\\w-]+)?}{path:|/}user/profile")
 public class UserProfiles extends AbstractKapuaResource {
 
     @Inject


### PR DESCRIPTION
A scopeId can contain dashes. On some rest endpoints, to maintain the legacy (deprecated) representation that  accepted (and then ignored) the scopeId as the first part of the url, the regex \w+ has been used - however that covers MOST of the characters that can appear in a ScopeId, _except_ the dash. This pr fixes that.