### PR TITLE
 🐛 [Authentication] Return `MfaRequiredException` when `trustKey` is not valid

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
@@ -12,6 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang.time.DateUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.shiro.authc.IncorrectCredentialsException;
@@ -56,15 +65,6 @@ import org.eclipse.kapua.storage.TxManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCrypt;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * {@link MfaOptionService} implementation.
@@ -314,7 +314,7 @@ public class MfaOptionServiceImpl implements MfaOptionService {
             return false;
         });
         if (!res) {
-            if ( (tokenAuthenticationCode != null && !tokenAuthenticationCode.isEmpty()) || (tokenTrustKey != null && !tokenTrustKey.isEmpty())) {
+            if (tokenAuthenticationCode != null && !tokenAuthenticationCode.isEmpty()) {
                 throw new IncorrectCredentialsException();
             }
             // In case both the authenticationCode and the trustKey are null, the MFA login via Rest API must be triggered.


### PR DESCRIPTION
### Overview
This PR addresses an issue where an invalid `trustKey` during login would not trigger the expected Multi-Factor Authentication (MFA) flow. As part of the fix, the `MfaRequiredException` will now be correctly returned when the provided `trustKey` is invalid.

### Changes
- Updated authentication logic to return `MfaRequiredException` when the provided `trustKey` is invalid.
  
### Why
When a `trustKey` is invalid, the user should be prompted for MFA to ensure secure login. This fix aligns the system with the expected security protocols.