### PR TITLE
:bug: [Docker] Fixed mirrors for CentOS 7

### DIFF
--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -16,7 +16,9 @@ FROM @docker.base.image@
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-openjdk
 
-RUN yum install -y java-1.8.0-openjdk && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum install -y java-1.8.0-openjdk && \
     yum install -y curl && \
     yum install -y openssl && \
     mkdir -p /opt/jolokia && \


### PR DESCRIPTION
This PR fixes mirrorlist for CentOS images which are no longer available.

See: https://www.redhat.com/en/topics/linux/centos-linux-eol#:~:text=As%20a%20result%2C%20CentOS%20Linux,EOL%20on%20June%2030%2C%202024.

**Related Issue**
_None_

**Description of the solution adopted**
Updated mirrors in mirrorlist files

**Screenshots**
_None_

**Any side note on the changes made**
_None_