### PR TITLE
✨ [Jobs] Add username/password in PackageDownloadRequest example for `Package Download/Install` step

### DIFF
--- a/service/device/management/packages/job/src/main/resources/liquibase/2.0.0/changelog-packages-job-2.0.0.post.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/2.0.0/changelog-packages-job-2.0.0.post.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./packages_job_step_definition_property_update_example_field.xml"/>
+
+</databaseChangeLog>

--- a/service/device/management/packages/job/src/main/resources/liquibase/2.0.0/packages_job_step_definition_property_update_example_field.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/2.0.0/packages_job_step_definition_property_update_example_field.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/packages_job_step_definition_property_update_example_field.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+
+    <changeSet id="packages_job_step_definition_property_update-1.2.0" author="eurotech">
+        <update tableName="job_job_step_definition_properties">
+            <column name="example_value" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;
+&lt;downloadRequest&gt;&#10;
+   &lt;uri&gt;http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp&lt;/uri&gt;&#10;
+   &lt;name&gt;heater&lt;/name&gt;&#10;
+   &lt;version&gt;1.0.300&lt;/version&gt;&#10;
+   &lt;install&gt;true&lt;/install&gt;&#10;
+   &lt;!-- &lt;username&gt;&lt;/username&gt;&#10;
+   &lt;password&gt;&lt;/password&gt; --&gt;&#10;
+&lt;/downloadRequest&gt;"/>
+            <where>name = 'packageDownloadRequest'</where>
+        </update>
+
+        <update tableName="job_job_step_definition_properties">
+            <column name="example_value" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;
+&lt;uninstallRequest&gt;&#10;
+    &lt;name&gt;heater&lt;/name&gt;&#10;
+    &lt;version&gt;1.0.300&lt;/version&gt;&#10;
+    &lt;reboot&gt;true&lt;/reboot&gt;&#10;
+    &lt;rebootDelay&gt;30000&lt;/rebootDelay&gt;&#10;
+&lt;/uninstallRequest&gt;"/>
+            <where>name = 'packageUninstallRequest'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/device/management/packages/job/src/main/resources/liquibase/changelog-packages-job-master.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/changelog-packages-job-master.xml
@@ -19,5 +19,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-packages-job-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-packages-job-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.4/changelog-packages-job-1.0.4.xml"/>
+    <include relativeToChangelogFile="true" file="./2.0.0/changelog-packages-job-2.0.0.post.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
### Description
This PR updates the example XML value for the `PackageDownloadRequest` in the `job_job_step_definition_properties` table. The current example lacked fields for `username` and `password`, which are sometimes required for repository authentication during a package download/install operation in Kura. 

To address this, I have updated the default XML string to include commented-out sections for the `username` and `password` fields. This way, users can easily see that credentials can be added if required, without having to consult external support.

### Changes Made
- Modified the default value of the `example_value` for `PackageDownloadRequest` in the step definitions.
- Added commented-out `<username>` and `<password>` fields in the XML template.

### Why This Change Was Needed
Users previously had no clear indication that they could provide a username and password for authenticated package downloads. This could lead to confusion or support requests. By including these fields as comments, we make the functionality visible and easily accessible, improving the user experience.