### PR TITLE
🔧  [Datastore] Datastore caches individually configurable

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/CacheConfig.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/CacheConfig.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.cache;
+
+public class CacheConfig {
+
+    public final int maxSize;
+    public final ExpiryPolicy expirationStrategy;
+    public final int expirationTimeoutSeconds;
+
+    public CacheConfig(int maxSize, int expirationTimeoutSeconds, ExpiryPolicy expirationStrategy) {
+        this.expirationStrategy = expirationStrategy;
+        this.expirationTimeoutSeconds = expirationTimeoutSeconds;
+        this.maxSize = maxSize;
+    }
+
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/ExpiryPolicy.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/ExpiryPolicy.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.cache;
+
+public enum ExpiryPolicy {
+    MODIFIED,
+    TOUCHED
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
@@ -25,10 +25,9 @@ import com.google.common.cache.CacheBuilder;
  * Default Kapua cache implementation
  *
  * @param <K>
- *            keys type
+ *         keys type
  * @param <V>
- *            values type
- *
+ *         values type
  * @since 1.0
  */
 public class LocalCache<K, V> implements Cache<K, V> {
@@ -44,24 +43,57 @@ public class LocalCache<K, V> implements Cache<K, V> {
      * Construct local cache setting the provided max size, expire time and default value
      *
      * @param sizeMax
-     *            max cache size
+     *         max cache size
      * @param expireAfter
-     *            values ttl
+     *         values ttl
      * @param defaultValue
-     *            default value (if no value is found for a specific key)
+     *         default value (if no value is found for a specific key)
      */
     public LocalCache(int sizeMax, int expireAfter, final V defaultValue) {
+        this(new CacheConfig(sizeMax, expireAfter, ExpiryPolicy.MODIFIED), defaultValue);
+    }
+
+    /**
+     * Construct local cache setting the provided max size, expire time and default value
+     *
+     * @param sizeMax
+     *         max cache size
+     * @param expireAfter
+     *         values ttl
+     * @param defaultValue
+     *         default value (if no value is found for a specific key)
+     */
+    public LocalCache(int sizeMax, int expireAfter, final ExpiryPolicy expirationStrategy, final V defaultValue) {
+        this(new CacheConfig(sizeMax, expireAfter, expirationStrategy), defaultValue);
+    }
+
+    /**
+     * Construct local cache setting the provided max size, expire time and default value
+     *
+     * @param cacheConfig
+     *         cache configuration
+     * @param defaultValue
+     *         default value (if no value is found for a specific key)
+     */
+    public LocalCache(CacheConfig cacheConfig, final V defaultValue) {
         this.defaultValue = defaultValue;
-        cache = CacheBuilder.newBuilder().maximumSize(sizeMax).expireAfterWrite(expireAfter, TimeUnit.SECONDS).build();
+        switch (cacheConfig.expirationStrategy) {
+        case MODIFIED:
+            cache = CacheBuilder.newBuilder().maximumSize(cacheConfig.maxSize).expireAfterWrite(cacheConfig.expirationTimeoutSeconds, TimeUnit.SECONDS).build();
+            break;
+        case TOUCHED:
+            cache = CacheBuilder.newBuilder().maximumSize(cacheConfig.maxSize).expireAfterAccess(cacheConfig.expirationTimeoutSeconds, TimeUnit.SECONDS).build();
+            break;
+        }
     }
 
     /**
      * Construct local cache setting the provided max size and default value. <b>ttl is disabled, so no time based eviction will be performed.</b>
      *
      * @param sizeMax
-     *            max cache size
+     *         max cache size
      * @param defaultValue
-     *            default value (if no value is found for a specific key)
+     *         default value (if no value is found for a specific key)
      */
     public LocalCache(int sizeMax, final V defaultValue) {
         this.defaultValue = defaultValue;

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/KapuaCacheManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/KapuaCacheManager.java
@@ -12,19 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.service.internal.cache;
 
-import com.codahale.metrics.Counter;
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.kapua.KapuaErrorCodes;
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.KapuaRuntimeException;
-import org.eclipse.kapua.commons.metric.MetricServiceFactory;
-import org.eclipse.kapua.commons.setting.KapuaSettingException;
-import org.eclipse.kapua.commons.setting.system.SystemSetting;
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-import org.eclipse.kapua.commons.util.KapuaFileUtils;
-import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import javax.cache.Cache;
 import javax.cache.CacheException;
@@ -36,23 +29,27 @@ import javax.cache.expiry.Duration;
 import javax.cache.expiry.ModifiedExpiryPolicy;
 import javax.cache.expiry.TouchedExpiryPolicy;
 import javax.cache.spi.CachingProvider;
-import java.io.Serializable;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.commons.cache.ExpiryPolicy;
+import org.eclipse.kapua.commons.metric.MetricServiceFactory;
+import org.eclipse.kapua.commons.setting.KapuaSettingException;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.eclipse.kapua.commons.util.KapuaFileUtils;
+import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Counter;
 
 /**
- * Class responsible for managing the various caches that are instantiated.
- * All the caches are stored in a Map, where the keys are the cache names and the value are the caches themselves.
+ * Class responsible for managing the various caches that are instantiated. All the caches are stored in a Map, where the keys are the cache names and the value are the caches themselves.
  */
 public class KapuaCacheManager {
-
-    enum ExpiryPolicy {
-        MODIFIED,
-        TOUCHED
-    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KapuaCacheManager.class);
 
@@ -119,7 +116,8 @@ public class KapuaCacheManager {
     /**
      * Method responsible for getting an existing cache, or instantiating a new cache if the searched one does not exists yet.
      *
-     * @param cacheName the name of the cache.
+     * @param cacheName
+     *         the name of the cache.
      * @return the Cache object containing the desired cache.
      */
     public static Cache<Serializable, Serializable> getCache(String cacheName) {
@@ -138,7 +136,6 @@ public class KapuaCacheManager {
         }
         return cache;
     }
-
 
     private static void checkCacheManager() {
         //called by synchronized section so no concurrency issues can arise

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractBaseKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractBaseKapuaSetting.java
@@ -16,20 +16,20 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
-
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.DataConfiguration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.configuration.PropertyConverter;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 
 /**
- * An abstract base class which does not make any assumptions on where the
- * configuration comes from
+ * An abstract base class which does not make any assumptions on where the configuration comes from
  *
- * @param <K> The settings key type
+ * @param <K>
+ *         The settings key type
  */
 public class AbstractBaseKapuaSetting<K extends SettingKey> {
 
@@ -41,7 +41,8 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
      * This is useful for testing when the configuration has to be provided
      * </p>
      *
-     * @param map the map of values
+     * @param map
+     *         the map of values
      * @return the configuration, may be {@code null} if the "map" parameter was null
      */
     public static <K extends SettingKey> AbstractBaseKapuaSetting<K> fromMap(Map<String, Object> map) {
@@ -149,6 +150,30 @@ public class AbstractBaseKapuaSetting<K extends SettingKey> {
             }
         }
         return config.getInt(key.key());
+    }
+
+    /**
+     * Get an integer property
+     *
+     * @param key
+     * @return
+     */
+    public Optional<Integer> getInteger(K key) {
+        if (systemPropertyHotSwap) {
+            String sysProp = System.getProperty(key.key());
+            if (sysProp != null) {
+                try {
+                    return Optional.ofNullable(PropertyConverter.toInteger(sysProp));
+                } catch (Exception ex) {
+                    return Optional.empty();
+                }
+            }
+        }
+        try {
+            return Optional.ofNullable(config.getInteger(key.key(), null));
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
     }
 
     /**

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreCacheManager.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreCacheManager.java
@@ -16,15 +16,17 @@ import org.eclipse.kapua.commons.cache.LocalCache;
 import org.eclipse.kapua.service.datastore.internal.schema.Metadata;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettings;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettingsKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Datastore cache manager.<br>
- * It keeps informations about channels, metrics and clients to speed up the store operation and avoid time consuming unnecessary operations.
+ * Datastore cache manager.<br> It keeps informations about channels, metrics and clients to speed up the store operation and avoid time consuming unnecessary operations.
  *
  * @since 1.0.0
  */
 public class DatastoreCacheManager {
 
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private static final DatastoreCacheManager INSTANCE = new DatastoreCacheManager();
 
     private final LocalCache<String, Metadata> schemaCache;
@@ -33,16 +35,13 @@ public class DatastoreCacheManager {
     private final LocalCache<String, Boolean> clientsCache;
 
     private DatastoreCacheManager() {
-        DatastoreSettings config = DatastoreSettings.getInstance();
-        int expireAfter = config.getInt(DatastoreSettingsKey.CONFIG_CACHE_LOCAL_EXPIRE_AFTER);
-        int sizeMax = config.getInt(DatastoreSettingsKey.CONFIG_CACHE_LOCAL_SIZE_MAXIMUM);
-        int sizeMaxMetadata = config.getInt(DatastoreSettingsKey.CONFIG_CACHE_METADATA_LOCAL_SIZE_MAXIMUM);
+        final DatastoreSettings config = DatastoreSettings.getInstance();
+        final int sizeMaxMetadata = config.getInt(DatastoreSettingsKey.CONFIG_CACHE_METADATA_LOCAL_SIZE_MAXIMUM);
 
-        // TODO set expiration to happen frequently because the reset cache method will not get
-        // called from service clients any more
-        channelsCache = new LocalCache<>(sizeMax, expireAfter, false);
-        metricsCache = new LocalCache<>(sizeMax, expireAfter, false);
-        clientsCache = new LocalCache<>(sizeMax, expireAfter, false);
+        clientsCache = new LocalCache<>(config.getClientCacheConfig(), false);
+        channelsCache = new LocalCache<>(config.getChannelsCacheConfig(), false);
+        metricsCache = new LocalCache<>(config.getMetricsCacheConfig(), false);
+
         schemaCache = new LocalCache<>(sizeMaxMetadata, null);
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettings.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettings.java
@@ -12,7 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.setting;
 
+import java.util.EnumSet;
+import java.util.Optional;
+
+import org.eclipse.kapua.commons.cache.CacheConfig;
+import org.eclipse.kapua.commons.cache.ExpiryPolicy;
 import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Datastore {@link AbstractKapuaSetting}.
@@ -21,6 +28,7 @@ import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
  */
 public class DatastoreSettings extends AbstractKapuaSetting<DatastoreSettingsKey> {
 
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     /**
      * Resource file from which source properties.
      *
@@ -52,5 +60,51 @@ public class DatastoreSettings extends AbstractKapuaSetting<DatastoreSettingsKey
      */
     public static DatastoreSettings getInstance() {
         return INSTANCE;
+    }
+
+    private CacheConfig getCacheConfig(
+            String cacheName,
+            DatastoreSettingsKey specificCacheExpireKey,
+            DatastoreSettingsKey specificCacheExpireStrategy,
+            DatastoreSettingsKey specificCacheMaxSizeKey) {
+        int defaultExpireAfter = this.getInt(DatastoreSettingsKey.CONFIG_CACHE_LOCAL_EXPIRE_AFTER);
+        int defaultSizeMax = this.getInt(DatastoreSettingsKey.CONFIG_CACHE_LOCAL_SIZE_MAXIMUM);
+
+        final Optional<Integer> specificCacheExpireAfter = this.getInteger(specificCacheExpireKey);
+        final ExpiryPolicy expirationStrategy = Optional.ofNullable(this.getString(specificCacheExpireStrategy))
+                .flatMap(v -> EnumSet.allOf(ExpiryPolicy.class)
+                        .stream()
+                        .filter(e -> e.name().toUpperCase().equals(v.toUpperCase()))
+                        .findFirst())
+                .orElse(ExpiryPolicy.MODIFIED);
+        final Optional<Integer> specificCacheMaxSize = this.getInteger(specificCacheMaxSizeKey);
+        final Integer maxSizeFinal = specificCacheMaxSize.orElse(defaultSizeMax);
+        final Integer cacheExpireFinal = specificCacheExpireAfter.orElse(defaultExpireAfter);
+        logger.info("Config for {} cache: max size {}, expire time {}s with policy {}", cacheName, maxSizeFinal, cacheExpireFinal, expirationStrategy);
+        return new CacheConfig(maxSizeFinal, cacheExpireFinal, expirationStrategy);
+    }
+
+    public CacheConfig getClientCacheConfig() {
+        return getCacheConfig("clients",
+                DatastoreSettingsKey.CONFIG_CLIENTS_CACHE_LOCAL_EXPIRE_AFTER,
+                DatastoreSettingsKey.CONFIG_CLIENTS_CACHE_LOCAL_EXPIRE_STRATEGY,
+                DatastoreSettingsKey.CONFIG_CLIENTS_CACHE_LOCAL_SIZE_MAXIMUM
+        );
+    }
+
+    public CacheConfig getChannelsCacheConfig() {
+        return getCacheConfig("channels",
+                DatastoreSettingsKey.CONFIG_CHANNELS_CACHE_LOCAL_EXPIRE_AFTER,
+                DatastoreSettingsKey.CONFIG_CHANNELS_CACHE_LOCAL_EXPIRE_STRATEGY,
+                DatastoreSettingsKey.CONFIG_CHANNELS_CACHE_LOCAL_SIZE_MAXIMUM
+        );
+    }
+
+    public CacheConfig getMetricsCacheConfig() {
+        return getCacheConfig("metrics",
+                DatastoreSettingsKey.CONFIG_METRICS_CACHE_LOCAL_EXPIRE_AFTER,
+                DatastoreSettingsKey.CONFIG_METRICS_CACHE_LOCAL_EXPIRE_STRATEGY,
+                DatastoreSettingsKey.CONFIG_METRICS_CACHE_LOCAL_SIZE_MAXIMUM
+        );
     }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
@@ -23,15 +23,51 @@ import org.eclipse.kapua.commons.setting.SettingKey;
 public enum DatastoreSettingsKey implements SettingKey {
 
     /**
-     * Local cache expire time
+     * Local cache expire time (default value is no specific cache value is defined)
      */
     CONFIG_CACHE_LOCAL_EXPIRE_AFTER("datastore.cache.local.expire.after"),
     /**
-     * Local cache maximum size
+     * Channels Local cache expire time. Overrides the default value if specified, can be omitted to use the value of CONFIG_CACHE_LOCAL_EXPIRE_AFTER.
+     */
+    CONFIG_CHANNELS_CACHE_LOCAL_EXPIRE_AFTER("datastore.cache.channels.local.expire.after"),
+    /**
+     * Clients Local cache expire time. Overrides the default value if specified, can be omitted to use the value of CONFIG_CACHE_LOCAL_EXPIRE_AFTER.
+     */
+    CONFIG_CLIENTS_CACHE_LOCAL_EXPIRE_AFTER("datastore.cache.clients.local.expire.after"),
+    /**
+     * Metrics Local cache expire time. Overrides the default value if specified, can be omitted to use the value of CONFIG_CACHE_LOCAL_EXPIRE_AFTER.
+     */
+    CONFIG_METRICS_CACHE_LOCAL_EXPIRE_AFTER("datastore.cache.metrics.local.expire.after"),
+    /**
+     * Channels Local cache expire strategy (either MODIFIED or TOUCHED). If omitted, MODIFIED will be assumed.
+     */
+    CONFIG_CHANNELS_CACHE_LOCAL_EXPIRE_STRATEGY("datastore.cache.channels.local.expire.strategy"),
+    /**
+     * Clients Local cache expire strategy (either MODIFIED or TOUCHED). If omitted, MODIFIED will be assumed.
+     */
+    CONFIG_CLIENTS_CACHE_LOCAL_EXPIRE_STRATEGY("datastore.cache.clients.local.expire.strategy"),
+    /**
+     * Metrics Local cache expire strategy (either MODIFIED or TOUCHED). If omitted, MODIFIED will be assumed.
+     */
+    CONFIG_METRICS_CACHE_LOCAL_EXPIRE_STRATEGY("datastore.cache.metrics.local.expire.strategy"),
+    /**
+     * Local cache maximum size (default value is no specific cache value is defined)
      */
     CONFIG_CACHE_LOCAL_SIZE_MAXIMUM("datastore.cache.local.size.maximum"),
     /**
-     * Metadata cache maximum size
+     * Channels Local cache expire time. Overrides the default value if specified, can be omitted to use the value of CONFIG_CACHE_LOCAL_SIZE_MAXIMUM.
+     */
+    CONFIG_CHANNELS_CACHE_LOCAL_SIZE_MAXIMUM("datastore.cache.channels.local.size.maximum"),
+    /**
+     * Clients Local cache expire time. Overrides the default value if specified, can be omitted to use the value of CONFIG_CACHE_LOCAL_SIZE_MAXIMUM.
+     */
+    CONFIG_CLIENTS_CACHE_LOCAL_SIZE_MAXIMUM("datastore.cache.clients.local.size.maximum"),
+    /**
+     * Metrics Local cache expire time. Overrides the default value if specified, can be omitted to use the value of CONFIG_CACHE_LOCAL_SIZE_MAXIMUM.
+     */
+    CONFIG_METRICS_CACHE_LOCAL_SIZE_MAXIMUM("datastore.cache.metrics.local.size.maximum"),
+    /**
+     * Metadata cache maximum size (default value is no specific cache value is defined)
      */
     CONFIG_CACHE_METADATA_LOCAL_SIZE_MAXIMUM("datastore.cache.metadata.local.size.maximum"),
     /**

--- a/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
@@ -11,28 +11,37 @@
 #     Eurotech - initial API and implementation
 #     Red Hat Inc
 ###############################################################################
-
 # Index parameters
 #refresh interval (in seconds)
 datastore.index.refresh_interval=5
 datastore.index.number_of_shards=1
 datastore.index.number_of_replicas=0
-
 #
 #maximum entries to be deleted in a single delete call
 datastore.delete.max_entries_on_delete=100
-
 #
 # Local cache setting
-
+# MUST be defined even if all caches are overridden
 # Expire timeout for the registry services cache in seconds
-datastore.cache.local.expire.after=60
 datastore.cache.local.size.maximum=1000
+datastore.cache.local.expire.after=60
 datastore.cache.metadata.local.size.maximum=1000
-
+# Specific caches overrides
+# Clients cache overrides (if any value is omitted, the Local cache settings equivalent will be used)
+#datastore.cache.clients.local.size.maximum=1100
+#datastore.cache.clients.local.expire.after=120
+#datastore.cache.clients.local.expire.strategy=TOUCHED
+# Channels cache overrides (if any value is omitted, the Local cache settings equivalent will be used)
+#datastore.cache.channels.local.size.maximum=1100
+#datastore.cache.channels.local.expire.after=120
+#datastore.cache.channels.local.expire.strategy=TOUCHED
+# Metrics cache overrides (if any value is omitted, the Local cache settings equivalent will be used)
+#datastore.cache.metrics.local.size.maximum=1100
+#datastore.cache.metrics.local.expire.after=120
+#datastore.cache.metrics.local.expire.strategy=TOUCHED
+#
 # Datastore index prefix
 datastore.index.prefix=
-
 #
 #maximum value for limit parameter
 datastore.query.limit.max=10000


### PR DESCRIPTION
This PR adds the ability to override the default configuration for datastore caches on an individual basis.
The following additional parameters can now be used to fine-tune caches:
```
# Specific caches overrides
# Clients cache overrides (if any value is omitted, the Local cache settings equivalent will be used)
#datastore.cache.clients.local.size.maximum=1100
#datastore.cache.clients.local.expire.after=120
#datastore.cache.clients.local.expire.strategy=TOUCHED
# Channels cache overrides (if any value is omitted, the Local cache settings equivalent will be used)
#datastore.cache.channels.local.size.maximum=1100
#datastore.cache.channels.local.expire.after=120
#datastore.cache.channels.local.expire.strategy=TOUCHED
# Metrics cache overrides (if any value is omitted, the Local cache settings equivalent will be used)
#datastore.cache.metrics.local.size.maximum=1100
#datastore.cache.metrics.local.expire.after=120
#datastore.cache.metrics.local.expire.strategy=TOUCHED
``` 
