### PR TITLE
:bug: [CI] Added missing installation of Node JS and swagger required to build the project for Owasp Dependency Check

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -21,6 +21,11 @@ jobs:
           distribution: 'zulu'
           java-version: 11
           cache: 'maven'
+      - uses: actions/setup-node@v4 # Installs Node and NPM
+        with:
+          node-version: 16
+      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
+        run: 'npm install -g @apidevtools/swagger-cli'
       - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
This PR adds the installation of NodeJS and Swagger-CLI in the runner of the Owasp Depenency Check

**Related Issue**
_None_

**Description of the solution adopted**
Added installation of missing components

**Screenshots**
_None_

**Any side note on the changes made**
_None_