### PR TITLE
:bug: [Accounts] Current account update was not checking for not null organisation name and email

### DIFF
--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountMapper.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountMapper.java
@@ -13,15 +13,19 @@
 package org.eclipse.kapua.service.account.internal;
 
 import org.eclipse.kapua.commons.model.mappers.KapuaBaseMapper;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountFactory;
 import org.eclipse.kapua.service.account.AccountUpdateRequest;
 import org.eclipse.kapua.service.account.CurrentAccountUpdateRequest;
+import org.eclipse.kapua.service.account.Organization;
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(uses = KapuaBaseMapper.class, componentModel = MappingConstants.ComponentModel.JSR330, injectionStrategy = InjectionStrategy.CONSTRUCTOR, collectionMappingStrategy = CollectionMappingStrategy.TARGET_IMMUTABLE)
 public interface AccountMapper {
@@ -36,6 +40,14 @@ public interface AccountMapper {
     @Mapping(target = "parentAccountPath", ignore = true)
     @Mapping(target = "childAccounts", ignore = true)
     void merge(@MappingTarget Account account, AccountUpdateRequest request);
+
+    default Organization createOrganisation() {
+        return KapuaLocator.getInstance().getComponent(AccountFactory.class).newOrganization();
+    }
+
+    @Mapping(target = "name", source = "name", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "email", source = "email", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(@MappingTarget Organization account, Organization request);
 
     //For backward compatibility only
     AccountUpdateRequest mapChildUpdate(Account account);

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -189,7 +189,9 @@ public class AccountServiceImpl
 
     private Account doUpdateCurrentAccount(CurrentAccountUpdateRequest request) throws KapuaException {
         ArgumentValidator.notNull(request.organization, "request.organization");
-        ArgumentValidator.match(request.organization.getEmail(), CommonsValidationRegex.EMAIL_REGEXP, "request.organization.email");
+        ArgumentValidator.notEmptyOrNull(request.organization.getName(), "account.organization.name");
+        ArgumentValidator.notEmptyOrNull(request.organization.getEmail(), "account.organization.email");
+        ArgumentValidator.match(request.organization.getEmail(), CommonsValidationRegex.EMAIL_REGEXP, "account.organization.email");
 
         final KapuaId accountId = KapuaSecurityUtils.getSession().getScopeId();
         authorizationService.checkPermission(permissionFactory.newPermission(Domains.ACCOUNT, Actions.write, accountId));
@@ -208,6 +210,8 @@ public class AccountServiceImpl
         // Argument validation
         ArgumentValidator.notNull(accountId, "accountId");
         ArgumentValidator.notNull(request.organization, "account.organization");
+        ArgumentValidator.notEmptyOrNull(request.organization.getName(), "account.organization.name");
+        ArgumentValidator.notEmptyOrNull(request.organization.getEmail(), "account.organization.email");
         ArgumentValidator.match(request.organization.getEmail(), CommonsValidationRegex.EMAIL_REGEXP, "account.organization.email");
 
         return txManager.execute(tx -> {


### PR DESCRIPTION
This PR fixes the following bug:

Invoke the PUT v1/account endpoint with the payload:
{
  "optlock": 32,
  "organization": {
   "expirationDate": "2026-02-01T22:59_59.999Z"
  }
}
An error 500 is returned:
{
  "type": "exceptionInfo",
  "httpErrorCode": 500,
  "message": "An internal error occurred: Error during Persistence Operation.",
  "kapuaErrorCode": "INTERNAL_ERROR"
}
Expected behaviour:
An error of class 400 should be returned.
