### PR TITLE
🐛 [REST API] Correct response schema for GET `data/messages/{datastoreMessageId}` to return `dataMessage`

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-datastoreMessageId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-datastoreMessageId.yaml
@@ -27,7 +27,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './dataMessage.yaml#/components/schemas/dataMessageListResult'
+                $ref: './dataMessage.yaml#/components/schemas/dataMessage'
         400:
           $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:


### PR DESCRIPTION
### Summary
This PR fixes the response schema for the `GET {scopeId}/data/messages/{datastoreMessageId}` endpoint in the Kapua API. Previously, the OpenAPI schema incorrectly documented the response as `dataMessageListResult` when it should have returned a `dataMessage`.

### What was fixed
The OpenAPI documentation previously showed the following response:

<details>
  <summary>Old example</summary>

```json
{
  "type": "storableListResult",
  "limitExceeded": true,
  "size": 2,
  "items": [
    {
      "type": "jsonDatastoreMessage",
      "capturedOn": "2019-09-12T09:35:04.383Z",
      "channel": {
        "type": "kapuaDataChannel",
        "semanticParts": [
          "heater",
          "data"
        ]
      },
      "clientId": "Client-Id-1",
      "deviceId": "WyczTs_GuDM",
      "payload": {
        "metrics": [
          {
            "valueType": "string",
            "value": 5,
            "name": "temperatureExternal"
          },
          {
            "valueType": "string",
            "value": 20.25,
            "name": "temperatureInternal"
          },
          {
            "valueType": "string",
            "value": 30,
            "name": "temperatureExhaust"
          },
          {
            "valueType": "string",
            "value": -441478528,
            "name": "errorCode"
          }
        ]
      },
      "receivedOn": "2019-09-12T09:35:04.389Z",
      "scopeId": "AQ",
      "sentOn": "2019-09-12T09:35:04.383Z",
      "datastoreId": "6349cec8-396b-4aac-bc2f-8fca9fe0c67c",
      "timestamp": "2019-09-12T09:35:04.383Z"
    },
    {
      "type": "jsonDatastoreMessage",
      "capturedOn": "2019-09-12T09:25:05.096Z",
      "channel": {
        "type": "kapuaDataChannel",
        "semanticParts": [
          "heater",
          "data"
        ]
      },
      "clientId": "Client-Id-1",
      "deviceId": "WyczTs_GuDM",
      "payload": {
        "metrics": [
          {
            "valueType": "string",
            "value": 5,
            "name": "temperatureExternal"
          },
          {
            "valueType": "string",
            "value": 20,
            "name": "temperatureInternal"
          },
          {
            "valueType": "string",
            "value": 30,
            "name": "temperatureExhaust"
          },
          {
            "valueType": "string",
            "value": 0,
            "name": "errorCode"
          }
        ]
      },
      "receivedOn": "2019-09-12T09:25:05.102Z",
      "scopeId": "AQ",
      "sentOn": "2019-09-12T09:25:05.096Z",
      "datastoreId": "bb07d7fc-dc62-492f-b8da-7e28df69e112",
      "timestamp": "2019-09-12T09:25:05.096Z"
    }
  ],
  "totalCount": 61
}
```
</details>

However, the correct response format should be a `dataMessage`, as seen here:
<details>
  <summary>New example</summary>

```json
{
  "type": "jsonDatastoreMessage",
  "capturedOn": "2019-09-12T09:25:05.096Z",
  "channel": {
    "type": "kapuaDataChannel",
    "semanticParts": [
      "heater",
      "data"
    ]
  },
  "clientId": "Client-Id-1",
  "deviceId": "WyczTs_GuDM",
  "payload": {
    "metrics": [
      {
        "valueType": "string",
        "value": 5,
        "name": "temperatureExternal"
      },
      {
        "valueType": "string",
        "value": 20,
        "name": "temperatureInternal"
      },
      {
        "valueType": "string",
        "value": 30,
        "name": "temperatureExhaust"
      },
      {
        "valueType": "string",
        "value": 0,
        "name": "errorCode"
      }
    ]
  },
  "receivedOn": "2019-09-12T09:25:05.102Z",
  "scopeId": "AQ",
  "sentOn": "2019-09-12T09:25:05.096Z",
  "datastoreId": "bb07d7fc-dc62-492f-b8da-7e28df69e112",
  "timestamp": "2019-09-12T09:25:05.096Z"
}
```
</details>

A real response example:
<details>
  <summary>Real response example</summary>

```json
{
  "type": "jsonDatastoreMessage",
  "channel": {
    "semanticParts": [
      "genericMetric"
    ]
  },
  "clientId": "pahoClient",
  "deviceId": "T5mpNWpOcdY",
  "payload": {
    "metrics": [
      {
        "valueType": "string",
        "value": "GeneriMetricHere",
        "name": "genericMetric"
      }
    ]
  },
  "receivedOn": "1970-01-20T23:56:28.576Z",
  "scopeId": "AQ",
  "datastoreId": "9f55aa27-e3c4-4709-8bee-091466d04f18",
  "timestamp": "2024-10-01T13:16:16.611Z"
}
```
</details>