### PR TITLE
FIX -  marshalling/unmarshalling Password[] and KuraPassword[] types

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/PasswordPropertyAdapter.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/PasswordPropertyAdapter.java
@@ -29,11 +29,6 @@ public class PasswordPropertyAdapter extends ClassBasedXmlPropertyAdapterBase<Pa
     }
 
     @Override
-    public boolean canMarshall(Class<?> objectClass) {
-        return Password.class.equals(objectClass);
-    }
-
-    @Override
     public boolean doesEncrypt() {
         return true;
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/PasswordPropertyAdapter.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/PasswordPropertyAdapter.java
@@ -91,7 +91,7 @@ public class PasswordPropertyAdapter extends ClassBasedXmlPropertyAdapterBase<Pa
             return Arrays
                     .stream(property.getValues())
                     .map(value -> unmarshallValue(value, property.isEncrypted() && !Strings.isNullOrEmpty(value)))
-                    .collect(Collectors.toList()).toArray();
+                    .collect(Collectors.toList()).toArray(new Password[values.length]);
         }
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapterTest.java
@@ -13,8 +13,10 @@
 package org.eclipse.kapua.model.xml.adapters;
 
 import org.eclipse.kapua.model.xml.XmlPropertyAdapted;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
 import javax.xml.bind.annotation.XmlAttribute;
@@ -25,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Category(JUnitTests.class)
 public class XmlPropertiesAdapterTest {
     public enum TestTypes {
         First,

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraPasswordPropertyAdapter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraPasswordPropertyAdapter.java
@@ -30,11 +30,6 @@ public class KuraPasswordPropertyAdapter extends ClassBasedXmlPropertyAdapterBas
     }
 
     @Override
-    public boolean canMarshall(Class objectClass) {
-        return KuraPassword.class.equals(objectClass);
-    }
-
-    @Override
     public boolean doesEncrypt() {
         return true;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraPasswordPropertyAdapter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraPasswordPropertyAdapter.java
@@ -99,7 +99,7 @@ public class KuraPasswordPropertyAdapter extends ClassBasedXmlPropertyAdapterBas
             return Arrays
                     .stream(property.getValues())
                     .map(value -> unmarshallValue(value, property.isEncrypted() && !Strings.isNullOrEmpty(value)))
-                    .collect(Collectors.toList()).toArray();
+                    .collect(Collectors.toList()).toArray(new KuraPassword[values.length]);
         }
     }
 }


### PR DESCRIPTION
Brief description of the PR.
I noticed that, when an XML/JSON representing a device configuration contains an array of Password or KuraPassword objects, something is wrong with the unmarshalling of it. This is also true for the opposite marshalling process

The problem lies in the *adapter classes we wrote to allow JAXB perform marshalling/unmarshalling processes