### PR TITLE
Fix `ClassNotFoundException` handling in `ServiceConfigurations`

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/ServiceConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/ServiceConfigurations.java
@@ -80,13 +80,19 @@ public class ServiceConfigurations extends AbstractKapuaResource {
     public Response update(
             @PathParam("scopeId") ScopeId scopeId,
             ServiceConfiguration serviceConfiguration
-    ) throws KapuaException, ClassNotFoundException {
+    ) throws KapuaException {
         Account account = accountService.find(scopeId);
         if (account == null) {
             throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
         }
         for (ServiceComponentConfiguration serviceComponentConfiguration : serviceConfiguration.getComponentConfigurations()) {
-            Class<KapuaService> configurableServiceClass = (Class<KapuaService>) Class.forName(serviceComponentConfiguration.getId()).asSubclass(KapuaService.class);
+            Class<KapuaService> configurableServiceClass;
+            try {
+                configurableServiceClass =
+                    (Class<KapuaService>) Class.forName(serviceComponentConfiguration.getId()).asSubclass(KapuaService.class);
+            } catch (ClassNotFoundException e) {
+                throw new KapuaIllegalArgumentException("serviceConfiguration.componentConfiguration.id", serviceComponentConfiguration.getId());
+            }
             if (!KapuaConfigurableService.class.isAssignableFrom(configurableServiceClass)) {
                 throw new KapuaIllegalArgumentException("serviceComponentConfiguration.id", serviceComponentConfiguration.getId());
             }
@@ -102,8 +108,13 @@ public class ServiceConfigurations extends AbstractKapuaResource {
     public ServiceComponentConfiguration getComponent(
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("serviceId") String serviceId
-    ) throws KapuaException, ClassNotFoundException {
-        Class<KapuaService> configurableServiceClass = (Class<KapuaService>) Class.forName(serviceId).asSubclass(KapuaService.class);
+    ) throws KapuaException {
+        Class<KapuaService> configurableServiceClass;
+        try {
+            configurableServiceClass = (Class<KapuaService>) Class.forName(serviceId).asSubclass(KapuaService.class);
+        } catch (ClassNotFoundException e) {
+            throw new KapuaIllegalArgumentException("service.pid", serviceId);
+        }
         if (!KapuaConfigurableService.class.isAssignableFrom(configurableServiceClass)) {
             throw new KapuaIllegalArgumentException("service.pid", serviceId);
         }
@@ -128,12 +139,17 @@ public class ServiceConfigurations extends AbstractKapuaResource {
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("serviceId") String serviceId,
             ServiceComponentConfiguration serviceComponentConfiguration
-    ) throws KapuaException, ClassNotFoundException {
+    ) throws KapuaException {
         Account account = accountService.find(scopeId);
         if (account == null) {
             throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
         }
-        Class<KapuaService> configurableServiceClass = (Class<KapuaService>) Class.forName(serviceId).asSubclass(KapuaService.class);
+        Class<KapuaService> configurableServiceClass;
+        try {
+            configurableServiceClass = (Class<KapuaService>) Class.forName(serviceId).asSubclass(KapuaService.class);
+        } catch (ClassNotFoundException e) {
+            throw new KapuaIllegalArgumentException("service.pid", serviceId);
+        }
         if (!KapuaConfigurableService.class.isAssignableFrom(configurableServiceClass)) {
             throw new KapuaIllegalArgumentException("service.pid", serviceId);
         }


### PR DESCRIPTION
## Description
This pull request addresses an issue in the `ServiceConfigurations` class where `ClassNotFoundException` was being thrown by the following methods:
- `update(...)`
- `getComponent(...)`
- `updateComponent(...)`

These exceptions were not user-friendly and have now been replaced with `KapuaIllegalArgumentException` to provide a better user experience since the affected values are user-provided values.

## Note
Please merge this pull request after [eclipse/kapua#4064](https://github.com/eclipse/kapua/pull/4064) is merged.