### PR TITLE
✨ [REST API] Added "askTotalCount" parameter for tags api

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Tags.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Tags.java
@@ -67,6 +67,7 @@ public class Tags extends AbstractKapuaResource {
     public TagListResult simpleQuery(
             @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("name") String name,
+            @QueryParam("askTotalCount") boolean askTotalCount,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         TagQuery query = tagFactory.newQuery(scopeId);
@@ -79,6 +80,7 @@ public class Tags extends AbstractKapuaResource {
 
         query.setOffset(offset);
         query.setLimit(limit);
+        query.setAskTotalCount(askTotalCount);
 
         return query(scopeId, query);
     }

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId.yaml
@@ -25,6 +25,7 @@ paths:
           description: The tag name to filter results
           schema:
             type: string
+        - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:


### PR DESCRIPTION
Similarly as we have for devices and other APIs,  query parameter askTotalCount, boolean, has been added to provide capability to count total number of tags present in db