### PR TITLE
FIX - deleteAllIndexes & refreshAllIndexes methods re-factoring

### DIFF
--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/ElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/ElasticsearchClient.java
@@ -260,6 +260,14 @@ public interface ElasticsearchClient<C extends Closeable> {
     void refreshAllIndexes() throws ClientException;
 
     /**
+     * Forces the Elasticsearch to refresh a specific index.
+     *
+     * @throws ClientException if error occurs while refreshing.
+     * @since 2.1.0
+     */
+    void refreshIndex(String index) throws ClientException;
+
+    /**
      * Deletes all indexes.
      *
      * <b>

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/ElasticsearchRepository.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/ElasticsearchRepository.java
@@ -256,6 +256,15 @@ public abstract class ElasticsearchRepository<
         }
     }
 
+    public void refreshIndex(String indexExp) {
+        try {
+            this.indexUpserted.invalidateAll();
+            elasticsearchClientProviderInstance.getElasticsearchClient().refreshIndex(indexExp);
+        } catch (ClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public void deleteAllIndexes() {
         try {

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/ElasticsearchResourcePaths.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/ElasticsearchResourcePaths.java
@@ -100,6 +100,13 @@ public class ElasticsearchResourcePaths {
     }
 
     /**
+     * @since 2.1.0
+     */
+    public static String refreshIndex(@NotNull String index) {
+        return String.format("/%s/_refresh", index);
+    }
+
+    /**
      * @since 1.0.0
      */
     public static String defaultPathDocType(@NotNull String index) {

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
@@ -437,6 +437,16 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
         }
     }
 
+    public void refreshIndex(String index) throws ClientException {
+        LOG.debug("Refresh index: {}", index);
+        Request request = new Request(ElasticsearchKeywords.ACTION_POST, ElasticsearchResourcePaths.refreshIndex(index));
+        Response refreshIndexResponse = restCallTimeoutHandler(() -> getClient().performRequest(request), index, "REFRESH INDEX");
+
+        if (!isRequestSuccessful(refreshIndexResponse)) {
+            throw buildExceptionFromUnsuccessfulResponse("Refresh indexes", refreshIndexResponse);
+        }
+    }
+
     @Override
     public void deleteAllIndexes() throws ClientException {
         LOG.debug("Delete all indexes");

--- a/service/commons/storable/api/src/main/java/org/eclipse/kapua/service/storable/repository/StorableRepository.java
+++ b/service/commons/storable/api/src/main/java/org/eclipse/kapua/service/storable/repository/StorableRepository.java
@@ -41,6 +41,8 @@ public interface StorableRepository<
 
     void refreshAllIndexes();
 
+    void refreshIndex(String indexExp);
+
     void deleteAllIndexes();
 
     void deleteIndexes(String indexExp);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoElasticsearchRepository.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoElasticsearchRepository.java
@@ -65,6 +65,11 @@ public class ChannelInfoElasticsearchRepository extends DatastoreElasticSearchRe
     }
 
     @Override
+    public void refreshAllIndexes() {
+        super.refreshIndex(datastoreUtils.getChannelIndexName(KapuaId.ANY));
+    }
+
+    @Override
     public void deleteAllIndexes() {
         super.deleteIndexes(datastoreUtils.getChannelIndexName(KapuaId.ANY));
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoElasticsearchRepository.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoElasticsearchRepository.java
@@ -63,4 +63,9 @@ public class ChannelInfoElasticsearchRepository extends DatastoreElasticSearchRe
     protected JsonNode getIndexSchema() throws MappingException {
         return ChannelInfoSchema.getChannelTypeSchema();
     }
+
+    @Override
+    public void deleteAllIndexes() {
+        super.deleteIndexes(datastoreUtils.getChannelIndexName(KapuaId.ANY));
+    }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoElasticsearchRepository.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoElasticsearchRepository.java
@@ -64,4 +64,8 @@ public class ClientInfoElasticsearchRepository extends DatastoreElasticSearchRep
         return storable.getId();
     }
 
+    @Override
+    public void deleteAllIndexes() {
+        super.deleteIndexes(datastoreUtils.getClientIndexName(KapuaId.ANY));
+    }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoElasticsearchRepository.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoElasticsearchRepository.java
@@ -65,6 +65,11 @@ public class ClientInfoElasticsearchRepository extends DatastoreElasticSearchRep
     }
 
     @Override
+    public void refreshAllIndexes() {
+        super.refreshIndex(datastoreUtils.getClientIndexName(KapuaId.ANY));
+    }
+
+    @Override
     public void deleteAllIndexes() {
         super.deleteIndexes(datastoreUtils.getClientIndexName(KapuaId.ANY));
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageElasticsearchRepository.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageElasticsearchRepository.java
@@ -205,7 +205,7 @@ public class MessageElasticsearchRepository extends DatastoreElasticSearchReposi
 
     @Override
     public void deleteAllIndexes() {
-        super.deleteAllIndexes();
+        super.deleteIndexes(datastoreUtils.getDataIndexName(KapuaId.ANY));
         this.metricsByIndex.invalidateAll();
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageElasticsearchRepository.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageElasticsearchRepository.java
@@ -199,7 +199,7 @@ public class MessageElasticsearchRepository extends DatastoreElasticSearchReposi
 
     @Override
     public void refreshAllIndexes() {
-        super.refreshAllIndexes();
+        super.refreshIndex(datastoreUtils.getDataIndexName(KapuaId.ANY));
         this.metricsByIndex.invalidateAll();
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
@@ -498,6 +498,9 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
     @Override
     public void refreshAllIndexes() throws ClientException {
         messageRepository.refreshAllIndexes();
+        clientInfoRepository.refreshAllIndexes();
+        channelInfoRepository.refreshAllIndexes();
+        metricInfoRepository.refreshAllIndexes();
     }
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
@@ -498,9 +498,6 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
     @Override
     public void refreshAllIndexes() throws ClientException {
         messageRepository.refreshAllIndexes();
-        clientInfoRepository.refreshAllIndexes();
-        channelInfoRepository.refreshAllIndexes();
-        metricInfoRepository.refreshAllIndexes();
     }
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRepositoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRepositoryImpl.java
@@ -63,4 +63,9 @@ public class MetricInfoRepositoryImpl extends DatastoreElasticSearchRepositoryBa
     protected StorableId idExtractor(MetricInfo storable) {
         return storable.getId();
     }
+
+    @Override
+    public void deleteAllIndexes() {
+        super.deleteIndexes(datastoreUtils.getMetricIndexName(KapuaId.ANY));
+    }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRepositoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRepositoryImpl.java
@@ -65,6 +65,11 @@ public class MetricInfoRepositoryImpl extends DatastoreElasticSearchRepositoryBa
     }
 
     @Override
+    public void refreshAllIndexes() {
+        super.refreshIndex(datastoreUtils.getMetricIndexName(KapuaId.ANY));
+    }
+
+    @Override
     public void deleteAllIndexes() {
         super.deleteIndexes(datastoreUtils.getMetricIndexName(KapuaId.ANY));
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -136,9 +136,11 @@ public class DatastoreUtils extends AbstractStoreUtils {
         if (StringUtils.isNotEmpty(prefix)) {
             sb.append(prefix).append("-");
         }
-        String indexName = normalizedIndexName(scopeId.toStringId());
-        if (scopeId.equals(KapuaId.ANY)) {
+        String indexName;
+        if (KapuaId.ANY.equals(scopeId)) {
             indexName = "*";
+        } else {
+            indexName = normalizedIndexName(scopeId.toStringId());
         }
         sb.append(indexName).append("-").append("data-message").append("-*");
         return sb.toString();
@@ -201,9 +203,11 @@ public class DatastoreUtils extends AbstractStoreUtils {
         if (StringUtils.isNotEmpty(prefix)) {
             sb.append(prefix).append("-");
         }
-        String indexName = normalizedIndexName(scopeId.toStringId());
-        if (scopeId.equals(KapuaId.ANY)) {
+        String indexName;
+        if (KapuaId.ANY.equals(scopeId)) {
             indexName = "*";
+        } else {
+            indexName = normalizedIndexName(scopeId.toStringId());
         }
         sb.append(indexName);
         sb.append("-data-").append(indexType.name().toLowerCase());

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -137,6 +137,9 @@ public class DatastoreUtils extends AbstractStoreUtils {
             sb.append(prefix).append("-");
         }
         String indexName = normalizedIndexName(scopeId.toStringId());
+        if (scopeId.equals(KapuaId.ANY)) {
+            indexName = "*";
+        }
         sb.append(indexName).append("-").append("data-message").append("-*");
         return sb.toString();
     }
@@ -199,6 +202,9 @@ public class DatastoreUtils extends AbstractStoreUtils {
             sb.append(prefix).append("-");
         }
         String indexName = normalizedIndexName(scopeId.toStringId());
+        if (scopeId.equals(KapuaId.ANY)) {
+            indexName = "*";
+        }
         sb.append(indexName);
         sb.append("-data-").append(indexType.name().toLowerCase());
         return sb.toString();


### PR DESCRIPTION
The deleteAllIndexes method, called in tests, was calling 4 times a low-level ES method that was deleting all the indexes stored. This was accomplished by calling the various deleteAllIndexes in the 4 *repositories classes, that had the same common implementation. I re-factored this implementation in order to delete only the respective repository indexes. 
Furthermore, I modified the refreshAllIndexes implementation, with the same logic.
This fix serves mainly to prepare the codebase to the usage of OpenSearch at the place of ES.

