### PR TITLE
:bug: [Broker] Added missing Eclipse Link ASM dependency

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -213,6 +213,7 @@
                 <include>org.bitbucket.b_c:jose4j</include>
                 <include>org.checkerframework:checker-qual</include>
                 <include>org.eclipse.paho:org.eclipse.paho.client.mqttv3</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.asm</include>
                 <include>org.eclipse.persistence:org.eclipse.persistence.jpa</include>
                 <include>org.eclipse.persistence:org.eclipse.persistence.jpa.jpql</include>
                 <include>org.eclipse.persistence:org.eclipse.persistence.core</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -321,6 +321,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.asm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1471,6 +1471,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.asm</artifactId>
+                <version>9.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.moxy</artifactId>
                 <version>${eclipselink.version}</version>
             </dependency>


### PR DESCRIPTION
This PR adds a missing Eclipse Link ASM dependency

**Related Issue**
_None_

**Description of the solution adopted**
Added the dependency

**Screenshots**
_None_

**Any side note on the changes made**
This was preventing the broker Docker image to start