### PR TITLE
:bug: [Datastore] FIX - SSL configuration on Elasticsearch clients

### DIFF
--- a/assembly/consumer/telemetry/docker/Dockerfile
+++ b/assembly/consumer/telemetry/docker/Dockerfile
@@ -37,7 +37,6 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
               -Dcommons.eventbus.url=\${SERVICE_BROKER_ADDR} \
               -Dconsumer.jaxb_context_class_name=org.eclipse.kapua.consumer.telemetry.TelemetryJAXBContextProvider \
               -Ddatastore.elasticsearch.nodes=\${DATASTORE_ADDR} \
-              -Ddatastore.elasticsearch.port=\${DATASTORE_PORT} \
               -Ddatastore.client.class=\${DATASTORE_CLIENT} \
               -Dbroker.host=\${BROKER_HOST} \
               -Dbroker.port=\${BROKER_PORT} \

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
@@ -374,7 +374,6 @@ public class BasicSteps extends TestBase {
         logger.info("{}: {}", SystemSettingKey.DB_JDBC_DRIVER.key(), SystemSetting.getInstance().getString(SystemSettingKey.DB_JDBC_DRIVER));
         logger.info("{}: {}", SystemSettingKey.DB_CONNECTION_SCHEME.key(), SystemSetting.getInstance().getString(SystemSettingKey.DB_CONNECTION_SCHEME));
         logger.info("Rest: datastore.elasticsearch.node: {}", DatastoreElasticsearchClientSettings.getInstance().getString(DatastoreElasticsearchClientSettingsKey.NODES));
-        logger.info("Rest: datastore.elasticsearch.port: {}", DatastoreElasticsearchClientSettings.getInstance().getString(DatastoreElasticsearchClientSettingsKey.PORT));
         logger.info("===============================================");
     }
 

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastoreJunit/MessageStoreServiceSslTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastoreJunit/MessageStoreServiceSslTest.java
@@ -96,7 +96,6 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
     @Ignore
     public void connectNoSsl() throws InterruptedException, KapuaException, ParseException {
         // datastore.elasticsearch.ssl.enabled=false
-        // datastore.elasticsearch.ssl.trust_server_certificate=false
         // datastore.elasticsearch.ssl.keystore.path=
         // datastore.elasticsearch.ssl.keystore.password=
         // datastore.elasticsearch.ssl.keystore.type=jks
@@ -117,7 +116,6 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
     @Ignore
     public void connectSsl() throws InterruptedException, KapuaException, ParseException {
         // datastore.elasticsearch.ssl.enabled=true
-        // datastore.elasticsearch.ssl.trust_server_certificate=false
         // datastore.elasticsearch.ssl.keystore.path=
         // datastore.elasticsearch.ssl.keystore.password=
         // datastore.elasticsearch.ssl.keystore.type=jks
@@ -137,7 +135,6 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
     @Ignore
     public void connectSslTrustServerNoTrustStoreSet() throws InterruptedException, KapuaException, ParseException {
         // datastore.elasticsearch.ssl.enabled=true
-        // datastore.elasticsearch.ssl.trust_server_certificate=true
         // datastore.elasticsearch.ssl.keystore.path=
         // datastore.elasticsearch.ssl.keystore.password=
         // datastore.elasticsearch.ssl.keystore.type=jks
@@ -157,7 +154,6 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
     @Ignore
     public void connectSslTrustServerTrustStoreSet() throws InterruptedException, KapuaException, ParseException {
         // datastore.elasticsearch.ssl.enabled=false
-        // datastore.elasticsearch.ssl.trust_server_certificate=false
         // datastore.elasticsearch.ssl.keystore.path=
         // datastore.elasticsearch.ssl.keystore.password=
         // datastore.elasticsearch.ssl.keystore.type=jks
@@ -177,7 +173,6 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
     @Ignore
     public void connectSslTrustServerSelfSignedTrustStore() throws InterruptedException, KapuaException, ParseException {
         // datastore.elasticsearch.ssl.enabled=false
-        // datastore.elasticsearch.ssl.trust_server_certificate=false
         // datastore.elasticsearch.ssl.keystore.path=
         // datastore.elasticsearch.ssl.keystore.password=
         // datastore.elasticsearch.ssl.keystore.type=jks

--- a/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -35,7 +35,6 @@ datastore.elasticsearch.request.socket.timeout.millis=-1
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false
-datastore.elasticsearch.ssl.trust_server_certificate=false
 datastore.elasticsearch.ssl.keystore.path=
 datastore.elasticsearch.ssl.keystore.password=
 datastore.elasticsearch.ssl.keystore.type=jks

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientSslConfiguration.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientSslConfiguration.java
@@ -41,7 +41,6 @@ package org.eclipse.kapua.service.elasticsearch.client.configuration;
 public class ElasticsearchClientSslConfiguration {
 
     private boolean enabled;
-    private boolean trustServiceCertificate;
     private String keyStorePath;
     private String keyStorePassword;
     private String keyStoreType;
@@ -69,28 +68,6 @@ public class ElasticsearchClientSslConfiguration {
      */
     public ElasticsearchClientSslConfiguration setEnabled(boolean enabled) {
         this.enabled = enabled;
-        return this;
-    }
-
-    /**
-     * Gets whether or not to trust the server certificate.
-     *
-     * @return {@code true} if needs to be trusted, {@code false} otherwise.
-     * @since 1.3.0
-     */
-    public boolean isTrustServiceCertificate() {
-        return trustServiceCertificate;
-    }
-
-    /**
-     * Sets whether or not to trust the server certificate.
-     *
-     * @param trustServiceCertificate {@code true} if needs to be trusted, {@code false} otherwise.
-     * @return This {@link ElasticsearchClientSslConfiguration} to chain method invocation.
-     * @since 1.3.0
-     */
-    public ElasticsearchClientSslConfiguration setTrustServiceCertificate(boolean trustServiceCertificate) {
-        this.trustServiceCertificate = trustServiceCertificate;
         return this;
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
@@ -39,13 +39,21 @@ public class DatastoreElasticsearchClientConfiguration extends ElasticsearchClie
 
         setUsername(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.USERNAME));
         setPassword(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.PASSWORD));
+
         getRequestConfiguration().setQueryTimeout(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_QUERY_TIMEOUT));
         getRequestConfiguration().setScrollTimeout(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_SCROLL_TIMEOUT));
         getRequestConfiguration().setConnectionTimeoutMillis(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_CONNECTION_TIMEOUT_MILLIS, -1));
         getRequestConfiguration().setSocketTimeoutMillis(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_SOCKET_TIMEOUT_MILLIS, -1));
         getRequestConfiguration().setRequestRetryAttemptMax(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_RETRY_MAX));
         getRequestConfiguration().setRequestRetryAttemptWait(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.REQUEST_RETRY_WAIT));
+
         getSslConfiguration().setEnabled(elasticsearchClientSettings.getBoolean(DatastoreElasticsearchClientSettingsKey.SSL_ENABLED));
+        getSslConfiguration().setKeyStoreType(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.SSL_KEYSTORE_TYPE));
+        getSslConfiguration().setKeyStorePath(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.SSL_KEYSTORE_PATH));
+        getSslConfiguration().setKeyStorePassword(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.SSL_KEYSTORE_PASSWORD));
+        getSslConfiguration().setTrustStorePath(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.SSL_TRUSTSTORE_PATH));
+        getSslConfiguration().setTrustStorePassword(elasticsearchClientSettings.getString(DatastoreElasticsearchClientSettingsKey.SSL_TRUSTSTORE_PASSWORD));
+
         setNumberOfIOThreads(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.NUMBER_OF_IO_THREADS, 0));
         getReconnectConfiguration().setReconnectDelay(30000);
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
@@ -52,17 +52,11 @@ public enum DatastoreElasticsearchClientSettingsKey implements SettingKey {
      */
     PASSWORD("datastore.elasticsearch.password"),
     /**
-     * Elasticsearch port.
-     *
-     * @since 1.3.0
-     */
-    PORT("datastore.elasticsearch.port"),
-    /**
      * Wait between client reconnection task executions.
      *
      * @since 1.3.0
      */
-    CLIENT_RECONNECTION_WAIT_BETWEEN_EXECUTIONS("datastore.elasticsearch.client.reconnection_wait_between_exec"),
+    CLIENT_RECONNECTION_WAIT_BETWEEN_EXECUTIONS("datastore.elasticsearch.client.reconnection_wait_between_exec"), //TODO: this is not used, should we allow to set a value for this?
     /**
      * Request query timeout.
      *
@@ -94,13 +88,6 @@ public enum DatastoreElasticsearchClientSettingsKey implements SettingKey {
      */
     SSL_ENABLED("datastore.elasticsearch.ssl.enabled"),
 
-    /**
-     * Force Elastichsearch client to trust the server certificate on the ssl connection handshake so, if true, no check will be performed for the server certificate (at the present only the rest
-     * client supports it)
-     *
-     * @since 1.3.0
-     */
-    SSL_TRUST_SERVER_CERTIFICATE("datastore.elasticsearch.ssl.trust_server_certificate"),
     /**
      * Elastichsearch client key store password (at the present only the rest client supports it).
      *

--- a/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -35,7 +35,6 @@ datastore.elasticsearch.request.socket.timeout.millis=-1
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false
-datastore.elasticsearch.ssl.trust_server_certificate=false
 datastore.elasticsearch.ssl.keystore.path=
 datastore.elasticsearch.ssl.keystore.password=
 datastore.elasticsearch.ssl.keystore.type=jks

--- a/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
@@ -36,7 +36,6 @@ datastore.elasticsearch.request.socket.timeout.millis=-1
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false
-datastore.elasticsearch.ssl.trust_server_certificate=false
 datastore.elasticsearch.ssl.keystore.path=
 datastore.elasticsearch.ssl.keystore.password=
 datastore.elasticsearch.ssl.keystore.type=jks

--- a/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
@@ -36,7 +36,6 @@ datastore.elasticsearch.request.socket.timeout.millis=-1
 #
 # SSL
 datastore.elasticsearch.ssl.enabled=false
-datastore.elasticsearch.ssl.trust_server_certificate=false
 datastore.elasticsearch.ssl.keystore.path=
 datastore.elasticsearch.ssl.keystore.password=
 datastore.elasticsearch.ssl.keystore.type=jks


### PR DESCRIPTION
There were some errors in how we configured SSL connection from the ES client to the ES instance that this PR addressed in different ways

1. The "datastore.elasticsearch.ssl.trust_server_certificate" property value has been removed from the code, considered too harmful. Besides, it's logic was inverted in the ES client code (when True actually was considered False and vice versa, something quite dangerous that was luckily "fixed" by a subsequent bug: the next point)
2. We were not considering that, when setting the connection manager "DefaultConnectingIOReactor" in the ES client code, it was hiding the whole SSL context we configured earlier in the code. I modified a bit the logic of this configuration to solve this problem.

In particular, when we were doing this:
<img width="552" alt="Screenshot 2024-07-24 at 15 44 09" src="https://github.com/user-attachments/assets/c4202fc3-9bf5-4128-b749-fd3ce63623f2">

we were not considering this fact:

![Screenshot 2024-07-24 at 15 44 33](https://github.com/user-attachments/assets/ea15f5e6-edd2-4124-b8b5-621d8d35c59c)

3. Some env. variables related to SSL and ES, both set on docker compose and on helm-charts, were not linked/read at all within the code, so I added them inside the "DatastoreElasticsearchClientConfiguration.java" Class for completeness. With this, the SSL can be configured completely