### PR TITLE
✨ [REST API] Implement sorting functionality in `/{scopeId}/credentials` API

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Credentials.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Credentials.java
@@ -12,21 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.app.api.core.model.CountResult;
-import org.eclipse.kapua.app.api.core.model.EntityId;
-import org.eclipse.kapua.app.api.core.model.ScopeId;
-import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
-import org.eclipse.kapua.model.query.predicate.AndPredicate;
-import org.eclipse.kapua.service.KapuaService;
-import org.eclipse.kapua.service.authentication.credential.Credential;
-import org.eclipse.kapua.service.authentication.credential.CredentialAttributes;
-import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
-import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
-import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
-import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
-import org.eclipse.kapua.service.authentication.credential.CredentialService;
-
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -40,6 +25,23 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import com.google.common.base.Strings;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.app.api.core.model.CountResult;
+import org.eclipse.kapua.app.api.core.model.EntityId;
+import org.eclipse.kapua.app.api.core.model.ScopeId;
+import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialAttributes;
+import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
+import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
+import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
+import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
+import org.eclipse.kapua.service.authentication.credential.CredentialService;
 
 @Path("{scopeId}/credentials")
 public class Credentials extends AbstractKapuaResource {
@@ -66,6 +68,8 @@ public class Credentials extends AbstractKapuaResource {
     public CredentialListResult simpleQuery(
             @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("userId") EntityId userId,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         CredentialQuery query = credentialFactory.newQuery(scopeId);
@@ -73,6 +77,9 @@ public class Credentials extends AbstractKapuaResource {
         AndPredicate andPredicate = query.andPredicate();
         if (userId != null) {
             andPredicate.and(query.attributePredicate(CredentialAttributes.USER_ID, userId));
+        }
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
         }
         query.setPredicate(andPredicate);
 

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId.yaml
@@ -25,6 +25,16 @@ paths:
           description: The optional id to filter results
           schema:
             $ref: '../openapi.yaml#/components/schemas/kapuaId'
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - name: sortDir
+          in: query
+          description: The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive (except for "clientId" parameter).
+          schema:
+            type: string
+            enum:
+              - ASCENDING
+              - DESCENDING
+            default: ASCENDING
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
 


### PR DESCRIPTION
### Summary
This pull request introduces sorting capabilities to the '/{scopeId}/credentials' API endpoint by adding two new query parameters: `sortDir` and `sortParam`.

### Details
- **sortDir:** Accepts NULL/ASCENDING/DESCENDING, and determines the order of sorting.
- **sortParam:** Defines the field by which the sorting is applied.
  
This enhancement mirrors the sorting functionality already available in other API endpoints, such as `/devices`. By using these parameters, users can now sort the credentials information based on any specified field in either ascending or descending order.

### Example Usage
To sort the credentials information in ascending order by a specific field, the request would look like:
`GET /{scopeId}/credentials?sortDir=ASCENDING&sortParam=<field_name>`
This update enhances the flexibility and usability of the API by providing consistent sorting behavior across different endpoints.