### PR TITLE
Fix NPE in `ServiceConfigurations` resource by handling missing `Account`

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/ServiceConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/ServiceConfigurations.java
@@ -12,6 +12,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
@@ -25,21 +41,6 @@ import org.eclipse.kapua.service.config.KapuaConfigurableService;
 import org.eclipse.kapua.service.config.ServiceComponentConfiguration;
 import org.eclipse.kapua.service.config.ServiceConfiguration;
 import org.eclipse.kapua.service.config.ServiceConfigurationFactory;
-
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Path("{scopeId}/serviceConfigurations")
 public class ServiceConfigurations extends AbstractKapuaResource {
@@ -84,6 +85,9 @@ public class ServiceConfigurations extends AbstractKapuaResource {
             if (KapuaConfigurableService.class.isAssignableFrom(configurableServiceClass)) {
                 KapuaConfigurableService configurableService = (KapuaConfigurableService) locator.getService(configurableServiceClass);
                 Account account = accountService.find(scopeId);
+                if (account == null) {
+                    throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
+                }
                 configurableService.setConfigValues(scopeId, account.getScopeId(), serviceComponentConfiguration.getProperties());
             }
         }
@@ -126,6 +130,9 @@ public class ServiceConfigurations extends AbstractKapuaResource {
         if (KapuaConfigurableService.class.isAssignableFrom(configurableServiceClass)) {
             KapuaConfigurableService configurableService = (KapuaConfigurableService) locator.getService(configurableServiceClass);
             Account account = accountService.find(scopeId);
+            if (account == null) {
+                throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
+            }
             configurableService.setConfigValues(scopeId, account.getScopeId(), serviceComponentConfiguration.getProperties());
         }
         return Response.noContent().build();

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/ServiceConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/ServiceConfigurations.java
@@ -80,14 +80,14 @@ public class ServiceConfigurations extends AbstractKapuaResource {
             @PathParam("scopeId") ScopeId scopeId,
             ServiceConfiguration serviceConfiguration
     ) throws KapuaException, ClassNotFoundException {
+        Account account = accountService.find(scopeId);
+        if (account == null) {
+            throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
+        }
         for (ServiceComponentConfiguration serviceComponentConfiguration : serviceConfiguration.getComponentConfigurations()) {
             Class<KapuaService> configurableServiceClass = (Class<KapuaService>) Class.forName(serviceComponentConfiguration.getId()).asSubclass(KapuaService.class);
             if (KapuaConfigurableService.class.isAssignableFrom(configurableServiceClass)) {
                 KapuaConfigurableService configurableService = (KapuaConfigurableService) locator.getService(configurableServiceClass);
-                Account account = accountService.find(scopeId);
-                if (account == null) {
-                    throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
-                }
                 configurableService.setConfigValues(scopeId, account.getScopeId(), serviceComponentConfiguration.getProperties());
             }
         }
@@ -126,13 +126,13 @@ public class ServiceConfigurations extends AbstractKapuaResource {
             @PathParam("serviceId") String serviceId,
             ServiceComponentConfiguration serviceComponentConfiguration
     ) throws KapuaException, ClassNotFoundException {
+        Account account = accountService.find(scopeId);
+        if (account == null) {
+            throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
+        }
         Class<KapuaService> configurableServiceClass = (Class<KapuaService>) Class.forName(serviceId).asSubclass(KapuaService.class);
         if (KapuaConfigurableService.class.isAssignableFrom(configurableServiceClass)) {
             KapuaConfigurableService configurableService = (KapuaConfigurableService) locator.getService(configurableServiceClass);
-            Account account = accountService.find(scopeId);
-            if (account == null) {
-                throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
-            }
             configurableService.setConfigValues(scopeId, account.getScopeId(), serviceComponentConfiguration.getProperties());
         }
         return Response.noContent().build();


### PR DESCRIPTION
### Description
This pull request addresses a potential `NullPointerException` (NPE) in the `ServiceConfigurations` resource of the Kapua REST API. The issue arises when the `scopeId` provided does not match any existing account.

### Details
Currently, the `ServiceConfigurations` resource performs the following operation:
```java
Account account = accountService.find(scopeId);
configurableService.setConfigValues(scopeId, account.getScopeId(), serviceComponentConfiguration.getProperties());
```
If the `accountService.find(scopeId)` method returns `null`, attempting to call `account.getScopeId()` will result in a `NullPointerException`.

The problem occurs specifically with the following calls:
- `PUT v1/{non-existing-scope-id}/serviceConfigurations`
- `PUT v1/{non-existing-scope-id}/serviceConfigurations/{dummy-component-id}`

### Changes
- Added a check to see if `accountService.find(scopeId)` returns `null`.
- Throw `KapuaEntityNotFoundException` if the account is not found for the given `scopeId`.