### PR TITLE
FIX: 500 Internal Error is shown trying to call /{scopeId}/users/{userId}/credentials/password/_reset endpoint

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialImpl.java
@@ -122,7 +122,7 @@ public class CredentialImpl extends AbstractKapuaUpdatableEntity implements Cred
                           Date expirationDate) {
         super(scopeId);
 
-        this.userId = (KapuaEid) userId;
+        this.userId = KapuaEid.parseKapuaId(userId);
         this.credentialType = credentialType;
         this.credentialKey = credentialKey;
         this.status = credentialStatus;


### PR DESCRIPTION
Investigating the issue, I found the problem: An attempt to cast the parameter “usedId” received via API from the UserId type to the KapuaEid type. Fixing this solved the problem