### PR TITLE
:wrench: [Elasticsearch] Adding configuration parameters to Elasticsearch client

### DIFF
--- a/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -20,15 +20,18 @@ datastore.elasticsearch.nodes=127.0.0.1:9200
 datastore.elasticsearch.username=
 datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
-datastore.elasticsearch.numberOfIOThreads=1
+# <=0 ==> use the default
+datastore.elasticsearch.numberOfIOThreads=-1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
 datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
-datastore.elasticsearch.request.connection.timeout.millis=5000
-datastore.elasticsearch.request.socket.timeout.millis=3000
+# <0 ==> use the default
+datastore.elasticsearch.request.connection.timeout.millis=-1
+# <0 ==> use the default
+datastore.elasticsearch.request.socket.timeout.millis=-1
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false

--- a/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -20,12 +20,15 @@ datastore.elasticsearch.nodes=127.0.0.1:9200
 datastore.elasticsearch.username=
 datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
+datastore.elasticsearch.numberOfIOThreads=1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
 datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
+datastore.elasticsearch.request.connection.timeout.millis=5000
+datastore.elasticsearch.request.socket.timeout.millis=3000
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientConfiguration.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientConfiguration.java
@@ -12,10 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.elasticsearch.client.configuration;
 
-import org.eclipse.kapua.service.elasticsearch.client.ElasticsearchClient;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.kapua.service.elasticsearch.client.ElasticsearchClient;
 
 /**
  * The {@link ElasticsearchClientConfiguration} used to configure an instance of a {@link ElasticsearchClient}
@@ -30,6 +31,7 @@ public class ElasticsearchClientConfiguration {
     private List<ElasticsearchNode> nodes;
     private String username;
     private String password;
+    private Integer numberOfIOThreads;
 
     private ElasticsearchClientReconnectConfiguration reconnectConfiguration;
     private ElasticsearchClientRequestConfiguration requestConfiguration;
@@ -48,7 +50,8 @@ public class ElasticsearchClientConfiguration {
     /**
      * Sets the module name which is managing the {@link ElasticsearchClient} instance.
      *
-     * @param moduleName The module name which is managing the {@link ElasticsearchClient} instance.
+     * @param moduleName
+     *         The module name which is managing the {@link ElasticsearchClient} instance.
      * @since 1.3.0
      */
     public void setModuleName(String moduleName) {
@@ -68,7 +71,8 @@ public class ElasticsearchClientConfiguration {
     /**
      * Sets the Elasticsearch cluster name to use.
      *
-     * @param clusterName The Elasticsearch cluster name to use.
+     * @param clusterName
+     *         The Elasticsearch cluster name to use.
      * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -91,7 +95,6 @@ public class ElasticsearchClientConfiguration {
         return nodes;
     }
 
-
     /**
      * Adds a new {@link ElasticsearchNode} to the {@link List} {@link ElasticsearchNode}s already configured.
      * <p>
@@ -100,8 +103,10 @@ public class ElasticsearchClientConfiguration {
      *     getNodes().add(new ElasticsearchNode(address, port));
      * </pre>
      *
-     * @param address The host of the Elasticsearch node
-     * @param port    The port of the Elasticsearch node
+     * @param address
+     *         The host of the Elasticsearch node
+     * @param port
+     *         The port of the Elasticsearch node
      * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -113,7 +118,8 @@ public class ElasticsearchClientConfiguration {
     /**
      * Sets the {@link List} of {@link ElasticsearchNode}s.
      *
-     * @param nodes The {@link List} of {@link ElasticsearchNode}s.
+     * @param nodes
+     *         The {@link List} of {@link ElasticsearchNode}s.
      * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -137,7 +143,8 @@ public class ElasticsearchClientConfiguration {
      * <p>
      * Optional.
      *
-     * @param username The username used to authenticate into Elasticsearch.
+     * @param username
+     *         The username used to authenticate into Elasticsearch.
      * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -161,7 +168,8 @@ public class ElasticsearchClientConfiguration {
      * <p>
      * Optional.
      *
-     * @param password The password used to authenticate into Elasticsearch.
+     * @param password
+     *         The password used to authenticate into Elasticsearch.
      * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -187,7 +195,8 @@ public class ElasticsearchClientConfiguration {
     /**
      * Sets the {@link ElasticsearchClientReconnectConfiguration}.
      *
-     * @param reconnectConfiguration The {@link ElasticsearchClientReconnectConfiguration}.
+     * @param reconnectConfiguration
+     *         The {@link ElasticsearchClientReconnectConfiguration}.
      * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -213,7 +222,8 @@ public class ElasticsearchClientConfiguration {
     /**
      * Sets the {@link ElasticsearchClientReconnectConfiguration}.
      *
-     * @param requestConfiguration the {@link ElasticsearchClientReconnectConfiguration}.
+     * @param requestConfiguration
+     *         the {@link ElasticsearchClientReconnectConfiguration}.
      * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -239,12 +249,24 @@ public class ElasticsearchClientConfiguration {
     /**
      * Sets the {@link ElasticsearchClientSslConfiguration}
      *
-     * @param sslConfiguration The {@link ElasticsearchClientSslConfiguration}
+     * @param sslConfiguration
+     *         The {@link ElasticsearchClientSslConfiguration}
      * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
      * @since 1.3.0
      */
     public ElasticsearchClientConfiguration setSslConfiguration(ElasticsearchClientSslConfiguration sslConfiguration) {
         this.sslConfiguration = sslConfiguration;
+        return this;
+    }
+
+    public int getNumberOfIOThreads() {
+        return Optional.ofNullable(numberOfIOThreads)
+                .filter(i -> i > 0)
+                .orElseGet(() -> Runtime.getRuntime().availableProcessors());
+    }
+
+    public ElasticsearchClientConfiguration setNumberOfIOThreads(Integer numberOfIOThreads) {
+        this.numberOfIOThreads = numberOfIOThreads;
         return this;
     }
 }

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientConfiguration.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientConfiguration.java
@@ -31,7 +31,7 @@ public class ElasticsearchClientConfiguration {
     private List<ElasticsearchNode> nodes;
     private String username;
     private String password;
-    private Integer numberOfIOThreads;
+    private Optional<Integer> numberOfIOThreads;
 
     private ElasticsearchClientReconnectConfiguration reconnectConfiguration;
     private ElasticsearchClientRequestConfiguration requestConfiguration;
@@ -259,14 +259,13 @@ public class ElasticsearchClientConfiguration {
         return this;
     }
 
-    public int getNumberOfIOThreads() {
-        return Optional.ofNullable(numberOfIOThreads)
-                .filter(i -> i > 0)
-                .orElseGet(() -> Runtime.getRuntime().availableProcessors());
+    public Optional<Integer> getNumberOfIOThreads() {
+        return this.numberOfIOThreads;
     }
 
     public ElasticsearchClientConfiguration setNumberOfIOThreads(Integer numberOfIOThreads) {
-        this.numberOfIOThreads = numberOfIOThreads;
+        this.numberOfIOThreads = Optional.ofNullable(numberOfIOThreads)
+                .filter(i -> i > 0);
         return this;
     }
 }

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientRequestConfiguration.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientRequestConfiguration.java
@@ -17,8 +17,7 @@ import org.eclipse.kapua.service.elasticsearch.client.model.Request;
 /**
  * The {@link ElasticsearchClientRequestConfiguration} definition.
  * <p>
- * It contains values for configuring request properties.
- * It contains default values to ease the usage of the class.
+ * It contains values for configuring request properties. It contains default values to ease the usage of the class.
  */
 public class ElasticsearchClientRequestConfiguration {
 
@@ -27,6 +26,8 @@ public class ElasticsearchClientRequestConfiguration {
 
     private int queryTimeout = 15000;
     private int scrollTimeout = 60000;
+    private int connectionTimeoutMillis = 5000;
+    private int socketTimeoutMillis = 3000;
 
     /**
      * Gets the number of maximum attempts to retry a {@link Request}.
@@ -43,7 +44,8 @@ public class ElasticsearchClientRequestConfiguration {
     /**
      * Sets the number of maximum attempts to retry a {@link Request}.
      *
-     * @param requestRetryAttemptMax The number of maximum attempts to retry a {@link Request}.
+     * @param requestRetryAttemptMax
+     *         The number of maximum attempts to retry a {@link Request}.
      * @return This {@link ElasticsearchClientRequestConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -67,7 +69,8 @@ public class ElasticsearchClientRequestConfiguration {
     /**
      * Sets the wait time between {@link Request} retries.
      *
-     * @param requestRetryAttemptWait The wait time between {@link Request} retries.
+     * @param requestRetryAttemptWait
+     *         The wait time between {@link Request} retries.
      * @return This {@link ElasticsearchClientRequestConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -91,7 +94,8 @@ public class ElasticsearchClientRequestConfiguration {
     /**
      * Sets the query {@link Request} timeout.
      *
-     * @param queryTimeout The query {@link Request} timeout.
+     * @param queryTimeout
+     *         The query {@link Request} timeout.
      * @return This {@link ElasticsearchClientRequestConfiguration} to chain method invocation.
      * @since 1.3.0
      */
@@ -115,12 +119,63 @@ public class ElasticsearchClientRequestConfiguration {
     /**
      * Sets the scroll {@link Request} timeout.
      *
-     * @param scrollTimeout The scroll {@link Request} timeout.
+     * @param scrollTimeout
+     *         The scroll {@link Request} timeout.
      * @return This {@link ElasticsearchClientRequestConfiguration} to chain method invocation.
      * @since 1.3.0
      */
     public ElasticsearchClientRequestConfiguration setScrollTimeout(int scrollTimeout) {
         this.scrollTimeout = scrollTimeout;
+        return this;
+    }
+
+    /**
+     * Gets the {@link Request} connection timeout. https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.17/_timeouts.html
+     * <p>
+     * Default value: 5000 ms
+     *
+     * @return The query {@link Request} connection timeout.
+     * @since 2.1.0
+     */
+    public int getConnectionTimeoutMillis() {
+        return connectionTimeoutMillis;
+    }
+
+    /**
+     * Gets the {@link Request} socket timeout. https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.17/_timeouts.html
+     * <p>
+     * Default value: 3000 ms
+     *
+     * @return The query {@link Request} connection timeout.
+     * @since 2.1.0
+     */
+    public int getSocketTimeoutMillis() {
+        return socketTimeoutMillis;
+    }
+
+    /**
+     * Sets the scroll {@link Request} connection timeout. https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.17/_timeouts.html.
+     *
+     * @param connectionTimeoutMillis
+     *         The scroll {@link Request} connection timeout.
+     * @return This {@link ElasticsearchClientRequestConfiguration} to chain method invocation.
+     * @since 2.1.0
+     */
+    public ElasticsearchClientRequestConfiguration setConnectionTimeoutMillis(int connectionTimeoutMillis) {
+        this.connectionTimeoutMillis = connectionTimeoutMillis;
+        return this;
+    }
+
+    /**
+     * Sets the scroll {@link Request} socket timeout. https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.17/_timeouts.html.
+     *
+     * @param socketTimeoutMillis
+     *         The scroll {@link Request} socket timeout.
+     * @return This {@link ElasticsearchClientRequestConfiguration} to chain method invocation.
+     * @since 2.1.0
+     */
+    public ElasticsearchClientRequestConfiguration setSocketTimeoutMillis(int socketTimeoutMillis) {
+        this.socketTimeoutMillis = socketTimeoutMillis;
         return this;
     }
 }

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientRequestConfiguration.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientRequestConfiguration.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.elasticsearch.client.configuration;
 
+import java.util.Optional;
+
 import org.eclipse.kapua.service.elasticsearch.client.model.Request;
 
 /**
@@ -26,8 +28,8 @@ public class ElasticsearchClientRequestConfiguration {
 
     private int queryTimeout = 15000;
     private int scrollTimeout = 60000;
-    private int connectionTimeoutMillis = 5000;
-    private int socketTimeoutMillis = 3000;
+    private Optional<Integer> connectionTimeoutMillis = Optional.empty();
+    private Optional<Integer> socketTimeoutMillis = Optional.empty();
 
     /**
      * Gets the number of maximum attempts to retry a {@link Request}.
@@ -137,7 +139,7 @@ public class ElasticsearchClientRequestConfiguration {
      * @return The query {@link Request} connection timeout.
      * @since 2.1.0
      */
-    public int getConnectionTimeoutMillis() {
+    public Optional<Integer> getConnectionTimeoutMillis() {
         return connectionTimeoutMillis;
     }
 
@@ -149,7 +151,7 @@ public class ElasticsearchClientRequestConfiguration {
      * @return The query {@link Request} connection timeout.
      * @since 2.1.0
      */
-    public int getSocketTimeoutMillis() {
+    public Optional<Integer> getSocketTimeoutMillis() {
         return socketTimeoutMillis;
     }
 
@@ -161,8 +163,8 @@ public class ElasticsearchClientRequestConfiguration {
      * @return This {@link ElasticsearchClientRequestConfiguration} to chain method invocation.
      * @since 2.1.0
      */
-    public ElasticsearchClientRequestConfiguration setConnectionTimeoutMillis(int connectionTimeoutMillis) {
-        this.connectionTimeoutMillis = connectionTimeoutMillis;
+    public ElasticsearchClientRequestConfiguration setConnectionTimeoutMillis(Integer connectionTimeoutMillis) {
+        this.connectionTimeoutMillis = Optional.ofNullable(connectionTimeoutMillis).filter(i -> i >= 0);
         return this;
     }
 
@@ -174,8 +176,8 @@ public class ElasticsearchClientRequestConfiguration {
      * @return This {@link ElasticsearchClientRequestConfiguration} to chain method invocation.
      * @since 2.1.0
      */
-    public ElasticsearchClientRequestConfiguration setSocketTimeoutMillis(int socketTimeoutMillis) {
-        this.socketTimeoutMillis = socketTimeoutMillis;
+    public ElasticsearchClientRequestConfiguration setSocketTimeoutMillis(Integer socketTimeoutMillis) {
+        this.socketTimeoutMillis = Optional.ofNullable(socketTimeoutMillis).filter(i -> i >= 0);
         return this;
     }
 }

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
@@ -24,6 +24,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -349,9 +350,11 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
         restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> customizeHttpClient(httpClientBuilder, finalSslContext, finalCredentialsProvider));
         //        restClientBuilder.setFailureListener(new RestElasticsearchFailureListener());
         restClientBuilder.setRequestConfigCallback(
-                requestConfigBuilder -> requestConfigBuilder
-                        .setConnectTimeout(clientConfiguration.getRequestConfiguration().getConnectionTimeoutMillis())
-                        .setSocketTimeout(clientConfiguration.getRequestConfiguration().getSocketTimeoutMillis()));
+                requestConfigBuilder -> {
+                    clientConfiguration.getRequestConfiguration().getConnectionTimeoutMillis().ifPresent(timout -> requestConfigBuilder.setConnectTimeout(timout));
+                    clientConfiguration.getRequestConfiguration().getSocketTimeoutMillis().ifPresent(timout -> requestConfigBuilder.setSocketTimeout(timout));
+                    return requestConfigBuilder;
+                });
         RestClient restClient = restClientBuilder.build();
 
         // Init Kapua Elasticsearch Client
@@ -375,12 +378,17 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
             if (credentialsProvider != null) {
                 httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
             }
-            ;
-            DefaultConnectingIOReactor ioReactor = new DefaultConnectingIOReactor(
-                    IOReactorConfig.custom().setIoThreadCount(
-                            getClientConfiguration().getNumberOfIOThreads()
-                    ).build()
-            );
+            final DefaultConnectingIOReactor ioReactor;
+            final Optional<Integer> numberOfIOThreads = getClientConfiguration().getNumberOfIOThreads();
+            if (numberOfIOThreads.isPresent()) {
+                ioReactor = new DefaultConnectingIOReactor(
+                        IOReactorConfig.custom().setIoThreadCount(
+                                numberOfIOThreads.get()
+                        ).build()
+                );
+            } else {
+                ioReactor = new DefaultConnectingIOReactor();
+            }
             ioReactor.setExceptionHandler(new IOReactorExceptionHandler() {
 
                 @Override

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
@@ -13,8 +13,25 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.elasticsearch.client.rest;
 
-import com.google.common.base.Strings;
-import com.google.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.net.ssl.SSLContext;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -24,6 +41,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
 import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.apache.http.nio.reactor.IOReactorException;
 import org.apache.http.nio.reactor.IOReactorExceptionHandler;
 import org.apache.http.ssl.SSLContextBuilder;
@@ -47,23 +65,8 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
 
 /**
  * {@link ElasticsearchClientProvider} REST implementation.
@@ -209,7 +212,8 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
      * <p>
      * It takes care of stopping the {@link #reconnectExecutorTask}.
      *
-     * @throws IOException see {@link RestClient#close()} javadoc.
+     * @throws IOException
+     *         see {@link RestClient#close()} javadoc.
      * @since 1.0.0
      */
     private void closeClient() throws IOException {
@@ -239,8 +243,10 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
     /**
      * The {@link Callable} that connects (and reconnects) the {@link RestClient}.
      *
-     * @param initClientMethod The {@link Callable} that connects (and reconnects) the {@link RestClient}.
-     * @throws Exception if the given {@link Callable} throws {@link Exception}.
+     * @param initClientMethod
+     *         The {@link Callable} that connects (and reconnects) the {@link RestClient}.
+     * @throws Exception
+     *         if the given {@link Callable} throws {@link Exception}.
      * @since 1.0.0
      */
     private void reconnectClientTask(Callable<RestClient> initClientMethod) throws Exception {
@@ -261,7 +267,8 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
      * Initializes the {@link RestClient} as per {@link ElasticsearchClientConfiguration}.
      *
      * @return The initialized {@link RestClient}.
-     * @throws ClientInitializationException if any {@link Exception} occurs while {@link RestClient} initialization.
+     * @throws ClientInitializationException
+     *         if any {@link Exception} occurs while {@link RestClient} initialization.
      * @since 1.0.0
      */
     private RestClient initClient() throws ClientInitializationException {
@@ -340,8 +347,11 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
         final SSLContext finalSslContext = sslContext;
         final CredentialsProvider finalCredentialsProvider = credentialsProvider;
         restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> customizeHttpClient(httpClientBuilder, finalSslContext, finalCredentialsProvider));
-//        restClientBuilder.setFailureListener(new RestElasticsearchFailureListener());
-
+        //        restClientBuilder.setFailureListener(new RestElasticsearchFailureListener());
+        restClientBuilder.setRequestConfigCallback(
+                requestConfigBuilder -> requestConfigBuilder
+                        .setConnectTimeout(clientConfiguration.getRequestConfiguration().getConnectionTimeoutMillis())
+                        .setSocketTimeout(clientConfiguration.getRequestConfiguration().getSocketTimeoutMillis()));
         RestClient restClient = restClientBuilder.build();
 
         // Init Kapua Elasticsearch Client
@@ -365,8 +375,12 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
             if (credentialsProvider != null) {
                 httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
             }
-
-            DefaultConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
+            ;
+            DefaultConnectingIOReactor ioReactor = new DefaultConnectingIOReactor(
+                    IOReactorConfig.custom().setIoThreadCount(
+                            getClientConfiguration().getNumberOfIOThreads()
+                    ).build()
+            );
             ioReactor.setExceptionHandler(new IOReactorExceptionHandler() {
 
                 @Override
@@ -460,8 +474,10 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
     /**
      * Initializes the {@link KeyStore}  as per  {@link ElasticsearchClientSslConfiguration} with the given {@link SSLContextBuilder}.
      *
-     * @param sslBuilder The {@link SSLContextBuilder} to use.
-     * @throws ClientInitializationException if {@link KeyStore} cannot be initialized.
+     * @param sslBuilder
+     *         The {@link SSLContextBuilder} to use.
+     * @throws ClientInitializationException
+     *         if {@link KeyStore} cannot be initialized.
      * @since 1.0.0
      */
     private void initKeyStore(SSLContextBuilder sslBuilder) throws ClientInitializationException {
@@ -483,10 +499,13 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
     /**
      * Loads the {@link KeyStore}  as per {@link ElasticsearchClientSslConfiguration}.
      *
-     * @param keystorePath     The {@link KeyStore} path.
-     * @param keystorePassword The {@link KeyStore} password.
+     * @param keystorePath
+     *         The {@link KeyStore} path.
+     * @param keystorePassword
+     *         The {@link KeyStore} password.
      * @return The initialized {@link KeyStore}.
-     * @throws ClientInitializationException if {@link KeyStore} cannot be loaded.
+     * @throws ClientInitializationException
+     *         if {@link KeyStore} cannot be loaded.
      * @since 1.0.0
      */
     private KeyStore loadKeyStore(String keystorePath, String keystorePassword) throws ClientInitializationException {
@@ -509,8 +528,10 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
      *     <li>Use the JVM default truststore: as fallback option</li>
      * </ol>
      *
-     * @param sslBuilder The {@link SSLContextBuilder} to use.
-     * @throws ClientInitializationException if {@link KeyStore} cannot be initialized.
+     * @param sslBuilder
+     *         The {@link SSLContextBuilder} to use.
+     * @throws ClientInitializationException
+     *         if {@link KeyStore} cannot be initialized.
      * @since 1.0.0
      */
     private void initTrustStore(SSLContextBuilder sslBuilder) throws ClientInitializationException {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.client;
 
+import java.util.List;
+
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreElasticsearchClientSettings;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreElasticsearchClientSettingsKey;
 import org.eclipse.kapua.service.elasticsearch.client.configuration.ElasticsearchClientConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 public class DatastoreElasticsearchClientConfiguration extends ElasticsearchClientConfiguration {
 
@@ -41,10 +41,12 @@ public class DatastoreElasticsearchClientConfiguration extends ElasticsearchClie
         setPassword(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.PASSWORD));
         getRequestConfiguration().setQueryTimeout(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_QUERY_TIMEOUT));
         getRequestConfiguration().setScrollTimeout(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_SCROLL_TIMEOUT));
+        getRequestConfiguration().setConnectionTimeoutMillis(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_CONNECTION_TIMEOUT_MILLIS));
+        getRequestConfiguration().setSocketTimeoutMillis(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_SOCKET_TIMEOUT_MILLIS));
         getRequestConfiguration().setRequestRetryAttemptMax(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_RETRY_MAX));
         getRequestConfiguration().setRequestRetryAttemptWait(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_RETRY_WAIT));
         getSslConfiguration().setEnabled(elasticsearchClientSettings.getBoolean(DatastoreElasticsearchClientSettingsKey.SSL_ENABLED));
-
+        setNumberOfIOThreads(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.NUMBER_OF_IO_THREADS, 1));
         getReconnectConfiguration().setReconnectDelay(30000);
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
@@ -41,12 +41,12 @@ public class DatastoreElasticsearchClientConfiguration extends ElasticsearchClie
         setPassword(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.PASSWORD));
         getRequestConfiguration().setQueryTimeout(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_QUERY_TIMEOUT));
         getRequestConfiguration().setScrollTimeout(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_SCROLL_TIMEOUT));
-        getRequestConfiguration().setConnectionTimeoutMillis(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_CONNECTION_TIMEOUT_MILLIS));
-        getRequestConfiguration().setSocketTimeoutMillis(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_SOCKET_TIMEOUT_MILLIS));
+        getRequestConfiguration().setConnectionTimeoutMillis(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_CONNECTION_TIMEOUT_MILLIS, -1));
+        getRequestConfiguration().setSocketTimeoutMillis(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_SOCKET_TIMEOUT_MILLIS, -1));
         getRequestConfiguration().setRequestRetryAttemptMax(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_RETRY_MAX));
         getRequestConfiguration().setRequestRetryAttemptWait(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_RETRY_WAIT));
         getSslConfiguration().setEnabled(elasticsearchClientSettings.getBoolean(DatastoreElasticsearchClientSettingsKey.SSL_ENABLED));
-        setNumberOfIOThreads(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.NUMBER_OF_IO_THREADS, 1));
+        setNumberOfIOThreads(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.NUMBER_OF_IO_THREADS, 0));
         getReconnectConfiguration().setReconnectDelay(30000);
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
@@ -132,19 +132,19 @@ public enum DatastoreElasticsearchClientSettingsKey implements SettingKey {
      */
     SSL_TRUSTSTORE_PASSWORD("datastore.elasticsearch.ssl.truststore.password"),
     /**
-     * Elastichsearch client number of IO threads. Leave <=0 to use the default
+     * Elastichsearch client number of IO threads. Leave &lt;=0 to use the default
      *
      * @since 2.1.0
      */
     NUMBER_OF_IO_THREADS("datastore.elasticsearch.numberOfIOThreads"),
     /**
-     * Elastichsearch client request connection timeout in milliseconds. Leave <=0 to use the default
+     * Elastichsearch client request connection timeout in milliseconds. Leave &lt;0 to use the default
      *
      * @since 2.1.0
      */
     REQUEST_CONNECTION_TIMEOUT_MILLIS("datastore.elasticsearch.request.connection.timeout.millis"),
     /**
-     * Elastichsearch client request socket timeout in milliseconds. Leave <=0 to use the default
+     * Elastichsearch client request socket timeout in milliseconds. Leave &lt;0 to use the default
      *
      * @since 2.1.0
      */

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
@@ -130,7 +130,25 @@ public enum DatastoreElasticsearchClientSettingsKey implements SettingKey {
      *
      * @since 1.3.0
      */
-    SSL_TRUSTSTORE_PASSWORD("datastore.elasticsearch.ssl.truststore.password");
+    SSL_TRUSTSTORE_PASSWORD("datastore.elasticsearch.ssl.truststore.password"),
+    /**
+     * Elastichsearch client number of IO threads (use 0 or less to let the default value ofRuntime.getRuntime().availableProcessors() to be used
+     *
+     * @since 2.1.0
+     */
+    NUMBER_OF_IO_THREADS("datastore.elasticsearch.numberOfIOThreads"),
+    /**
+     * Elastichsearch client request connection timeout in milliseconds
+     *
+     * @since 2.1.0
+     */
+    REQUEST_CONNECTION_TIMEOUT_MILLIS("datastore.elasticsearch.request.connection.timeout.millis"),
+    /**
+     * Elastichsearch client request socket timeout in milliseconds
+     *
+     * @since 2.1.0
+     */
+    REQUEST_SOCKET_TIMEOUT_MILLIS("datastore.elasticsearch.request.socket.timeout.millis");
 
     /**
      * The key value in the configuration resources.
@@ -142,7 +160,8 @@ public enum DatastoreElasticsearchClientSettingsKey implements SettingKey {
     /**
      * Set up the {@code enum} with the key value provided
      *
-     * @param key The value mapped by this {@link Enum} value
+     * @param key
+     *         The value mapped by this {@link Enum} value
      * @since 1.0.0
      */
     DatastoreElasticsearchClientSettingsKey(String key) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
@@ -132,19 +132,19 @@ public enum DatastoreElasticsearchClientSettingsKey implements SettingKey {
      */
     SSL_TRUSTSTORE_PASSWORD("datastore.elasticsearch.ssl.truststore.password"),
     /**
-     * Elastichsearch client number of IO threads (use 0 or less to let the default value ofRuntime.getRuntime().availableProcessors() to be used
+     * Elastichsearch client number of IO threads. Leave <=0 to use the default
      *
      * @since 2.1.0
      */
     NUMBER_OF_IO_THREADS("datastore.elasticsearch.numberOfIOThreads"),
     /**
-     * Elastichsearch client request connection timeout in milliseconds
+     * Elastichsearch client request connection timeout in milliseconds. Leave <=0 to use the default
      *
      * @since 2.1.0
      */
     REQUEST_CONNECTION_TIMEOUT_MILLIS("datastore.elasticsearch.request.connection.timeout.millis"),
     /**
-     * Elastichsearch client request socket timeout in milliseconds
+     * Elastichsearch client request socket timeout in milliseconds. Leave <=0 to use the default
      *
      * @since 2.1.0
      */

--- a/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -20,12 +20,15 @@ datastore.elasticsearch.nodes=localhost:9200
 datastore.elasticsearch.username=
 datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
+datastore.elasticsearch.numberOfIOThreads=1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
 datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
+datastore.elasticsearch.request.connection.timeout.millis=5000
+datastore.elasticsearch.request.socket.timeout.millis=3000
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false

--- a/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -20,15 +20,18 @@ datastore.elasticsearch.nodes=localhost:9200
 datastore.elasticsearch.username=
 datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
-datastore.elasticsearch.numberOfIOThreads=1
+# <=0 ==> use the default
+datastore.elasticsearch.numberOfIOThreads=-1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
 datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
-datastore.elasticsearch.request.connection.timeout.millis=5000
-datastore.elasticsearch.request.socket.timeout.millis=3000
+# <0 ==> use the default
+datastore.elasticsearch.request.connection.timeout.millis=-1
+# <0 ==> use the default
+datastore.elasticsearch.request.socket.timeout.millis=-1
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false

--- a/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
@@ -21,12 +21,15 @@ datastore.elasticsearch.nodes=127.0.0.1:9200
 datastore.elasticsearch.username=
 datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
+datastore.elasticsearch.numberOfIOThreads=1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
 datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
+datastore.elasticsearch.request.connection.timeout.millis=5000
+datastore.elasticsearch.request.socket.timeout.millis=3000
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false

--- a/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
@@ -21,15 +21,18 @@ datastore.elasticsearch.nodes=127.0.0.1:9200
 datastore.elasticsearch.username=
 datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
-datastore.elasticsearch.numberOfIOThreads=1
+# <=0 ==> use the default
+datastore.elasticsearch.numberOfIOThreads=-1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
 datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
-datastore.elasticsearch.request.connection.timeout.millis=5000
-datastore.elasticsearch.request.socket.timeout.millis=3000
+# <0 ==> use the default
+datastore.elasticsearch.request.connection.timeout.millis=-1
+# <0 ==> use the default
+datastore.elasticsearch.request.socket.timeout.millis=-1
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false

--- a/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
@@ -21,12 +21,15 @@ datastore.elasticsearch.nodes=localhost:9300
 datastore.elasticsearch.username=
 datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
+datastore.elasticsearch.numberOfIOThreads=1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
 datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
+datastore.elasticsearch.request.connection.timeout.millis=5000
+datastore.elasticsearch.request.socket.timeout.millis=3000
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false

--- a/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
@@ -21,15 +21,18 @@ datastore.elasticsearch.nodes=localhost:9300
 datastore.elasticsearch.username=
 datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
-datastore.elasticsearch.numberOfIOThreads=1
+# <=0 ==> use the default
+datastore.elasticsearch.numberOfIOThreads=-1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
 datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
-datastore.elasticsearch.request.connection.timeout.millis=5000
-datastore.elasticsearch.request.socket.timeout.millis=3000
+# <0 ==> use the default
+datastore.elasticsearch.request.connection.timeout.millis=-1
+# <0 ==> use the default
+datastore.elasticsearch.request.socket.timeout.millis=-1
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false


### PR DESCRIPTION
This PR makes parameters of Elasticsearch rest client configurable at startup time so that the performances can be tuned easier without the need to execute a new build. The parameters are the following:

- Rest Client IO Thread Count, configure via `datastore.elasticsearch.numberOfIOThreads`, set to <=0 to leave the default
- Request Connection Timeout, `datastore.elasticsearch.request.connection.timeout.millis`, set to <0 to leave the default
- Request Socket Timeout, `datastore.elasticsearch.request.socket.timeout.millis`, set to <0 to leave the default

The way to make these parameters configurable is explained in the Elasticsearch guide, see references below:

[Timeouts | Elasticsearch Java API Client [7.17] | Elastic](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.17/_timeouts.html) 

[Number of threads | Elasticsearch Java API Client [7.17] | Elastic](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.17/_number_of_threads.html)