### PR TITLE
FIX  - Unmarshalling of "credentialStatus" property for CredentialCreator

### DIFF
--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
@@ -112,7 +112,7 @@ public interface CredentialCreator extends KapuaEntityCreator<Credential> {
      * @return The {@link CredentialStatus}
      * @since 1.0.0
      */
-    @XmlElement(name = "status")
+    @XmlElement(name = "credentialStatus")
     CredentialStatus getCredentialStatus();
 
     /**


### PR DESCRIPTION
There is an issue during the unmarshalling of the mentioned parameter due to a probable typo in a recent change of our codebase. This resulted in the parameter being always null in the backend when, for example, a new Credential was issued via the POST request