### PR TITLE
:sparkles: [Core] Extended allowed chars in KapuaEntity.name

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
@@ -290,7 +290,7 @@ public class ArgumentValidator {
      * <ul>
      *     <li>{@link #notEmptyOrNull(String, String)}</li>
      *     <li>{@link #lengthRange(String, Integer, Integer, String)}</li>
-     *     <li>{@link #match(String, ValidationRegex, String)} with {@link CommonsValidationRegex#NAME_SPACE_REGEXP} </li>
+     *     <li>{@link #match(String, ValidationRegex, String)} with {@link CommonsValidationRegex#EXTENDED_NAME_REGEXP} </li>
      * </ul>
      *
      * @param name         The value to validate. Usually would be the {@link KapuaNamedEntity#getName()} or {@link KapuaNamedEntityCreator#getName()}, but other values could be provided
@@ -307,7 +307,7 @@ public class ArgumentValidator {
     public static void validateEntityName(@Nullable String name, @Nullable Integer minLength, @Nullable Integer maxLength, @NotNull String argumentName) throws KapuaIllegalNullArgumentException, KapuaIllegalArgumentException {
         notEmptyOrNull(name, argumentName);
         lengthRange(name, minLength, maxLength, argumentName);
-        match(name, CommonsValidationRegex.NAME_SPACE_REGEXP, argumentName);
+        match(name, CommonsValidationRegex.EXTENDED_NAME_REGEXP, argumentName);
     }
 
 
@@ -323,8 +323,9 @@ public class ArgumentValidator {
      * @see ArgumentValidator#notEmptyOrNull(String, String)
      * @see ArgumentValidator#lengthRange(String, Integer, Integer, String)
      * @see ArgumentValidator#match(String, ValidationRegex, String)
-     * @since 1.2.0
+     * @deprecated Since 2.1.0. Use {@link #validateEntityName(String, String)} which now support an extended charset
      */
+    @Deprecated
     public static void validateJobName(@Nullable String name, @NotNull String argumentName) throws KapuaIllegalNullArgumentException, KapuaIllegalArgumentException {
         validateJobName(name, 3, 255, argumentName);
     }
@@ -348,8 +349,10 @@ public class ArgumentValidator {
      * @see ArgumentValidator#notEmptyOrNull(String, String)
      * @see ArgumentValidator#lengthRange(String, Integer, Integer, String)
      * @see ArgumentValidator#match(String, ValidationRegex, String)
-     * @since 1.2.0
+     * @since 2.0.0
+     * @deprecated Since 2.1.0. Use {@link #validateEntityName(String, Integer, Integer, String)}  which now support an extended charset
      */
+    @Deprecated
     public static void validateJobName(@Nullable String name, @Nullable Integer minLength, @Nullable Integer maxLength, @NotNull String argumentName) throws KapuaIllegalNullArgumentException, KapuaIllegalArgumentException {
         notEmptyOrNull(name, argumentName);
         lengthRange(name, minLength, maxLength, argumentName);

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/CommonsValidationRegex.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/CommonsValidationRegex.java
@@ -27,13 +27,28 @@ public enum CommonsValidationRegex implements ValidationRegex {
     NAME_REGEXP("^[a-zA-Z0-9\\_\\-]{3,}$"),
 
     /**
-     * ^[a-zA-Z0-9\ \_\-]{3,}$
+     * ^[a-zA-Z0-9\ \_\-\.\:]{3,}$
+     *
+     * @since 2.1.0
      */
+    EXTENDED_NAME_REGEXP("^[a-zA-Z0-9\\ \\_\\-\\.\\:]{3,}$"),
+
+    /**
+     * ^[a-zA-Z0-9\ \_\-]{3,}$
+     *
+     * @since 1.0.0
+     * @deprecated Since 2.1.0. Please use {@link #EXTENDED_NAME_REGEXP}
+     */
+    @Deprecated
     NAME_SPACE_REGEXP("^[a-zA-Z0-9\\ \\_\\-]{3,}$"),
 
     /**
      * ^[a-zA-Z0-9\ \_\-\:]{3,}$
+     *
+     * @since 2.0.0
+     * @deprecated Since 2.1.0. Please use {@link #EXTENDED_NAME_REGEXP}
      */
+    @Deprecated
     NAME_SPACE_COLON_REGEXP("^[a-zA-Z0-9\\ \\_\\-\\:]{3,}$"),
 
     /**

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
@@ -115,6 +115,39 @@ public class ArgumentValidatorTest {
     }
 
     @Test
+    public void testIllegalCharacterExtendedNameRegExp() throws Exception {
+        String permittedSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890-_ .:";
+        String[] listOfFalseStringsNameSpace = new String[]{"abc!", "abc\\", "abc#", "abc$", "abc%", "abc&", "abc'",
+                "abc(", "abc)", "abc=", "abc?", "abc*", "abc;", "abc>", "abc<", "abc,", "abc¡", "abc™",
+                "abc£", "abc¢", "abc∞", "abc§", "abc¶", "abc•", "abcª", "abcº", "abc≠", "abcœ", "abc∑", "abc´", "abc®", "abc†",
+                "abc—", "abc¨", "abc^", "abcø", "abcπ", "abc[", "abc]", "abcå", "abcß", "abc∂", "abcƒ", "abc©", "abc ", "̏abc", "abc∆",
+                "abc…", "abc^", "abc\\", "abcΩ", "abc≈", "abcç", "abc√", "abc∫", "abc~", "abcµ", "abc≤", "abc≥", "abc÷", "abc⁄", "abc@",
+                "abc‹", "abc›", "abc€", "abcı", "abc–", "abc°", "abc·", "abc‚", "abc±", "abcŒ", "abc„", "abc‘", "abc”", "abc’",
+                "abcÉ", "abcØ", "abc∏", "abc{", "abc}", "abcÅ", "abcÍ", "abcÔ", "abc", "abcÒ", "abcæ", "abcÆ", "abc|", "abc«", "abc◊",
+                "abcÑ", "abc¯", "abcÈ", "abcˇ", "abc¿", "", "a", "ab", "abc¬",};
+        int sizeOfFalseStrings = listOfFalseStringsNameSpace.length;
+        String[] listOfPermittedStringsNameSpace = new String[]{permittedSymbols, "abc", "123", "ab1", "1ab", "ABC",
+                "as.", "as:",
+                "A1B", "A b", "A-ab1", "A_1", "ab-", "___", "---", "   ", "_- ", "ab ", "12 ", "12_", "2-1", "abcd1234-_ "};
+        int sizeOfPermittedStrings = listOfPermittedStringsNameSpace.length;
+        for (int i = 0; i < sizeOfFalseStrings; i++) {
+            try {
+                ArgumentValidator.match(listOfFalseStringsNameSpace[i], CommonsValidationRegex.EXTENDED_NAME_REGEXP, "EXTENDED_NAME_REGEXP_test_case");
+                Assert.fail("Exception expected for: " + listOfFalseStringsNameSpace[i]);
+            } catch (KapuaIllegalArgumentException e) {
+                // Expected
+            }
+        }
+        for (int i = 0; i < sizeOfPermittedStrings; i++) {
+            try {
+                ArgumentValidator.match(listOfPermittedStringsNameSpace[i], CommonsValidationRegex.EXTENDED_NAME_REGEXP, "EXTENDED_NAME_REGEXP_test_case");
+            } catch (Exception ex) {
+                Assert.fail("No exception expected for: " + listOfPermittedStringsNameSpace[i]);
+            }
+        }
+    }
+
+    @Test
     public void testIllegalCharacterNameSpaceRegExp() throws Exception {
         String argRegExprNameSpace = "^[a-zA-Z0-9\\ \\_\\-]{3,}$";
         String permittedSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890-_ ";

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
@@ -60,8 +60,17 @@ public class TextFieldValidator implements Validator {
         DEVICE_CLIENT_ID("device_client_id", "^((?!#|\\+|\\*|&|,|\\?|>|\\/|\\:\\:).)*$"),
         SNAPSHOT_FILE("snapshot_file", "^([a-zA-Z0-9\\:\\_\\-\\\\]){1,255}(\\.xml)"),
         NAME("name", "^[a-zA-Z0-9\\_\\-]{3,}$"),
+        /**
+         * @deprecated Since 6.1.0. Use {@link #EXTENDED_NAME}
+         */
+        @Deprecated
         NAME_SPACE("name_space", "^[a-zA-Z0-9\\ \\_\\-]{3,}$"),
+        /**
+         * @deprecated Since 6.1.0. Use {@link #EXTENDED_NAME}
+         */
+        @Deprecated
         NAME_SPACE_COLON("name_space_colon", "^[a-zA-Z0-9\\ \\_\\-\\:]{3,}$"),
+        EXTENDED_NAME("extended_name", "^[a-zA-Z0-9\\ \\_\\-\\.\\:]{3,}$"),
         PASSWORD("password", "^.*(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!\\\"\\#$%&'()*+,\\-./:;<=>?@\\[\\]\\\\^_`{|}~]).*$"),
         EMAIL("email", "^(\\w+)([-+.][\\w]+)*@(\\w[-\\w]*\\.){1,5}([A-Za-z]){2,63}$"),
         PHONE("phone", "^\\+? ?[0-9_]+( [0-9_]+)*$"),

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
@@ -56,7 +56,7 @@ public class GroupAddDialog extends EntityAddEditDialog {
         groupNameField.setMinLength(3);
         groupNameField.setMaxLength(255);
         groupNameField.setFieldLabel("* " + MSGS.dialogAddFieldName());
-        groupNameField.setValidator(new TextFieldValidator(groupNameField, FieldType.NAME_SPACE));
+        groupNameField.setValidator(new TextFieldValidator(groupNameField, FieldType.EXTENDED_NAME));
         groupNameField.setToolTip(MSGS.dialogAddFieldNameTooltip());
         groupFormPanel.add(groupNameField);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
@@ -119,7 +119,7 @@ public class RoleAddDialog extends EntityAddEditDialog {
         roleNameField.setMinLength(3);
         roleNameField.setMaxLength(255);
         roleNameField.setFieldLabel("* " + MSGS.dialogAddFieldName());
-        roleNameField.setValidator(new TextFieldValidator(roleNameField, FieldType.NAME_SPACE));
+        roleNameField.setValidator(new TextFieldValidator(roleNameField, FieldType.EXTENDED_NAME));
         roleNameField.setToolTip(MSGS.dialogAddFieldNameTooltip());
         roleFormPanel.add(roleNameField);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
@@ -58,7 +58,7 @@ public class JobAddDialog extends EntityAddEditDialog {
         name.setMaxLength(255);
         name.setName("name");
         name.setFieldLabel("* " + JOB_MSGS.dialogAddFieldName());
-        name.setValidator(new TextFieldValidator(name, FieldType.NAME_SPACE_COLON));
+        name.setValidator(new TextFieldValidator(name, FieldType.EXTENDED_NAME));
         name.setToolTip(JOB_MSGS.dialogAddFieldNameTooltip());
         jobFormPanel.add(name);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -144,7 +144,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         triggerName.setAllowBlank(false);
         triggerName.setMinLength(3);
         triggerName.setMaxLength(255);
-        triggerName.setValidator(new TextFieldValidator(triggerName, TextFieldValidator.FieldType.NAME_SPACE));
+        triggerName.setValidator(new TextFieldValidator(triggerName, TextFieldValidator.FieldType.EXTENDED_NAME));
         triggerName.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleScheduleNameLabel());
         triggerName.setToolTip(JOB_MSGS.dialogAddScheduleNameTooltip());
         mainPanel.add(triggerName);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -105,7 +105,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
         jobStepName = new KapuaTextField<String>();
         jobStepName.setMinLength(3);
         jobStepName.setMaxLength(255);
-        jobStepName.setValidator(new TextFieldValidator(jobStepName, TextFieldValidator.FieldType.NAME_SPACE));
+        jobStepName.setValidator(new TextFieldValidator(jobStepName, TextFieldValidator.FieldType.EXTENDED_NAME));
 
         jobStepDescription = new KapuaTextField<String>();
         jobStepIndex = new KapuaNumberField();

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
@@ -54,7 +54,7 @@ public class TagAddDialog extends EntityAddEditDialog {
         tagNameField = new KapuaTextField<String>();
         tagNameField.setAllowBlank(false);
         tagNameField.setFieldLabel("* " + MSGS.dialogAddFieldName());
-        tagNameField.setValidator(new TextFieldValidator(tagNameField, FieldType.NAME_SPACE));
+        tagNameField.setValidator(new TextFieldValidator(tagNameField, FieldType.EXTENDED_NAME));
         tagNameField.setMinLength(3);
         tagNameField.setMaxLength(255);
         tagFormPanel.add(tagNameField);

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
@@ -81,7 +81,7 @@ public class JobServiceImpl extends KapuaConfigurableServiceBase implements JobS
         // Argument validation
         ArgumentValidator.notNull(creator, "jobCreator");
         ArgumentValidator.notNull(creator.getScopeId(), "jobCreator.scopeId");
-        ArgumentValidator.validateJobName(creator.getName(), "jobCreator.name");
+        ArgumentValidator.validateEntityName(creator.getName(), "jobCreator.name");
         // Check access
         authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, creator.getScopeId()));
         return txManager.execute(tx -> {

--- a/service/security/test/src/test/resources/features/GroupServiceUnitTests.feature
+++ b/service/security/test/src/test/resources/features/GroupServiceUnitTests.feature
@@ -255,7 +255,7 @@ Feature: Access Groups
   Kapua should return an error.
     Given I create the group with name "NewAccessGroup" and description ""
     Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
-    When I update the group name from "NewAccessGroup" to name with special characters "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«"
+    When I update the group name from "NewAccessGroup" to name with special characters "!#$%&'()=»Ç>;<,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«"
     Then An exception was thrown
 
   Scenario: Editing Access Group name to empty name


### PR DESCRIPTION
This PR extends the allowed chars in KapuaEntity names

**Related Issue**
_None_

**Description of the solution adopted**
Added a new validation regex which includes:

- alphanumerics
- `.`
- `-`
- whitespace
- `:`
- `_`

**Screenshots**
_None_

**Any side note on the changes made**
_None_