### PR TITLE
 ✨ [Rest API] Add `sortDir` and `sortParam` functionality to `/{scopeId}/tags` API

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Tags.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Tags.java
@@ -12,22 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.app.api.core.model.CountResult;
-import org.eclipse.kapua.app.api.core.model.EntityId;
-import org.eclipse.kapua.app.api.core.model.ScopeId;
-import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
-import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
-import org.eclipse.kapua.model.query.predicate.AndPredicate;
-import org.eclipse.kapua.service.KapuaService;
-import org.eclipse.kapua.service.tag.Tag;
-import org.eclipse.kapua.service.tag.TagCreator;
-import org.eclipse.kapua.service.tag.TagFactory;
-import org.eclipse.kapua.service.tag.TagListResult;
-import org.eclipse.kapua.service.tag.TagQuery;
-import org.eclipse.kapua.service.tag.TagService;
-
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -41,6 +25,23 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import com.google.common.base.Strings;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.app.api.core.model.CountResult;
+import org.eclipse.kapua.app.api.core.model.EntityId;
+import org.eclipse.kapua.app.api.core.model.ScopeId;
+import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.tag.Tag;
+import org.eclipse.kapua.service.tag.TagCreator;
+import org.eclipse.kapua.service.tag.TagFactory;
+import org.eclipse.kapua.service.tag.TagListResult;
+import org.eclipse.kapua.service.tag.TagQuery;
+import org.eclipse.kapua.service.tag.TagService;
 
 @Path("{scopeId}/tags")
 public class Tags extends AbstractKapuaResource {
@@ -69,6 +70,8 @@ public class Tags extends AbstractKapuaResource {
             @QueryParam("name") String name,
             @QueryParam("askTotalCount") boolean askTotalCount,
             @QueryParam("matchTerm") String matchTerm,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         TagQuery query = tagFactory.newQuery(scopeId);
@@ -79,6 +82,9 @@ public class Tags extends AbstractKapuaResource {
         }
         if (matchTerm != null && !matchTerm.isEmpty()) {
             andPredicate.and(query.matchPredicate(matchTerm));
+        }
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
         }
         query.setPredicate(andPredicate);
 

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId.yaml
@@ -25,6 +25,16 @@ paths:
           description: The tag name to filter results
           schema:
             type: string
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - name: sortDir
+          in: query
+          description: The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive (except for "clientId" parameter).
+          schema:
+            type: string
+            enum:
+              - ASCENDING
+              - DESCENDING
+            default: ASCENDING
         - name: matchTerm
           in: query
           description: |


### PR DESCRIPTION
### Summary
This PR introduces sorting functionality to the `/tags` API by adding two query parameters:
- `sortDir`: Accepts `NULL`, `ASCENDING`, or `DESCENDING` to define the sorting order.
- `sortParam`: Specifies the field on which the sorting is applied.

### Changes
- Implemented `sortDir` and `sortParam` query parameters in the `/tags` API.
- When `sortDir` is `ASCENDING` or `DESCENDING`, sorting is applied to the field specified in `sortParam`.
- Mirrored the behavior from the `/devices` API to ensure consistency across similar endpoints.
- Updated the OpenAPI documentation to include details about the new query parameters for the `/tags` API.