### PR TITLE
:bug: Avoid multiple GuiceLocator instances, and handle potential multiple KapuaMessageListeners

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ArtemisSecurityModule.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ArtemisSecurityModule.java
@@ -12,14 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.artemis.plugin.security;
 
-import com.google.inject.Provides;
+import java.util.UUID;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.jms.JMSException;
+
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.broker.artemis.plugin.security.context.SecurityContext;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.LoginMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSetting;
 import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSettingKey;
-import org.eclipse.kapua.client.security.MessageListener;
+import org.eclipse.kapua.client.security.KapuaMessageListener;
 import org.eclipse.kapua.client.security.ServiceClient;
 import org.eclipse.kapua.client.security.ServiceClientMessagingImpl;
 import org.eclipse.kapua.client.security.amqpclient.Client;
@@ -28,12 +33,10 @@ import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-import javax.jms.JMSException;
-import java.util.UUID;
+import com.google.inject.Provides;
 
 public class ArtemisSecurityModule extends AbstractKapuaModule {
+
     @Override
     protected void configureModule() {
         bind(ServerContext.class).in(Singleton.class);
@@ -46,9 +49,9 @@ public class ArtemisSecurityModule extends AbstractKapuaModule {
     @Provides
     @Singleton
     SecurityContext securityContext(LoginMetric loginMetric,
-                                    BrokerSetting brokerSettings,
-                                    MetricsSecurityPlugin metricsSecurityPlugin,
-                                    RunWithLock runWithLock) {
+            BrokerSetting brokerSettings,
+            MetricsSecurityPlugin metricsSecurityPlugin,
+            RunWithLock runWithLock) {
         return new SecurityContext(loginMetric,
                 brokerSettings.getBoolean(BrokerSettingKey.PRINT_SECURITY_CONTEXT_REPORT, false),
                 new LocalCache<>(
@@ -74,14 +77,14 @@ public class ArtemisSecurityModule extends AbstractKapuaModule {
     @Singleton
     @Provides
     ServiceClient authServiceClient(
-            MessageListener messageListener,
+            KapuaMessageListener messageListener,
             @Named("clusterName") String clusterName,
             @Named("brokerHost") String brokerHost,
             SystemSetting systemSetting) {
         return new ServiceClientMessagingImpl(messageListener, buildClient(systemSetting, clusterName, brokerHost, messageListener));
     }
 
-    public Client buildClient(SystemSetting systemSetting, String clusterName, String brokerHost, MessageListener messageListener) {
+    public Client buildClient(SystemSetting systemSetting, String clusterName, String brokerHost, KapuaMessageListener messageListener) {
         //TODO change configuration (use service event broker for now)
         String clientId = "svc-ath-" + UUID.randomUUID().toString();
         String host = systemSetting.getString(SystemSettingKey.SERVICE_BUS_HOST, "events-broker");

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/ClientSecurityModule.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/ClientSecurityModule.java
@@ -12,18 +12,26 @@
  *******************************************************************************/
 package org.eclipse.kapua.client.security;
 
+import javax.inject.Singleton;
+
 import org.eclipse.kapua.client.security.metric.AuthLoginMetricFactory;
 import org.eclipse.kapua.client.security.metric.AuthMetric;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 
-import javax.inject.Singleton;
+import com.google.inject.Provides;
 
 public class ClientSecurityModule extends AbstractKapuaModule {
+
     @Override
     protected void configureModule() {
         bind(MetricsClientSecurity.class).in(Singleton.class);
-        bind(MessageListener.class).in(Singleton.class);
         bind(AuthMetric.class).in(Singleton.class);
         bind(AuthLoginMetricFactory.class).in(Singleton.class);
+    }
+
+    @Provides
+    @Singleton
+    KapuaMessageListener messageListener(MetricsClientSecurity metricsClientSecurity) {
+        return new KapuaMessageListener(metricsClientSecurity);
     }
 }

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/ServiceClientMessagingImpl.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/ServiceClientMessagingImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.client.security;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import javax.jms.JMSException;
 
 import org.eclipse.kapua.client.security.amqpclient.Client;
 import org.eclipse.kapua.client.security.bean.AuthRequest;
@@ -24,7 +24,7 @@ import org.eclipse.kapua.client.security.bean.ResponseContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jms.JMSException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * Security service. Implementation through AMQP messaging layer.
@@ -34,17 +34,18 @@ public class ServiceClientMessagingImpl implements ServiceClient {
     private static final Logger logger = LoggerFactory.getLogger(ServiceClientMessagingImpl.class);
 
     private static final int TIMEOUT = 5000;
-    private final MessageListener messageListener;
+    private final KapuaMessageListener messageListener;
 
     private Client client;
 
-    public ServiceClientMessagingImpl(MessageListener messageListener, Client client) {
+    public ServiceClientMessagingImpl(KapuaMessageListener messageListener, Client client) {
         this.messageListener = messageListener;
         this.client = client;
     }
 
     @Override
-    public AuthResponse brokerConnect(AuthRequest authRequest) throws InterruptedException, JMSException, JsonProcessingException {//TODO review exception when Kapua code will be linked (throw KapuaException)
+    public AuthResponse brokerConnect(AuthRequest authRequest)
+            throws InterruptedException, JMSException, JsonProcessingException {//TODO review exception when Kapua code will be linked (throw KapuaException)
         String requestId = MessageHelper.getNewRequestId();
         authRequest.setRequestId(requestId);
         authRequest.setAction(SecurityAction.brokerConnect.name());

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/bean/ResponseContainer.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/bean/ResponseContainer.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.client.security.bean;
 
-import org.eclipse.kapua.client.security.MessageListener;
+import org.eclipse.kapua.client.security.KapuaMessageListener;
 
 public class ResponseContainer<O extends Response> {
 
@@ -35,7 +35,7 @@ public class ResponseContainer<O extends Response> {
         return requestId;
     }
 
-    public static <O extends Response> ResponseContainer<O> createAnRegisterNewMessageContainer(MessageListener messageListener, Request request) {
+    public static <O extends Response> ResponseContainer<O> createAnRegisterNewMessageContainer(KapuaMessageListener messageListener, Request request) {
         ResponseContainer<O> messageContainer = new ResponseContainer<>(request.getRequestId());
         messageListener.registerCallback(request.getRequestId(), messageContainer);
         return messageContainer;

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -96,10 +96,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
         </dependency>

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
@@ -12,9 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.jpa;
 
-import com.zaxxer.hikari.HikariDataSource;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+
+import com.zaxxer.hikari.HikariDataSource;
 
 public final class DataSource {
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/KapuaEntityManagerFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/KapuaEntityManagerFactory.java
@@ -12,13 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.jpa;
 
-import com.google.common.base.Strings;
-import org.eclipse.kapua.commons.setting.system.SystemSetting;
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
-import org.eclipse.persistence.config.PersistenceUnitProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.persistence.Cache;
 import javax.persistence.EntityGraph;
@@ -30,8 +25,15 @@ import javax.persistence.Query;
 import javax.persistence.SynchronizationType;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.metamodel.Metamodel;
-import java.util.HashMap;
-import java.util.Map;
+
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
 
 /**
  * Base {@code abstract} {@link EntityManager}.
@@ -39,6 +41,7 @@ import java.util.Map;
  * @since 1.0.0
  */
 public class KapuaEntityManagerFactory implements EntityManagerFactory {
+
     private static final Logger LOG = LoggerFactory.getLogger(KapuaEntityManagerFactory.class);
     private static final String DEFAULT_DATASOURCE_NAME = "kapua-dbpool";
     private final EntityManagerFactory entityManagerFactory;
@@ -47,7 +50,8 @@ public class KapuaEntityManagerFactory implements EntityManagerFactory {
     /**
      * Constructor.
      *
-     * @param persistenceUnitName The {@link PersistenceUnit} name.
+     * @param persistenceUnitName
+     *         The {@link PersistenceUnit} name.
      * @since 2.0.0
      */
     public KapuaEntityManagerFactory(String persistenceUnitName) {
@@ -57,8 +61,10 @@ public class KapuaEntityManagerFactory implements EntityManagerFactory {
     /**
      * Constructor.
      *
-     * @param persistenceUnitName The {@link PersistenceUnit} name.
-     * @param datasourceName      The {@link DataSource} name.
+     * @param persistenceUnitName
+     *         The {@link PersistenceUnit} name.
+     * @param datasourceName
+     *         The {@link DataSource} name.
      * @since 2.0.0
      */
     public KapuaEntityManagerFactory(String persistenceUnitName, String datasourceName) {
@@ -69,6 +75,20 @@ public class KapuaEntityManagerFactory implements EntityManagerFactory {
             // This has to be set to false in order to disable the local object cache of EclipseLink.
             configOverrides.put(PersistenceUnitProperties.CACHE_SHARED_DEFAULT, "false");
             configOverrides.put(PersistenceUnitProperties.NON_JTA_DATASOURCE, DataSource.getDataSource());
+            // Uncomment the following and add the following lines to logback.xml to see full sql logs:
+            // <logger name="eclipselink.logging" level="ALL"/>
+            // <logger name="com.zaxxer.hikari" level="TRACE"/>
+            // configOverrides.put("eclipselink.logging.level", "ALL");
+            // configOverrides.put("eclipselink.logging.level.sql", "ALL");
+            // configOverrides.put("eclipselink.logging.level.transaction", "ALL");
+            // configOverrides.put("eclipselink.logging.level.connection", "ALL");
+            // configOverrides.put("eclipselink.logging.level.cache", "ALL");
+            // configOverrides.put("eclipselink.logging.parameters", "true");
+            // configOverrides.put("eclipselink.logging.session", "true");
+            // configOverrides.put("eclipselink.logging.thread", "true");
+            // configOverrides.put("eclipselink.logging.timestamp", "true");
+            // configOverrides.put("eclipselink.logging.connection", "true");
+            // configOverrides.put("eclipselink.logging.logger", "org.eclipse.persistence.logging.slf4j.SLF4JLogger");
 
             final String targetDatabase = systemSetting.getString(SystemSettingKey.DB_JDBC_DATABASE_TARGET);
             if (!Strings.isNullOrEmpty(targetDatabase)) {
@@ -100,9 +120,12 @@ public class KapuaEntityManagerFactory implements EntityManagerFactory {
     /**
      * Prints the {@link EntityManager}'s configuration.
      *
-     * @param persistenceUnitName The {@link PersistenceUnit#name()}.
-     * @param datasourceName      The datasource name.
-     * @param configOverrides     The configuration overrides for the {@link EntityManager}.
+     * @param persistenceUnitName
+     *         The {@link PersistenceUnit#name()}.
+     * @param datasourceName
+     *         The datasource name.
+     * @param configOverrides
+     *         The configuration overrides for the {@link EntityManager}.
      * @since 2.0.0
      */
     private void printEntityManagerConfiguration(String persistenceUnitName, String datasourceName, Map<String, Object> configOverrides) {

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -37,10 +37,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.guice;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -68,7 +70,7 @@ import com.google.inject.util.Modules;
  *
  * @since 1.0.0
  */
-public class GuiceLocatorImpl extends KapuaLocator {
+public class GuiceLocatorImpl extends KapuaLocator implements Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(GuiceLocatorImpl.class);
 
@@ -359,5 +361,10 @@ public class GuiceLocatorImpl extends KapuaLocator {
 
         // Print it!
         configurationPrinter.printLog();
+    }
+
+    @Override
+    public void close() throws IOException {
+        INITIALIZATION_ATTEMPTS.decrementAndGet();
     }
 }

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -95,7 +96,12 @@ public class GuiceLocatorImpl extends KapuaLocator {
         this(SERVICE_RESOURCE);
     }
 
+    private static final AtomicInteger INITIALIZATION_ATTEMPTS = new AtomicInteger(0);
+
     public GuiceLocatorImpl(@NotNull String resourceName) {
+        if (INITIALIZATION_ATTEMPTS.incrementAndGet() != 1) {
+            throw new KapuaRuntimeException(KapuaLocatorErrorCodes.LOCATOR_CANNOT_BE_REINITIALIZED);
+        }
         try {
             init(resourceName);
         } catch (Exception e) {
@@ -267,6 +273,7 @@ public class GuiceLocatorImpl extends KapuaLocator {
         try {
             injector = Guice.createInjector(stage, Modules.override(kapuaModules).with(overridingModules));
         } catch (Throwable t) {
+            injector = null;
             throw new RuntimeException(t);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
         <guava-failureaccess.version>1.0.1</guava-failureaccess.version>
         <guava-listenablefuture.version>9999.0-empty-to-avoid-conflict-with-guava</guava-listenablefuture.version>
         <guice.version>5.1.0</guice.version>
-        <guice-multibindings.version>4.2.3</guice-multibindings.version>
         <hamcrest-core.version>2.2</hamcrest-core.version>
         <h2.version>1.4.200</h2.version>
         <hikaricp.version>4.0.3</hikaricp.version>
@@ -1520,11 +1519,6 @@
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>${guice.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-multibindings</artifactId>
-                <version>${guice-multibindings.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/CleanLocatorInstance.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/CleanLocatorInstance.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.qa.common.utils;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.cucumber.guice.ScenarioScoped;
+import io.cucumber.java.en.Given;
+
+@ScenarioScoped
+public class CleanLocatorInstance {
+
+    private static final Logger logger = LoggerFactory.getLogger(CleanLocatorInstance.class);
+
+    @Given("^Clean Locator Instance$")
+    public void stop() {
+        KapuaLocator.getInstance().clearInstance();
+    }
+
+}

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/InitShiro.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/InitShiro.java
@@ -35,8 +35,7 @@ public class InitShiro {
         try {
             SecurityManager securityManager = SecurityUtils.getSecurityManager();
             logger.info("Found Shiro security manager {}", securityManager);
-        }
-        catch (UnavailableSecurityManagerException e) {
+        } catch (UnavailableSecurityManagerException e) {
             logger.info("Init shiro security manager...");
             SecurityUtil.initSecurityManager();
         }

--- a/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
@@ -397,4 +397,5 @@ Feature: Account Credential Service Integration Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountDeviceRegistryService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountDeviceRegistryService.feature
@@ -128,4 +128,5 @@ Feature: Account Device Registry Service Integration Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/account/AccountExpirationI9n.feature
@@ -517,4 +517,5 @@ Feature: Account expiration features
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountGroupService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountGroupService.feature
@@ -125,4 +125,5 @@ Feature: Account Group Service Integration Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountJobService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountJobService.feature
@@ -129,4 +129,5 @@ Feature: Account Job Service Integration Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountRoleService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountRoleService.feature
@@ -126,4 +126,5 @@ Feature: Account Role Service Integration Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountServiceCreation.feature
+++ b/qa/integration/src/test/resources/features/account/AccountServiceCreation.feature
@@ -394,4 +394,5 @@ Feature: Account Service Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountTagService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountTagService.feature
@@ -126,4 +126,5 @@ Feature: Account Tag Service Integration Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountUserService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountUserService.feature
@@ -126,4 +126,5 @@ Feature: Account User Service Integration Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/account/FindSelfAccount.feature
+++ b/qa/integration/src/test/resources/features/account/FindSelfAccount.feature
@@ -101,4 +101,5 @@ Feature: Self account find feature
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/authorization/AccessInfoService.feature
+++ b/qa/integration/src/test/resources/features/authorization/AccessInfoService.feature
@@ -726,4 +726,5 @@ Feature: Access Info Service CRUD tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/authorization/DomainService.feature
+++ b/qa/integration/src/test/resources/features/authorization/DomainService.feature
@@ -143,4 +143,5 @@ Feature: Domain Service tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/authorization/GroupService.feature
+++ b/qa/integration/src/test/resources/features/authorization/GroupService.feature
@@ -1053,4 +1053,5 @@ Feature: Group Service tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/authorization/RoleService.feature
+++ b/qa/integration/src/test/resources/features/authorization/RoleService.feature
@@ -423,4 +423,5 @@ Feature: Role Service tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -73,3 +73,4 @@ Feature: Device Broker Integration
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerIpConfigFileI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerIpConfigFileI9n.feature
@@ -39,3 +39,4 @@ Feature: Device Broker connection ip with config file
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerIpSysEnvI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerIpSysEnvI9n.feature
@@ -39,3 +39,4 @@ Feature: Device Broker connection ip with System environment variable
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerIpUndefinedI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerIpUndefinedI9n.feature
@@ -38,3 +38,4 @@ Feature: Device Broker connection ip not set
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerStealingLinkI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerStealingLinkI9n.feature
@@ -98,3 +98,4 @@ Feature: Device Broker Cluster tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/broker/DeviceData.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceData.feature
@@ -70,3 +70,4 @@ Feature: Device data scenarios
   @teardown
   Scenario: Stop docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/broker/DeviceLifecycle.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceLifecycle.feature
@@ -74,3 +74,4 @@ Feature: Device lifecycle scenarios
   @teardown
   Scenario: Stop docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
@@ -203,3 +203,4 @@ Feature: Broker ACL tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -582,3 +582,4 @@ Feature: Broker ACL tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/connection/UserCouplingI9n.feature
+++ b/qa/integration/src/test/resources/features/connection/UserCouplingI9n.feature
@@ -1420,3 +1420,4 @@ Feature: User Coupling
   @teardown
   Scenario: Stop docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -1455,3 +1455,4 @@ Feature: Datastore tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/integration/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -200,3 +200,4 @@ Feature: Datastore tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
+++ b/qa/integration/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
@@ -43,3 +43,4 @@ Feature: Datastore tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -5774,3 +5774,4 @@ Feature: Device Registry Integration
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/deviceManagement/DeviceManagementInventoryI9n.feature
+++ b/qa/integration/src/test/resources/features/deviceManagement/DeviceManagementInventoryI9n.feature
@@ -250,3 +250,4 @@ Feature: Device Management Inventory Service Tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/deviceManagement/DeviceManagementKeystoreI9n.feature
+++ b/qa/integration/src/test/resources/features/deviceManagement/DeviceManagementKeystoreI9n.feature
@@ -230,3 +230,4 @@ Feature: Device Management Keystore Service Tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
@@ -957,3 +957,4 @@ Feature: Endpoint Info Service Integration Tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
@@ -154,4 +154,5 @@ Feature: Job Execution service CRUD tests
   @teardown
   Scenario: Stop test environment
     Given Stop full docker environment
+    And Clean Locator Instance
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
@@ -254,4 +254,5 @@ Feature: Job service CRUD tests
   @teardown
   Scenario: Stop test environment
     Given Stop full docker environment
+    And Clean Locator Instance
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
@@ -155,4 +155,5 @@ Feature: Job Target service CRUD tests
   @teardown
   Scenario: Stop test environment
     Given Stop full docker environment
+    And Clean Locator Instance
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
@@ -145,3 +145,4 @@ Feature: Job Engine Service - Keystore Step Definitions
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
@@ -1014,3 +1014,4 @@ Feature: JobEngineService tests for restarting job with offline device
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -497,3 +497,4 @@ Feature: JobEngineService restart job tests with online device
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -424,3 +424,4 @@ Feature: JobEngineService restart job tests with online device - second part
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -1128,3 +1128,4 @@ Feature: JobEngineService tests for starting job with offline device
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -857,3 +857,4 @@ Feature: JobEngineService start job tests with online device
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
@@ -508,3 +508,4 @@ Feature: JobEngineService stop job tests with online device
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
@@ -289,3 +289,4 @@ Feature: JobEngineService execute job on device connect
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -786,4 +786,5 @@ Feature: Trigger service tests
   @teardown
   Scenario: Stop test environment
     Given Stop full docker environment
+    And Clean Locator Instance
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/rest/authentication/RestAuth.feature
+++ b/qa/integration/src/test/resources/features/rest/authentication/RestAuth.feature
@@ -104,3 +104,4 @@ Feature: REST API tests for User
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -667,4 +667,5 @@ Feature: User and Credential expiration and lockout features
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/user/TenantSEI9n.feature
+++ b/qa/integration/src/test/resources/features/user/TenantSEI9n.feature
@@ -64,4 +64,5 @@ Feature: Tenant service with Service Events
 
   @teardown
   Scenario: Stop event broker for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserCredentialsI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserCredentialsI9n.feature
@@ -312,4 +312,5 @@ Feature: Feature file for testing Password user credential
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
@@ -1468,3 +1468,4 @@ Feature: User Permission tests
   @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment
+    And Clean Locator Instance

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -1521,7 +1521,7 @@ Feature: User role service integration tests
     And I logout
 
   Scenario: testing "userIdsByRoleId" method on a selected role
-    I verify that I can fetch users assigned to a given role using the appropriate method
+  I verify that I can fetch users assigned to a given role using the appropriate method
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
@@ -1672,4 +1672,5 @@ Feature: User role service integration tests
   @teardown
   Scenario: Stop test environment
     Given Stop full docker environment
+    And Clean Locator Instance
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
@@ -214,4 +214,5 @@ Feature: User Service Integration
   @teardown
   Scenario: Stop test environment
     Given Stop full docker environment
+    And Clean Locator Instance
     And Reset Security Context

--- a/service/account/test/src/test/resources/features/AccountService.feature
+++ b/service/account/test/src/test/resources/features/AccountService.feature
@@ -182,4 +182,5 @@ Feature: User Account Service
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ServiceLoader;
 
@@ -111,6 +113,13 @@ public abstract class KapuaLocator implements KapuaServiceLoader {
     }
 
     public static void clearInstance() {
+        if (instance instanceof Closeable) {
+            try {
+                ((Closeable) instance).close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
         instance = null;
         isBeingCreated = false;
     }

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorErrorCodes.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.KapuaErrorCode;
  * Kapua locator error codes.
  *
  * @since 1.0
- *
  */
 public enum KapuaLocatorErrorCodes implements KapuaErrorCode {
     /**
@@ -49,4 +48,8 @@ public enum KapuaLocatorErrorCodes implements KapuaErrorCode {
      * Invalid locator configuration
      */
     INVALID_CONFIGURATION,
+    /**
+     * Locator cannot be initialized twice
+     */
+    LOCATOR_CANNOT_BE_REINITIALIZED
 }

--- a/service/api/src/main/resources/kapua-locator-service-error-messages.properties
+++ b/service/api/src/main/resources/kapua-locator-service-error-messages.properties
@@ -15,3 +15,4 @@ SERVICE_UNAVAILABLE=Service unavailable {0}
 SERVICE_PROVIDER_INVALID={0} is not a valid service provider for {1}
 FACTORY_UNAVAILABLE=Factory unavailable {0}
 FACTORY_PROVIDER_INVALID={0} is not a valid factory provider for {1}
+LOCATOR_CANNOT_BE_REINITIALIZED=The Locator context initialization attempted more than once - this could lead to multiple singleton instances being alive, resulting in hard-to-detect errors.

--- a/service/api/src/test/java/org/eclipse/kapua/locator/KapuaLocatorExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/locator/KapuaLocatorExceptionTest.java
@@ -39,11 +39,13 @@ public class KapuaLocatorExceptionTest {
         argument3 = 'c';
         throwables = new Throwable[] { new Throwable(), null };
         expectedMessageNullArguments = new String[] { "Service unavailable {0}", "{0} is not a valid service provider for {1}", "Factory unavailable {0}",
-                "{0} is not a valid factory provider for {1}", "Error: ", "Error: ", "Error: " };
+                "{0} is not a valid factory provider for {1}", "Error: ", "Error: ", "Error: ",
+                "The Locator context initialization attempted more than once - this could lead to multiple singleton instances being alive, resulting in hard-to-detect errors." };
         expectedMessage = new String[] { "Service unavailable " + argument1, argument1 + " is not a valid service provider for " + argument2, "Factory unavailable " + argument1,
                 argument1 + " is not a valid factory provider for " + argument2, "Error: " + argument1 + ", " + argument2 + ", " + argument3,
                 "Error: " + argument1 + ", " + argument2 + ", " + argument3,
-                "Error: " + argument1 + ", " + argument2 + ", " + argument3 };
+                "Error: " + argument1 + ", " + argument2 + ", " + argument3,
+                "The Locator context initialization attempted more than once - this could lead to multiple singleton instances being alive, resulting in hard-to-detect errors." };
     }
 
     @Test

--- a/service/api/src/test/java/org/eclipse/kapua/locator/KapuaLocatorExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/locator/KapuaLocatorExceptionTest.java
@@ -12,12 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator;
 
+import java.util.EnumSet;
+
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
 
 @Category(JUnitTests.class)
 public class KapuaLocatorExceptionTest {
@@ -32,18 +33,17 @@ public class KapuaLocatorExceptionTest {
     @Before
     public void initialize() {
         expectedErrorMessage = "kapua-locator-service-error-messages";
-        kapuaLocatorErrorCodes = new KapuaLocatorErrorCodes[]{KapuaLocatorErrorCodes.SERVICE_UNAVAILABLE, KapuaLocatorErrorCodes.SERVICE_PROVIDER_INVALID,
-                KapuaLocatorErrorCodes.FACTORY_UNAVAILABLE, KapuaLocatorErrorCodes.FACTORY_PROVIDER_INVALID, KapuaLocatorErrorCodes.COMPONENT_UNAVAILABLE,
-                KapuaLocatorErrorCodes.COMPONENT_PROVIDER_INVALID, KapuaLocatorErrorCodes.INVALID_CONFIGURATION};
+        kapuaLocatorErrorCodes = EnumSet.allOf(KapuaLocatorErrorCodes.class).toArray(new KapuaLocatorErrorCodes[0]);
         argument1 = "argument1";
         argument2 = 42;
         argument3 = 'c';
-        throwables = new Throwable[]{new Throwable(), null};
-        expectedMessageNullArguments = new String[]{"Service unavailable {0}", "{0} is not a valid service provider for {1}", "Factory unavailable {0}",
-                "{0} is not a valid factory provider for {1}", "Error: ", "Error: ", "Error: "};
-        expectedMessage = new String[]{"Service unavailable " + argument1, argument1 + " is not a valid service provider for " + argument2, "Factory unavailable " + argument1,
-                argument1 + " is not a valid factory provider for " + argument2, "Error: " + argument1 + ", " + argument2 + ", " + argument3, "Error: " + argument1 + ", " + argument2 + ", " + argument3,
-                "Error: " + argument1 + ", " + argument2 + ", " + argument3};
+        throwables = new Throwable[] { new Throwable(), null };
+        expectedMessageNullArguments = new String[] { "Service unavailable {0}", "{0} is not a valid service provider for {1}", "Factory unavailable {0}",
+                "{0} is not a valid factory provider for {1}", "Error: ", "Error: ", "Error: " };
+        expectedMessage = new String[] { "Service unavailable " + argument1, argument1 + " is not a valid service provider for " + argument2, "Factory unavailable " + argument1,
+                argument1 + " is not a valid factory provider for " + argument2, "Error: " + argument1 + ", " + argument2 + ", " + argument3,
+                "Error: " + argument1 + ", " + argument2 + ", " + argument3,
+                "Error: " + argument1 + ", " + argument2 + ", " + argument3 };
     }
 
     @Test

--- a/service/device/registry/test/src/test/resources/features/DeviceEvent.feature
+++ b/service/device/registry/test/src/test/resources/features/DeviceEvent.feature
@@ -121,4 +121,5 @@ Feature: Device Event CRUD tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/device/registry/test/src/test/resources/features/DeviceRegistry.feature
+++ b/service/device/registry/test/src/test/resources/features/DeviceRegistry.feature
@@ -229,4 +229,5 @@ Feature: Device Registry CRUD tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/device/registry/test/src/test/resources/features/DeviceRegistryValidation.feature
+++ b/service/device/registry/test/src/test/resources/features/DeviceRegistryValidation.feature
@@ -195,4 +195,5 @@ Feature: Device Registry Validation Tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/job/test/src/test/resources/features/JobService.feature
+++ b/service/job/test/src/test/resources/features/JobService.feature
@@ -352,4 +352,5 @@ Feature: Job service CRUD tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/job/test/src/test/resources/features/JobStepDefinitionService.feature
+++ b/service/job/test/src/test/resources/features/JobStepDefinitionService.feature
@@ -147,4 +147,5 @@ Feature: Job step definition service CRUD tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/job/test/src/test/resources/features/JobStepService.feature
+++ b/service/job/test/src/test/resources/features/JobStepService.feature
@@ -185,4 +185,5 @@ Feature: JobStepService CRUD tests
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/scheduler/test/src/test/resources/features/SchedulerService.feature
+++ b/service/scheduler/test/src/test/resources/features/SchedulerService.feature
@@ -239,4 +239,5 @@ Feature: Scheduler Service
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/tag/test/src/test/resources/features/TagService.feature
+++ b/service/tag/test/src/test/resources/features/TagService.feature
@@ -456,4 +456,5 @@ Feature: Tag Service
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/service/user/test/src/test/resources/features/UserService.feature
+++ b/service/user/test/src/test/resources/features/UserService.feature
@@ -446,4 +446,5 @@ Feature: User Service
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context

--- a/translator/test/src/test/resources/features/TranslatorUnitTests.feature
+++ b/translator/test/src/test/resources/features/TranslatorUnitTests.feature
@@ -329,5 +329,6 @@ Feature: Translator Service
 
   @teardown
   Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+    Given Clean Locator Instance
+    And Reset Security Context
     And An exception was thrown


### PR DESCRIPTION
Should guicelocator fail at broker startup, multiple instances of (Kapua)MessageListener are istantiated, failing device login due to split request/response maps.
In general, guice modules should avoid doing logic, and should avoid failing. Guice cannot guarantee that singleton objects previously instantiated are killed - which in some cases can be very distruptive.
This pr both avoids multiple guiceLocator instantiation attempts within a single process, but also puts in place safeguards that ensure that message correlation will continue to work even if there are multiple (Kapua)MessageListener (possibly due to changes in the wiring).
