### PR TITLE
✨ [REST API] Implement sorting functionality in `/{scopeId}/roles` API

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
@@ -84,9 +84,6 @@ public class EndpointInfos extends AbstractKapuaResource {
         if (matchTerm != null && !matchTerm.isEmpty()) {
             andPredicate.and(query.matchPredicate(matchTerm));
         }
-        if (matchTerm != null && !matchTerm.isEmpty()) {
-            andPredicate.and(query.matchPredicate(matchTerm));
-        }
         if (!Strings.isNullOrEmpty(sortParam)) {
             query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
         }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Roles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Roles.java
@@ -12,6 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
+import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import com.google.common.base.Strings;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
@@ -35,21 +50,6 @@ import org.eclipse.kapua.service.user.UserFactory;
 import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserQuery;
 import org.eclipse.kapua.service.user.UserService;
-
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.List;
 
 @Path("{scopeId}/roles")
 public class Roles extends AbstractKapuaResource {
@@ -81,6 +81,8 @@ public class Roles extends AbstractKapuaResource {
             @QueryParam("name") String name,
             @QueryParam("matchTerm") String matchTerm,
             @QueryParam("askTotalCount") boolean askTotalCount,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         RoleQuery query = roleFactory.newQuery(scopeId);
@@ -91,6 +93,9 @@ public class Roles extends AbstractKapuaResource {
         }
         if (matchTerm != null && !matchTerm.isEmpty()) {
             andPredicate.and(query.matchPredicate(matchTerm));
+        }
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
         }
         query.setPredicate(andPredicate);
 

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId.yaml
@@ -36,6 +36,16 @@ paths:
           schema:
             type: string
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - name: sortDir
+          in: query
+          description: The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive (except for "clientId" parameter).
+          schema:
+            type: string
+            enum:
+              - ASCENDING
+              - DESCENDING
+            default: ASCENDING
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:


### PR DESCRIPTION
### Summary
This pull request introduces sorting capabilities to the '/{scopeId}/roles' API endpoint by adding two new query parameters: `sortDir` and `sortParam`.

### Details
- **sortDir:** Accepts NULL/ASCENDING/DESCENDING, and determines the order of sorting.
- **sortParam:** Defines the field by which the sorting is applied.
  
This enhancement mirrors the sorting functionality already available in other API endpoints, such as `/devices`. By using these parameters, users can now sort the roles information based on any specified field in either ascending or descending order.

### Example Usage
To sort the roles information in ascending order by a specific field, the request would look like:
`GET /{scopeId}/roles?sortDir=ASCENDING&sortParam=<field_name>`
This update enhances the flexibility and usability of the API by providing consistent sorting behavior across different endpoints.