### PR TITLE
FIX - Reporting missing "property.type" XML/JSON property

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapter.java
@@ -11,14 +11,12 @@
  *     Eurotech - initial API and implementation
  *******************************************************************************/
 package org.eclipse.kapua.model.xml.adapters;
-
 import org.eclipse.kapua.model.xml.XmlPropertyAdapted;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,45 +36,26 @@ public class XmlPropertiesAdapter<T extends Enum<T>, V extends XmlPropertyAdapte
 
     @Override
     public Map<String, Object> unmarshal(V[] properties) {
-        Map<String, Object> unmarshalledProperties = new HashMap<>();
-
-         Optional.ofNullable(properties)
+        if (properties != null) {
+            for (V prop : properties) {
+                if (prop.getType() == null) {
+                    throw new InternalError("null value for property.type parameter");
+                }
+            }
+        }
+        Map<String, Object> unmarshalledProperties;
+        unmarshalledProperties = Optional.ofNullable(properties)
                 .map(Arrays::asList)
                 .orElse(Collections.emptyList())
                 .stream()
-                .filter(adaptedProp -> adaptedProp.getType() == null || xmlPropertyAdapters.containsKey((adaptedProp.getType())))
-                .forEach(adaptedProp -> unmarshalledProperties.put(adaptedProp.getName(), unmarshalProperty(adaptedProp)));
-
-        // This was a better way to do it, but Collectors.toMap does not accept `null` values.
-        // See Collectors#153 for reference.
-        //                .collect(Collectors.toMap(
-        //                        adaptedProp -> adaptedProp.getName(),
-        //                        adaptedProp -> {
-        //                            final XmlPropertyAdapter xmlPropertyAdapter = xmlPropertyAdapters.get(adaptedProp.getType());
-        //                            return xmlPropertyAdapter.unmarshallValues(adaptedProp);
-        //                        }));
+                .collect(Collectors.toMap(
+                        XmlPropertyAdapted::getName,
+                        adaptedProp -> {
+                            final XmlPropertyAdapter xmlPropertyAdapter = xmlPropertyAdapters.get(adaptedProp.getType());
+                            return xmlPropertyAdapter.unmarshallValues(adaptedProp);
+                        }));
 
         return unmarshalledProperties;
-    }
-
-    /**
-     * It unmarshal the given {@link XmlPropertyAdapted}.
-     * <p>
-     * If {@link XmlPropertyAdapted#getType()} is {@code null} it means that {@link XmlPropertyAdapted#getValues()} was {@code null}, so we can't determine its {@link XmlPropertyAdapted#getType()}.
-     * By the way, if original value was {@code null} we can safely return {@code null}.
-     *
-     * @param adaptedProp The {@link XmlPropertyAdapted} to unmarshal
-     * @return The unmarshalled {@link XmlPropertyAdapted}
-     * @since 2.1.0
-     */
-    public Object unmarshalProperty(V adaptedProp) {
-        if (adaptedProp.getType() != null) {
-            XmlPropertyAdapter xmlPropertyAdapter = xmlPropertyAdapters.get(adaptedProp.getType());
-            return xmlPropertyAdapter.unmarshallValues(adaptedProp);
-        }
-        else {
-            return null;
-        }
     }
 
     @Override

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapter.java
@@ -36,18 +36,16 @@ public class XmlPropertiesAdapter<T extends Enum<T>, V extends XmlPropertyAdapte
 
     @Override
     public Map<String, Object> unmarshal(V[] properties) {
-        if (properties != null) {
-            for (V prop : properties) {
-                if (prop.getType() == null) {
-                    throw new InternalError("null value for property.type parameter");
-                }
-            }
-        }
         Map<String, Object> unmarshalledProperties;
         unmarshalledProperties = Optional.ofNullable(properties)
                 .map(Arrays::asList)
                 .orElse(Collections.emptyList())
                 .stream()
+                .peek(adaptedProp -> {
+                    if (adaptedProp.getType() == null) {
+                        throw new InternalError("null value for property.type parameter");
+                    }
+                })
                 .filter(adaptedProp -> xmlPropertyAdapters.containsKey((adaptedProp.getType())))
                 .collect(Collectors.toMap(
                         XmlPropertyAdapted::getName,

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapter.java
@@ -48,6 +48,7 @@ public class XmlPropertiesAdapter<T extends Enum<T>, V extends XmlPropertyAdapte
                 .map(Arrays::asList)
                 .orElse(Collections.emptyList())
                 .stream()
+                .filter(adaptedProp -> xmlPropertyAdapters.containsKey((adaptedProp.getType())))
                 .collect(Collectors.toMap(
                         XmlPropertyAdapted::getName,
                         adaptedProp -> {

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapterTest.java
@@ -187,6 +187,23 @@ public class XmlPropertiesAdapterTest {
     }
 
     @Test
+    public void testUnmarshallingMissingProperties() {
+        //Given adapters
+        final StringPropertyAdapter stringAdapter = Mockito.spy(new StringPropertyAdapter());
+        final HashMap<TestTypes, XmlPropertyAdapter> adapters = new HashMap<TestTypes, XmlPropertyAdapter>() {
+            {
+                put(TestTypes.First, stringAdapter);
+            }
+        };
+        //and an instance
+        final XmlPropertiesAdapter instance = new TestPropertiesAdapter(adapters);
+        //When I unmarshal
+        final Map<String, Object> got = instance.unmarshal(null);
+        Map<String, Object> expectedResult = new HashMap<>();
+        Assert.assertEquals(got, expectedResult);
+    }
+
+    @Test
     public void testUnmarshalling() {
         //Given adapters
         final StringPropertyAdapter stringAdapter = Mockito.spy(new StringPropertyAdapter());

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapterTest.java
@@ -220,4 +220,27 @@ public class XmlPropertiesAdapterTest {
         Mockito.verify(booleanAdapter, Mockito.times(1)).unmarshallValue(Mockito.eq("true"));
         Mockito.verify(longAdapter, Mockito.never()).unmarshallValue(Mockito.any());
     }
+
+    @Test
+    public void testUnmarshallingMissingType() {
+        //Given adapters
+        final StringPropertyAdapter stringAdapter = Mockito.spy(new StringPropertyAdapter());
+        final BooleanPropertyAdapter booleanAdapter = Mockito.spy(new BooleanPropertyAdapter());
+        final LongPropertyAdapter longAdapter = Mockito.spy(new LongPropertyAdapter());
+        final HashMap<TestTypes, XmlPropertyAdapter> adapters = new HashMap<TestTypes, XmlPropertyAdapter>() {
+            {
+                put(TestTypes.First, stringAdapter);
+                put(TestTypes.Second, booleanAdapter);
+                put(TestTypes.Fourth, longAdapter);
+            }
+        };
+        //and an instance
+        final XmlPropertiesAdapter instance = new TestPropertiesAdapter(adapters);
+        //When I unmarshal
+        Assert.assertThrows(InternalError.class, () -> instance.unmarshal(new TestPropertyAdapted[]{
+                new TestPropertyAdapted("aString", TestTypes.First, "TheString"),
+                new TestPropertyAdapted("aBoolean", TestTypes.Second, "false", "true"),
+                new TestPropertyAdapted("anotherValue", null, "42")
+        }));
+    }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapterTest.java
@@ -127,7 +127,7 @@ public class ServiceXmlConfigPropertiesAdapterTest {
         ServiceXmlConfigPropertiesAdapted serviceXmlConfigPropertiesAdapted = new ServiceXmlConfigPropertiesAdapted();
 
         for (int i = 0; i < configPropertyType.length; i++) {
-            ServiceXmlConfigPropertyAdapted serviceXmlConfigPropertyAdapted1 = new ServiceXmlConfigPropertyAdapted();
+            ServiceXmlConfigPropertyAdapted serviceXmlConfigPropertyAdapted1 = new ServiceXmlConfigPropertyAdapted("fooname", configPropertyType[0], "foovalue");
             ServiceXmlConfigPropertyAdapted serviceXmlConfigPropertyAdapted2 = new ServiceXmlConfigPropertyAdapted(name + i, configPropertyType[i], stringValue);
             ServiceXmlConfigPropertyAdapted[] properties1 = new ServiceXmlConfigPropertyAdapted[]{serviceXmlConfigPropertyAdapted2};
 


### PR DESCRIPTION
the call to the rest-api endpoint PUT /{scopeId}/serviceConfigurations/{componentId} was returning a 204 code when some "properties" you want to update had a missing "type" parameter. This was wrong because, in this case, the back-end cannot unmarshall properly the xml/json, resulting in a no-up update, so an error should be shown to the client.

To change this, I modified the code of the custom unmarshaller we created (XmlPropertiesAdapter.java) in order to throw an internal exception in such case.

I tried to throw a more proper KapuaException instead of the internalError but I had some problems for the way JAXB handles exceptions. In a future PR I will work on this in order to more correctly propagate a 404 error code to the client

Finally, I added some tests 