### PR TITLE
♻️ [Database] Deprecate `db.pool.size.*` settings

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -10,7 +10,7 @@ This report is only partial for Eclipse Kapua release 2.1.0-SNAPSHOT, since we s
 
 With [#4112](https://github.com/eclipse/kapua/pull/4112) we deprecated `commons.db.pool.size.min` and `commons.db.pool.size.max` settings, switching to a new `commons.db.pool.size.fixed` setting which will configure the database connection pool to a fixed size with a default value of `5`.
 
-Backward compatibility is granted by `db.pool.size.strategy`. Default value is `fixed`, but it can be changed to `minmax` to continue use of a variable database connection pool. Be aware that at some point `minmax` strategy will be removed and only fixed size will be available.
+Backward compatibility is granted by `db.pool.size.strategy`. Default value is `fixed`, but it can be changed to `range` to continue use of a variable database connection pool. Be aware that at some point `range` strategy will be removed and only fixed size will be available.
 
 ## DB Changes
 

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -4,6 +4,14 @@ Below are described most important changes, features, additions and bugfixes tha
 
 This report is only partial for Eclipse Kapua release 2.1.0-SNAPSHOT, since we started to maintain it mid-release development.
 
+## Changes
+
+#### Deprecation of `db.pool.size.min` and `db.pool.size.max` sizing options
+
+With [#4112](https://github.com/eclipse/kapua/pull/4112) we deprecated `commons.db.pool.size.min` and `commons.db.pool.size.max` settings, switching to a new `commons.db.pool.size.fixed` setting which will configure the database connection pool to a fixed size with a default value of `5`.
+
+Backward compatibility is granted by `db.pool.size.strategy`. Default value is `fixed`, but it can be changed to `minmax` to continue use of a variable database connection pool. Be aware that at some point `minmax` strategy will be removed and only fixed size will be available.
+
 ## DB Changes
 
 #### New column in MFA Option table

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
@@ -29,24 +29,29 @@ public final class DataSource {
             SystemSetting config = SystemSetting.getInstance();
 
             hikariDataSource = new HikariDataSource();
+            hikariDataSource.setPoolName("hikari-main");
+            hikariDataSource.setRegisterMbeans(true);
+            hikariDataSource.setAllowPoolSuspension(false);
+
+            // Connection
             hikariDataSource.setDriverClassName(config.getString(SystemSettingKey.DB_JDBC_DRIVER));
             hikariDataSource.setJdbcUrl(JdbcConnectionUrlResolvers.resolveJdbcUrl());
             hikariDataSource.setUsername(config.getString(SystemSettingKey.DB_USERNAME));
             hikariDataSource.setPassword(config.getString(SystemSettingKey.DB_PASSWORD));
-            hikariDataSource.setMaximumPoolSize(config.getInt(SystemSettingKey.DB_POOL_SIZE_MAX, 20));
-            //commented out since is not good for performances
-            //see official documentation https://github.com/brettwooldridge/HikariCP
-            //This property controls the minimum number of idle connections that HikariCP tries to maintain in the pool.
-            //If the idle connections dip below this value, HikariCP will make a best effort to add additional connections
-            //quickly and efficiently. However, for maximum performance and responsiveness to spike demands, we recommend not
-            //setting this value and instead allowing HikariCP to act as a fixed size connection pool.
-            //Default: same as maximumPoolSize
-//            hikariDataSource.setMinimumIdle(config.getInt(SystemSettingKey.DB_POOL_SIZE_MIN, 1));
-            hikariDataSource.setPoolName("hikari-main");
-            hikariDataSource.setRegisterMbeans(true);
-            hikariDataSource.setAllowPoolSuspension(false);
-            //fixed size so this parameter is ignored by hikari
-//            hikariDataSource.setIdleTimeout(config.getInt(SystemSettingKey.DB_POOL_IDLE_TIMEOUT, 180000));
+
+            // Pool
+            hikariDataSource.setMaximumPoolSize(config.getInt(SystemSettingKey.DB_POOL_SIZE, 5));
+            // Commented out since is not good for performances
+            // See official documentation https://github.com/brettwooldridge/HikariCP
+            // This property controls the minimum number of idle connections that HikariCP tries to maintain in the pool.
+            // If the idle connections dip below this value, HikariCP will make a best effort to add additional connections
+            // quickly and efficiently. However, for maximum performance and responsiveness to spike demands, we recommend not
+            // setting this value and instead allowing HikariCP to act as a fixed size connection pool.
+            //
+            // hikariDataSource.setMinimumIdle(config.getInt(SystemSettingKey.DB_POOL_SIZE_MIN, 1));
+
+            // Fixed size so this parameter is ignored by hikari
+            // hikariDataSource.setIdleTimeout(config.getInt(SystemSettingKey.DB_POOL_IDLE_TIMEOUT, 180000));
             hikariDataSource.setKeepaliveTime(config.getInt(SystemSettingKey.DB_POOL_KEEPALIVE_TIME, 30000));
             hikariDataSource.setMaxLifetime(config.getInt(SystemSettingKey.DB_POOL_MAX_LIFETIME, 1800000));
             hikariDataSource.setConnectionTestQuery(config.getString(SystemSettingKey.DB_POOL_TEST_QUERY, "SELECT 1"));

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
@@ -40,7 +40,7 @@ public final class DataSource {
             hikariDataSource.setPassword(config.getString(SystemSettingKey.DB_PASSWORD));
 
             // Pool
-            hikariDataSource.setMaximumPoolSize(config.getInt(SystemSettingKey.DB_POOL_SIZE, 5));
+            hikariDataSource.setMaximumPoolSize(config.getInt(SystemSettingKey.DB_POOL_SIZE_FIXED, 5));
             // Commented out since is not good for performances
             // See official documentation https://github.com/brettwooldridge/HikariCP
             // This property controls the minimum number of idle connections that HikariCP tries to maintain in the pool.

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/DataSource.java
@@ -53,15 +53,15 @@ public final class DataSource {
                     hikariDataSource.setMaximumPoolSize(config.getInt(SystemSettingKey.DB_POOL_SIZE_FIXED, 5));
                 }
                 break;
-                case "minmax": {
-                    LOG.warn("Using deprecated 'minmax' db connection pool sizing strategy. Please consider migrating to 'fixed' strategy");
+                case "range": {
+                    LOG.warn("Using deprecated 'range' db connection pool sizing strategy. Please consider migrating to 'fixed' strategy");
                     hikariDataSource.setMinimumIdle(config.getInt(SystemSettingKey.DB_POOL_SIZE_MIN, 1));
                     hikariDataSource.setMaximumPoolSize(config.getInt(SystemSettingKey.DB_POOL_SIZE_MAX, 20));
                     hikariDataSource.setIdleTimeout(config.getInt(SystemSettingKey.DB_POOL_IDLE_TIMEOUT, 180000));
                 }
                 break;
                 default: {
-                    throw KapuaRuntimeException.internalError("Unrecognized value for setting 'commons.db.pool.size.strategy'. Available values are 'minmax' and 'fixed'. Value provided: '" + dbConnectionPoolStrategy+ "'");
+                    throw KapuaRuntimeException.internalError("Unrecognized value for setting 'commons.db.pool.size.strategy'. Available values are 'range' and 'fixed'. Value provided: '" + dbConnectionPoolStrategy+ "'");
                 }
             }
 
@@ -98,7 +98,7 @@ public final class DataSource {
                 dbPoolConfigPrinter.addParameter("Size", hikariDataSource.getMaximumPoolSize());
             }
             break;
-            case "minmax": {
+            case "range": {
                 dbPoolConfigPrinter.addParameter("Min idle", hikariDataSource.getMinimumIdle());
                 dbPoolConfigPrinter.addParameter("Max size", hikariDataSource.getMaximumPoolSize());
                 dbPoolConfigPrinter.addParameter("Idle timeout", hikariDataSource.getIdleTimeout());

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -168,13 +168,30 @@ public enum SystemSettingKey implements SettingKey {
     DB_CHARACTER_WILDCARD_SINGLE("commons.db.character.wildcard.single"),
 
     /**
-     * Database pool minimum pool size
+     * Database fixed pool size.
+     *
+     * @since 2.1.0
      */
-    DB_POOL_SIZE_MIN("commons.db.pool.size.min"),
+    DB_POOL_SIZE("commons.db.pool.size"),
+
     /**
-     * Database pool maximum pool size
+     * Database pool minimum pool size.
+     *
+     * @since 1.0.0
+     * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE}
      */
+    @Deprecated
+    DB_POOL_SIZE_MIN("commons.db.pool.size.min"),
+
+    /**
+     * Database pool maximum pool size.
+     *
+     * @since 1.0.0
+     * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE}
+     */
+    @Deprecated
     DB_POOL_SIZE_MAX("commons.db.pool.size.max"),
+
     /**
      * Database pool maximum time before evicting an idle connection
      *

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -177,7 +177,11 @@ public enum SystemSettingKey implements SettingKey {
     DB_POOL_SIZE_MAX("commons.db.pool.size.max"),
     /**
      * Database pool maximum time before evicting an idle connection
+     *
+     * @since 1.0.0
+     * @deprecated Since 2.1.0. No longer used.
      */
+    @Deprecated
     DB_POOL_IDLE_TIMEOUT("commons.db.pool.idle.timeout"),
     /**
      * Database pool keepalive query interval for idle connections

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -171,8 +171,8 @@ public enum SystemSettingKey implements SettingKey {
      * Database pool size strategy.
      * <p>
      * Created to maintain backward compatibility with 2.0.x release.
-     * 2.0.x is defaulting to {@code minmax} since the previous strategy was using a variable DB connection pool sizing.
-     * {@code minmax} strategy is deprecated and users should migrate to use {@code fixed} strategy
+     * 2.0.x is defaulting to {@code range} since the previous strategy was using a variable DB connection pool sizing.
+     * {@code range} strategy is deprecated and users should migrate to use {@code fixed} strategy
      * <p>
      * See official documentation <a href="https://github.com/brettwooldridge/HikariCP">Hikari CP Docs</a> about performances.
      *
@@ -192,7 +192,7 @@ public enum SystemSettingKey implements SettingKey {
     /**
      * Database pool minimum pool size.
      * <p>
-     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code minmax}
+     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code range}
      *
      * @since 1.0.0
      * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE_FIXED}
@@ -203,7 +203,7 @@ public enum SystemSettingKey implements SettingKey {
     /**
      * Database pool maximum pool size.
      * <p>
-     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code minmax}
+     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code range}
      *
      * @since 1.0.0
      * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE_FIXED}
@@ -214,7 +214,7 @@ public enum SystemSettingKey implements SettingKey {
     /**
      * Database pool maximum time before evicting an idle connection
      * <p>
-     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code minmax}
+     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code range}
      *
      * @since 1.0.0
      * @deprecated Since 2.1.0.

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -168,7 +168,22 @@ public enum SystemSettingKey implements SettingKey {
     DB_CHARACTER_WILDCARD_SINGLE("commons.db.character.wildcard.single"),
 
     /**
+     * Database pool size strategy.
+     * <p>
+     * Created to maintain backward compatibility with 2.0.x release.
+     * 2.0.x is defaulting to {@code minmax} since the previous strategy was using a variable DB connection pool sizing.
+     * {@code minmax} strategy is deprecated and users should migrate to use {@code fixed} strategy
+     * <p>
+     * See official documentation <a href="https://github.com/brettwooldridge/HikariCP">Hikari CP Docs</a> about performances.
+     *
+     * @since 2.1.0
+     */
+    DB_POOL_SIZE_STRATEGY("commons.db.pool.size.strategy"),
+
+    /**
      * Database fixed pool size.
+     * <p>
+     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code fixed}
      *
      * @since 2.1.0
      */
@@ -176,6 +191,8 @@ public enum SystemSettingKey implements SettingKey {
 
     /**
      * Database pool minimum pool size.
+     * <p>
+     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code minmax}
      *
      * @since 1.0.0
      * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE_FIXED}
@@ -185,6 +202,8 @@ public enum SystemSettingKey implements SettingKey {
 
     /**
      * Database pool maximum pool size.
+     * <p>
+     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code minmax}
      *
      * @since 1.0.0
      * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE_FIXED}
@@ -194,12 +213,15 @@ public enum SystemSettingKey implements SettingKey {
 
     /**
      * Database pool maximum time before evicting an idle connection
+     * <p>
+     * Taken into account when {@link #DB_POOL_SIZE_STRATEGY} is {@code minmax}
      *
      * @since 1.0.0
-     * @deprecated Since 2.1.0. No longer used.
+     * @deprecated Since 2.1.0.
      */
     @Deprecated
     DB_POOL_IDLE_TIMEOUT("commons.db.pool.idle.timeout"),
+
     /**
      * Database pool keepalive query interval for idle connections
      */

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -172,13 +172,13 @@ public enum SystemSettingKey implements SettingKey {
      *
      * @since 2.1.0
      */
-    DB_POOL_SIZE("commons.db.pool.size"),
+    DB_POOL_SIZE_FIXED("commons.db.pool.size.fixed"),
 
     /**
      * Database pool minimum pool size.
      *
      * @since 1.0.0
-     * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE}
+     * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE_FIXED}
      */
     @Deprecated
     DB_POOL_SIZE_MIN("commons.db.pool.size.min"),
@@ -187,7 +187,7 @@ public enum SystemSettingKey implements SettingKey {
      * Database pool maximum pool size.
      *
      * @since 1.0.0
-     * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE}
+     * @deprecated Since 2.1.0. Please make use of {@link #DB_POOL_SIZE_FIXED}
      */
     @Deprecated
     DB_POOL_SIZE_MAX("commons.db.pool.size.max"),

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 commons.db.character.escape=\\
 commons.db.character.wildcard.any=%

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 commons.db.character.escape=\\

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -43,6 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+# Introduced to maintain backward compatibility with 2.0.x release. In 2.0.x the default value is `minmax`
+commons.db.pool.size.strategy=fixed
+#commons.db.pool.size.strategy=minmax
+
 commons.db.pool.size.fixed=5
 # Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 commons.db.character.escape=\\

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -43,9 +43,9 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-# Introduced to maintain backward compatibility with 2.0.x release. In 2.0.x the default value is `minmax`
+# Introduced to maintain backward compatibility with 2.0.x release. In 2.0.x the default value is `range`
 commons.db.pool.size.strategy=fixed
-#commons.db.pool.size.strategy=minmax
+#commons.db.pool.size.strategy=range
 
 commons.db.pool.size.fixed=5
 # Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/system/SystemSettingKeyTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/system/SystemSettingKeyTest.java
@@ -57,6 +57,7 @@ public class SystemSettingKeyTest {
         systemSettings.put(SystemSettingKey.DB_USE_LEGACY_DATETIME_CODE, "commons.db.useLegacyDatetimeCode");
         systemSettings.put(SystemSettingKey.DB_SERVER_TIMEZONE, "commons.db.serverTimezone");
         systemSettings.put(SystemSettingKey.DB_CHAR_ENCODING, "commons.db.characterEncoding");
+        systemSettings.put(SystemSettingKey.DB_POOL_SIZE, "commons.db.pool.size");
         systemSettings.put(SystemSettingKey.DB_POOL_SIZE_MIN, "commons.db.pool.size.min");
         systemSettings.put(SystemSettingKey.DB_POOL_SIZE_MAX, "commons.db.pool.size.max");
         systemSettings.put(SystemSettingKey.DB_POOL_IDLE_TIMEOUT, "commons.db.pool.idle.timeout");

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/system/SystemSettingKeyTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/system/SystemSettingKeyTest.java
@@ -57,7 +57,7 @@ public class SystemSettingKeyTest {
         systemSettings.put(SystemSettingKey.DB_USE_LEGACY_DATETIME_CODE, "commons.db.useLegacyDatetimeCode");
         systemSettings.put(SystemSettingKey.DB_SERVER_TIMEZONE, "commons.db.serverTimezone");
         systemSettings.put(SystemSettingKey.DB_CHAR_ENCODING, "commons.db.characterEncoding");
-        systemSettings.put(SystemSettingKey.DB_POOL_SIZE, "commons.db.pool.size");
+        systemSettings.put(SystemSettingKey.DB_POOL_SIZE_FIXED, "commons.db.pool.size");
         systemSettings.put(SystemSettingKey.DB_POOL_SIZE_MIN, "commons.db.pool.size.min");
         systemSettings.put(SystemSettingKey.DB_POOL_SIZE_MAX, "commons.db.pool.size.max");
         systemSettings.put(SystemSettingKey.DB_POOL_IDLE_TIMEOUT, "commons.db.pool.idle.timeout");

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/system/SystemSettingKeyTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/system/SystemSettingKeyTest.java
@@ -57,7 +57,8 @@ public class SystemSettingKeyTest {
         systemSettings.put(SystemSettingKey.DB_USE_LEGACY_DATETIME_CODE, "commons.db.useLegacyDatetimeCode");
         systemSettings.put(SystemSettingKey.DB_SERVER_TIMEZONE, "commons.db.serverTimezone");
         systemSettings.put(SystemSettingKey.DB_CHAR_ENCODING, "commons.db.characterEncoding");
-        systemSettings.put(SystemSettingKey.DB_POOL_SIZE_FIXED, "commons.db.pool.size");
+        systemSettings.put(SystemSettingKey.DB_POOL_SIZE_STRATEGY, "commons.db.pool.size.strategy");
+        systemSettings.put(SystemSettingKey.DB_POOL_SIZE_FIXED, "commons.db.pool.size.fixed");
         systemSettings.put(SystemSettingKey.DB_POOL_SIZE_MIN, "commons.db.pool.size.min");
         systemSettings.put(SystemSettingKey.DB_POOL_SIZE_MAX, "commons.db.pool.size.max");
         systemSettings.put(SystemSettingKey.DB_POOL_IDLE_TIMEOUT, "commons.db.pool.idle.timeout");

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -47,7 +47,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -45,10 +45,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -45,11 +45,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -43,11 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -43,11 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -43,11 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -43,11 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
@@ -43,11 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/security/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/security/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/security/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/security/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/test/src/test/resources/kapua-environment-setting.properties
@@ -43,11 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/security/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/test/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/system/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/system/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/system/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/system/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/system/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/system/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/system/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/system/test/src/test/resources/kapua-environment-setting.properties
@@ -43,11 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/system/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/system/test/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -43,11 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -43,10 +43,10 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,6 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -43,7 +43,11 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
+
+commons.db.pool.size=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.min=2
+# Deprecated setting since 2.1.0. Use commons.db.pool.size
 commons.db.pool.size.max=30
 
 #

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -45,7 +45,6 @@ commons.db.characterEncoding=UTF-8
 
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
-commons.db.pool.borrow.timeout=15000
 
 #
 # Broker settings

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -44,10 +44,10 @@ commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
 
-commons.db.pool.size=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+commons.db.pool.size.fixed=5
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size
+# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
 commons.db.pool.size.max=30
 
 #

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -43,12 +43,8 @@ commons.db.useLegacyDatetimeCode=false
 commons.db.serverTimezone=UTC
 commons.db.characterEncoding=UTF-8
 
-
+commons.db.pool.size.strategy=fixed
 commons.db.pool.size.fixed=5
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.min=2
-# Deprecated setting since 2.1.0. Use commons.db.pool.size.fixed
-commons.db.pool.size.max=30
 
 #
 # Broker settings


### PR DESCRIPTION
This PR deprecates `commons.db.pool.size.min` and `commons.db.pool.size.max` settings since they have changed their meaning/usage after #4067 

We deprecated `commons.db.pool.size.min` and `commons.db.pool.size.max` settings, switching to a new `commons.db.pool.size.fixed` setting which will configure the database connection pool to a fixed size with a default value of `5`.

Backward compatibility is granted by `db.pool.size.strategy`. Default value is `fixed`, but it can be changed to `range` to continue use of a variable database connection pool. Be aware that at some point `range` strategy will be removed and only fixed size will be available.

**Related Issue**
This PR improves changes made in #4067

**Description of the solution adopted**
Deprecated usage of:
- `commons.db.pool.size.min`
- `commons.db.pool.size.max`
- `commons.db.pool.idle.timeout`

Removed:
- `commons.db.pool.size.initial` - not used nor referenced
- `commons.db.pool.borrow.timeout` - not used nor referenced

which were no longer used.

Introduced a new `commons.db.pool.size.strategy` and `commons.db.pool.size.fixed` settings to manage the pool sizing

**Screenshots**
_None_

**Any side note on the changes made**
Introduced `UPGRADE_NOTES.md` file to start maintaining a verbose upgrade notes log for notable changes in version