### PR TITLE
:sparkles: [Rest API] Added setting to filter JobStepDefinitions returned with GET request

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeys.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeys.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.app.api.core.settings;
 
 import org.eclipse.kapua.commons.setting.SettingKey;
+import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
 
 /**
  * REST API {@link SettingKey}s
@@ -37,7 +38,14 @@ public enum KapuaApiCoreSettingKeys implements SettingKey {
      *
      * @since 2.0.0
      */
-    API_DEVICE_MANAGEMENT_PACKAGE_RESPONSE_LEGACY_MODE("api.device.management.package.response.legacy.mode");
+    API_DEVICE_MANAGEMENT_PACKAGE_RESPONSE_LEGACY_MODE("api.device.management.package.response.legacy.mode"),
+
+    /**
+     * Regex to exclude {@link JobStepDefinition}s when returning results from GET request
+     *
+     * @since 2.0.0
+     */
+    JOB_STEP_DEFINITION_EXCLUDE_REGEX("api.job.step.definition.exclude.regex");
 
     private final String key;
 

--- a/rest-api/core/src/main/resources/kapua-api-core-settings.properties
+++ b/rest-api/core/src/main/resources/kapua-api-core-settings.properties
@@ -15,4 +15,5 @@ api.cors.refresh.interval=60
 api.cors.origins.allowed=
 api.device.management.package.response.legacy.mode=false
 api.exception.stacktrace.show=false
+api.job.step.definition.exclude.regex=
 api.path.param.scopeId.wildcard=_

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobStepDefinitions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobStepDefinitions.java
@@ -18,6 +18,9 @@ import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.app.api.core.settings.KapuaApiCoreSetting;
+import org.eclipse.kapua.app.api.core.settings.KapuaApiCoreSettingKeys;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.service.KapuaService;
@@ -49,6 +52,8 @@ public class JobStepDefinitions extends AbstractKapuaResource {
     public JobStepDefinitionService jobStepDefinitionService;
     @Inject
     public JobStepDefinitionFactory jobStepDefinitionFactory;
+
+    private static final String JOB_STEP_DEFINITION_EXCLUDE_REGEX = KapuaLocator.getInstance().getComponent(KapuaApiCoreSetting .class).getString(KapuaApiCoreSettingKeys.JOB_STEP_DEFINITION_EXCLUDE_REGEX);
 
     /**
      * Gets the {@link JobStep} list for a given {@link Job}.
@@ -101,7 +106,14 @@ public class JobStepDefinitions extends AbstractKapuaResource {
             JobStepDefinitionQuery query) throws KapuaException {
         query.setScopeId(KapuaId.ANY);
 
-        return jobStepDefinitionService.query(query);
+        JobStepDefinitionListResult jobStepDefinitions = jobStepDefinitionService.query(query);
+
+        if (!Strings.isNullOrEmpty(JOB_STEP_DEFINITION_EXCLUDE_REGEX)) {
+            jobStepDefinitions.getItems()
+                    .removeIf(jobStepDefinition -> jobStepDefinition.getName().matches(JOB_STEP_DEFINITION_EXCLUDE_REGEX));
+        }
+
+        return jobStepDefinitions;
     }
 
     /**


### PR DESCRIPTION
This PR adds a way to filter result returned with `GET /{scopeId]/jobStepDefinitions` 

**Related Issue**
This PR mimics changes in https://github.com/eclipse/kapua/pull/2191 but for the REST API

**Description of the solution adopted**
Added the new setting and added filtering of the results

**Screenshots**
_None_

**Any side note on the changes made**
This is not needed in Kapua 2.1.0 since it already has this feature https://github.com/eclipse/kapua/pull/3996