### PR TITLE
:fire: [Docker] Removed obsolete 'version' from Docker Compose files

### DIFF
--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     container_name: db

--- a/deployment/docker/compose/extras/docker-compose.api-dev.yml
+++ b/deployment/docker/compose/extras/docker-compose.api-dev.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   kapua-api:
     environment:

--- a/deployment/docker/compose/extras/docker-compose.broker-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.broker-debug.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   message-broker:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.broker-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.broker-jmx.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   message-broker:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.broker-ssl.yml
+++ b/deployment/docker/compose/extras/docker-compose.broker-ssl.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   message-broker:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.console-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.console-debug.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   kapua-console:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.console-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.console-jmx.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   kapua-console:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.console-ssl.yml
+++ b/deployment/docker/compose/extras/docker-compose.console-ssl.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   kapua-console:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.consumer-lifecycle-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.consumer-lifecycle-debug.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   consumer-lifecycle:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.consumer-lifecycle-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.consumer-lifecycle-jmx.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   consumer-lifecycle:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.consumer-telemetry-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.consumer-telemetry-debug.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   consumer-telemetry:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.consumer-telemetry-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.consumer-telemetry-jmx.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   consumer-telemetry:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.db-dev.yml
+++ b/deployment/docker/compose/extras/docker-compose.db-dev.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.es-dev.yml
+++ b/deployment/docker/compose/extras/docker-compose.es-dev.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   es-hq:
     container_name: es-hq

--- a/deployment/docker/compose/extras/docker-compose.es-storage-dir.yml
+++ b/deployment/docker/compose/extras/docker-compose.es-storage-dir.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   es:
     volumes:

--- a/deployment/docker/compose/extras/docker-compose.job-engine-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.job-engine-debug.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   job-engine:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.job-engine-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.job-engine-jmx.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   job-engine:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.rest-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.rest-debug.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   kapua-api:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.rest-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.rest-jmx.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   kapua-api:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.rest-ssl.yml
+++ b/deployment/docker/compose/extras/docker-compose.rest-ssl.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   kapua-api:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.service-authentication-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.service-authentication-debug.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   service-authentication:
     ports:

--- a/deployment/docker/compose/extras/docker-compose.service-authentication-jmx.yml
+++ b/deployment/docker/compose/extras/docker-compose.service-authentication-jmx.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   service-authentication:
     ports:

--- a/deployment/docker/compose/sso/docker-compose.console-sso.yml
+++ b/deployment/docker/compose/sso/docker-compose.console-sso.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   kapua-console:
     image: kapua/kapua-console:${IMAGE_VERSION}-sso

--- a/deployment/docker/compose/sso/docker-compose.keycloak.yml
+++ b/deployment/docker/compose/sso/docker-compose.keycloak.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   keycloak:
     container_name: kapua-keycloak


### PR DESCRIPTION
This PR removes obsolete `version` definition from Docker Compose files

See https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional

**Related Issue**
_None_

**Description of the solution adopted**
Removed `version` definition from Docker Compose files

**Screenshots**
_None_

**Any side note on the changes made**
_None_