### PR TITLE
:bug: [Device Management] Fixed KuraInventoryContainer.state mapping

### DIFF
--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
@@ -140,12 +140,25 @@ public class AbstractTranslatorAppInventoryKuraKapua<M extends InventoryResponse
             deviceInventoryContainer.setVersion(kuraInventoryContainer.getVersion());
             deviceInventoryContainer.setContainerType(kuraInventoryContainer.getType());
 
-            if (deviceInventoryContainer.getState() != null) {
-                try {
-                    deviceInventoryContainer.setState(DeviceInventoryContainerState.valueOf(kuraInventoryContainer.getState()));
-                } catch (IllegalArgumentException iae) {
-                    LOG.warn("Unrecognised KuraInventoryContainer.state '{}' received. Defaulting to UNKNOWN state for DeviceInventoryContainer {}", kuraInventoryContainer.getState(), deviceInventoryContainer.getName(), iae);
-                    deviceInventoryContainer.setState(DeviceInventoryContainerState.UNKNOWN);
+            if (kuraInventoryContainer.getState() != null) {
+                switch (kuraInventoryContainer.getState()) {
+                    case "active":
+                        deviceInventoryContainer.setState(DeviceInventoryContainerState.ACTIVE);
+                        break;
+                    case "installed":
+                        deviceInventoryContainer.setState(DeviceInventoryContainerState.INSTALLED);
+                        break;
+                    case "uninstalled":
+                        deviceInventoryContainer.setState(DeviceInventoryContainerState.UNINSTALLED);
+                        break;
+                    case "unknown":
+                        deviceInventoryContainer.setState(DeviceInventoryContainerState.UNKNOWN);
+                        break;
+                    default: {
+                        LOG.warn("Unrecognised KuraInventoryContainer.state '{}' received. Defaulting to UNKNOWN state for DeviceInventoryContainer {}", kuraInventoryContainer.getState(), deviceInventoryContainer.getName());
+                        deviceInventoryContainer.setState(DeviceInventoryContainerState.UNKNOWN);
+                    }
+
                 }
             } else {
                 LOG.warn("Property KuraInventoryContainer.state '{}' not present. Defaulting to UNKNOWN state for DeviceInventoryContainer {}", kuraInventoryContainer.getState(), deviceInventoryContainer.getName());


### PR DESCRIPTION
This PR fixes the mapping of `KuraContainer.state` mapping to `DeviceInventoryContainer.state`

**Related Issue**
_None_

**Description of the solution adopted**
Fixed mapping to match actual values returned by Kura.

See https://github.com/eclipse-kura/kura/blame/develop/kura/org.eclipse.kura.core.inventory/src/main/java/org/eclipse/kura/core/inventory/resources/DockerContainer.java#L105 for reference

**Screenshots**
_None_

**Any side note on the changes made**
_None_