### PR TITLE
:bug: [REST API] MetricType unmarshalling in APIs

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -91,15 +91,15 @@ public class DataMessages extends AbstractKapuaResource {
                                                                    @QueryParam("startDate") DateParam startDateParam,
                                                                    @QueryParam("endDate") DateParam endDateParam,
                                                                    @QueryParam("metricName") String metricName,
-                                                                   @QueryParam("metricType") MetricType<V> metricType,
+                                                                   @QueryParam("metricType") String metricType,
                                                                    @QueryParam("metricMin") String metricMinValue,
                                                                    @QueryParam("metricMax") String metricMaxValue,
                                                                    @QueryParam("sortDir") @DefaultValue("DESC") SortDirection sortDir,
                                                                    @QueryParam("offset") @DefaultValue("0") int offset,
                                                                    @QueryParam("limit") @DefaultValue("50") int limit)
             throws KapuaException {
-
-        MessageQuery query = parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientId, channel, strictChannel, startDateParam, endDateParam, metricName, metricType, metricMinValue, metricMaxValue, sortDir, offset, limit);
+        MetricType<V> internalMetricType = new MetricType<>(metricType);
+        MessageQuery query = parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientId, channel, strictChannel, startDateParam, endDateParam, metricName, internalMetricType, metricMinValue, metricMaxValue, sortDir, offset, limit);
 
         return query(scopeId, query);
     }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -93,14 +93,15 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
                                                                            @QueryParam("startDate") DateParam startDateParam,
                                                                            @QueryParam("endDate") DateParam endDateParam,
                                                                            @QueryParam("metricName") String metricName,
-                                                                           @QueryParam("metricType") MetricType<V> metricType,
+                                                                           @QueryParam("metricType") String metricType,
                                                                            @QueryParam("metricMin") String metricMinValue,
                                                                            @QueryParam("metricMax") String metricMaxValue,
                                                                            @QueryParam("sortDir") @DefaultValue("DESC") SortDirection sortDir,
                                                                            @QueryParam("offset") @DefaultValue("0") int offset,
                                                                            @QueryParam("limit") @DefaultValue("50") int limit)
             throws KapuaException {
-        MessageQuery query = DataMessages.parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientId, channel, strictChannel, startDateParam, endDateParam, metricName, metricType, metricMinValue, metricMaxValue, sortDir, offset, limit);
+        MetricType<V> internalMetricType = new MetricType<>(metricType);
+        MessageQuery query = DataMessages.parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientId, channel, strictChannel, startDateParam, endDateParam, metricName, internalMetricType , metricMinValue, metricMaxValue, sortDir, offset, limit);
         query.setScopeId(scopeId);
         final MessageListResult result = messageStoreService.query(query);
 


### PR DESCRIPTION
Brief description of the PR.
Some rest api methods accept query parameters of types MetricType, however a log at container startup warns that jersey does not know how to unmarshal them. I wanted to resolve this warning

**Description of the solution adopted**
I simply decided to change the MetricType QueryParam into a simple String, that is then parsed inside the method into the actual MetricType. In this way jersey doesn't complain 
