### PR TITLE
🐛 [Open API] FIX - API doc. on "GET /{scopeId}/devices" request section

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
@@ -30,7 +30,15 @@ paths:
         - $ref: './device.yaml#/components/parameters/fetchAttributes'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
-        - $ref: '../openapi.yaml#/components/parameters/sortDir'
+        - name: sortDir
+          in: query
+          description: The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive (except for "clientId" parameter).
+          schema:
+            type: string
+            enum:
+              - ASCENDING
+              - DESCENDING
+            default: ASCENDING
         - name: matchTerm
           in: query
           description: |


### PR DESCRIPTION
API documentation for:

GET /{scopeId}/devices

explains that sort is case insensitive. While this is true for most of the fields there are some cases when it is not. For example the clientID.
This PR fixed the issue