### PR TITLE
🐛  [Open API] FIX - Removed base64 format on dataChannel API docoumentation

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel.yaml
@@ -21,7 +21,6 @@ components:
       description: The ID of the ChannelInfo on which to perform the operation
       schema:
         type: string
-        format: base64
       required: true
   schemas:
     channelInfo:


### PR DESCRIPTION
The channelInfoId field has a file type. Should be a string, see the picture below.
This PR fixes this problem

![image](https://github.com/eclipse/kapua/assets/39708353/cfcedf91-522e-4a4d-a0cf-88861abadf22)