### PR TITLE
:bug: [Console GWT] Fixed Credential Edit dialog does not letting update the selected Credential

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
@@ -33,16 +33,16 @@ public class CredentialEditDialog extends CredentialAddDialog {
 
     public CredentialEditDialog(GwtSession currentSession, GwtCredential selectedCredential, String selectedUserId, String selectedUserName) {
         super(currentSession, selectedUserId, selectedUserName);
+
         this.selectedCredential = selectedCredential;
     }
 
     @Override
     public void submit() {
-        // TODO read enabled and expire date
-        selectedCredential.setCredentialKey(password.getValue());
         selectedCredential.setExpirationDate(expirationDate.getValue());
         selectedCredential.setCredentialStatus(credentialStatus.getValue().getValue().toString());
         selectedCredential.setOptlock(optlock.getValue().intValue());
+
         GWT_CREDENTIAL_SERVICE.update(xsrfToken, selectedCredential, new AsyncCallback<GwtCredential>() {
 
             @Override
@@ -99,16 +99,26 @@ public class CredentialEditDialog extends CredentialAddDialog {
     @Override
     protected void onRender(Element parent, int pos) {
         super.onRender(parent, pos);
-        password.setVisible(false);
-        confirmPassword.setVisible(false);
-        passwordTooltip.setVisible(false);
-        credentialFormPanel.remove(credentialType);
-        credentialTypeLabel.setVisible(true);
+
+        password.hide();
+        password.disable();
+
+        confirmPassword.hide();
+        confirmPassword.disable();
+
+        passwordTooltip.hide();
+
+        credentialType.hide();
+        credentialType.disable();
+
+        credentialTypeLabel.show();
         credentialTypeLabel.setValue(selectedCredential.getCredentialType());
+
         if (selectedCredential.getLockoutReset() != null && selectedCredential.getLockoutReset().after(new Date())) {
             lockedUntil.setText(MSGS.dialogEditLockedUntil(DateUtils.formatDateTime(selectedCredential.getLockoutReset())));
             credentialFormPanel.add(lockedUntil);
         }
+
         DialogUtils.resizeDialog(this, 400, 230);
     }
 

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/GwtKapuaAuthenticationModelConverter.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/GwtKapuaAuthenticationModelConverter.java
@@ -123,12 +123,11 @@ public class GwtKapuaAuthenticationModelConverter {
     public static Credential convertCredential(GwtCredential gwtCredential) {
 
         // Convert scopeId
-        KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(gwtCredential.getScopeId());
-        Credential credential = CREDENTIAL_FACTORY.newEntity(scopeId);
+        Credential credential = CREDENTIAL_FACTORY.newEntity(GwtKapuaCommonsModelConverter.convertKapuaId(gwtCredential.getScopeId()));
+
         GwtKapuaCommonsModelConverter.convertUpdatableEntity(gwtCredential, credential);
-        if (gwtCredential.getId() != null && !gwtCredential.getId().trim().isEmpty()) {
-            credential.setId(GwtKapuaCommonsModelConverter.convertKapuaId(gwtCredential.getId()));
-        }
+
+        credential.setId(GwtKapuaCommonsModelConverter.convertKapuaId(gwtCredential.getId()));
         credential.setUserId(GwtKapuaCommonsModelConverter.convertKapuaId(gwtCredential.getUserId()));
         credential.setCredentialType(convertCredentialType(gwtCredential.getCredentialTypeEnum()));
         credential.setCredentialKey(gwtCredential.getCredentialKey());
@@ -138,6 +137,7 @@ public class GwtKapuaAuthenticationModelConverter {
         credential.setFirstLoginFailure(gwtCredential.getFirstLoginFailure());
         credential.setLoginFailuresReset(gwtCredential.getLoginFailuresReset());
         credential.setLockoutReset(gwtCredential.getLockoutReset());
+
         // Return converted
         return credential;
     }


### PR DESCRIPTION
This PR  fixes the editing of the a Credential from the web admin Console which is currently never enabling the submit button.

**Related Issue**
This PR fixes/closes _{issue number}_

**Description of the solution adopted**
Hide and disabled fields that are not editable from the User in the Edit Dialog

**Screenshots**
_None_

**Any side note on the changes made**
_None_