### PR TITLE
🐛 Resolved JWT Certificate Issue Preventing REST API Logins for Accounts

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -12,6 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro;
 
+import java.util.Date;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import com.google.common.collect.Sets;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.ShiroException;
@@ -101,14 +109,6 @@ import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Date;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * {@link AuthenticationService} implementation.


### PR DESCRIPTION
**Issue Overview:**
Creating a JWT Certificate in a child account was causing login failures for users attempting to access the REST API. This affected both users of the child account and users from other accounts.

**Steps to Reproduce:**
1. Create a child account.
2. Create a JWT Certificate in the child account.
3. Log out and attempt to perform a login from the Console NG.

**Current Behaviour:**
- Users of the child account encounter login errors.
- Users from other accounts also encounter login errors.

**Expected Behaviour:**
- Users should be able to login with their own JWT certificate or the closest valid certificate in the hierarchy.

**Fix Implemented:**
Instead of querying the certificates and retrieving only one without specifying sorting (which defaulted to alphabetical order by name), the fix introduces significant changes:

1. **Query All Certificates:** The new implementation queries all of the user's certificates as well as the inherited ones. This comprehensive query ensures all potential JWT certificates are considered.
   
2. **Determine the Nearest Certificate:** A new function, `getNearestCertificate`, is introduced. This function processes the list of queried certificates to determine the nearest valid certificate. The function `getNearestCertificateFromList` is then used to get the actual closest certificate, prioritizing the user's own JWT certificate if it exists, or the closest parent JWT certificate otherwise.

This approach ensures that the most relevant JWT certificate is used for authentication.

**Code Changes:**
- Added `getNearestCertificate` function to query and process all relevant certificates.
- Implemented `getNearestCertificateFromList` to select the nearest valid certificate from the list.

**Screen Sharing of the Fix:**
[Screen sharing of the fix](https://github.com/user-attachments/assets/c094020d-81e8-45b4-aada-0e79d4694eec)

**Impact:**
- Users across all accounts can now reliably login to the REST API.

By merging this pull request, we ensure that the JWT Certificate creation process no longer disrupts the login functionality, providing a smoother and more secure user experience across all accounts.