### PR TITLE
:fix: set hikari configuration pool to fixed size (more performant)

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
@@ -32,14 +32,23 @@ public final class DataSource {
             hikariDataSource.setJdbcUrl(JdbcConnectionUrlResolvers.resolveJdbcUrl());
             hikariDataSource.setUsername(config.getString(SystemSettingKey.DB_USERNAME));
             hikariDataSource.setPassword(config.getString(SystemSettingKey.DB_PASSWORD));
-
             hikariDataSource.setMaximumPoolSize(config.getInt(SystemSettingKey.DB_POOL_SIZE_MAX, 20));
-            hikariDataSource.setMinimumIdle(config.getInt(SystemSettingKey.DB_POOL_SIZE_MIN, 1));
-            hikariDataSource.setIdleTimeout(config.getInt(SystemSettingKey.DB_POOL_IDLE_TIMEOUT, 180000));
+            //commented out since is not good for performances
+            //see official documentation https://github.com/brettwooldridge/HikariCP
+            //This property controls the minimum number of idle connections that HikariCP tries to maintain in the pool.
+            //If the idle connections dip below this value, HikariCP will make a best effort to add additional connections
+            //quickly and efficiently. However, for maximum performance and responsiveness to spike demands, we recommend not
+            //setting this value and instead allowing HikariCP to act as a fixed size connection pool.
+            //Default: same as maximumPoolSize
+//            hikariDataSource.setMinimumIdle(config.getInt(SystemSettingKey.DB_POOL_SIZE_MIN, 1));
+            hikariDataSource.setPoolName("hikari-main");
+            hikariDataSource.setRegisterMbeans(true);
+            hikariDataSource.setAllowPoolSuspension(false);
+            //fixed size so this parameter is ignored by hikari
+//            hikariDataSource.setIdleTimeout(config.getInt(SystemSettingKey.DB_POOL_IDLE_TIMEOUT, 180000));
             hikariDataSource.setKeepaliveTime(config.getInt(SystemSettingKey.DB_POOL_KEEPALIVE_TIME, 30000));
             hikariDataSource.setMaxLifetime(config.getInt(SystemSettingKey.DB_POOL_MAX_LIFETIME, 1800000));
             hikariDataSource.setConnectionTestQuery(config.getString(SystemSettingKey.DB_POOL_TEST_QUERY, "SELECT 1"));
-
             hikariDataSource.setLeakDetectionThreshold(config.getInt(SystemSettingKey.DB_POOL_LEAKDETECTION_THRESHOLD, 0));
         }
 


### PR DESCRIPTION
Brief description of the PR.
Fixes Hikari pool configuration to achieve better performances (fixed size).
Should we remove the 2 no more used options like SystemSettingKey.DB_POOL_IDLE_TIMEOUT and SystemSettingKey.DB_POOL_SIZE_MIN and their default values?

**Related Issue**
none

**Description of the solution adopted**
Remove 

**Screenshots**
none

**Any side note on the changes made**
none
