### PR TITLE
:zap: [Datastore] Reduce the number of queries to keep the registry info updates

### DIFF
--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
@@ -71,6 +71,11 @@ public enum DatastoreSettingsKey implements SettingKey {
      */
     CONFIG_CACHE_METADATA_LOCAL_SIZE_MAXIMUM("datastore.cache.metadata.local.size.maximum"),
     /**
+     * Metrics behaviour switch - when the cache does not know a specific metric, should the system ask ES about it (set to true, default) or just send an upsert for non-cached metrics (set to
+     * false)?
+     */
+    CONFIG_CACHE_METRICS_FETCH_FROM_SOURCE_BEFORE_UPSERT("datastore.cache.metrics.fetchBeforeUpsert"),
+    /**
      * Enable datastore timing profile
      */
     CONFIG_DATA_STORAGE_ENABLE_TIMING_PROFILE("datastore.enableTimingProfile"),

--- a/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
@@ -39,6 +39,7 @@ datastore.cache.metadata.local.size.maximum=1000
 #datastore.cache.metrics.local.size.maximum=1100
 #datastore.cache.metrics.local.expire.after=120
 #datastore.cache.metrics.local.expire.strategy=TOUCHED
+#datastore.cache.metrics.fetchBeforeUpsert=false
 #
 # Datastore index prefix
 datastore.index.prefix=


### PR DESCRIPTION
This pr adds a configuration switch that allows to skip a costly (and potentially unneccesary) fetch from elasticsearch currently performed for each metric not present in the cache (very inefficient in case of device messages with a lot of metrics).
The behaviour can me configured by the following parameter:
`datastore.cache.metrics.fetchBeforeUpsert=true`
omit the configuration or leave at 'true' to maintain the current behaviour, set to 'false' to skip the fetch