### PR TITLE
✨ [MFA] Added new 'hasTrustMe' attribute

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -3,3 +3,12 @@
 Below are described most important changes, features, additions and bugfixes that needs attention while performing the upgrade from the previous version.
 
 This report is only partial for Eclipse Kapua release 2.1.0-SNAPSHOT, since we started to maintain it mid-release development.
+
+## DB Changes
+
+#### New column in MFA Option table
+
+In PR [#4115](https://github.com/eclipse/kapua/pull/4115) a new `has_trust_me` column has been added to the `atht_mfa_option`.
+
+New column defaults to `null` and doesn't need any migration. The code itself will populate the column accordingly on first update.
+For large `atht_mfa_option` tables it might take sometime to be added.

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/MfaManagementPanel.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/MfaManagementPanel.java
@@ -484,7 +484,7 @@ public class MfaManagementPanel extends ContentPanel {
         boolean hasCredentialDelete = currentSession.hasPermission(CredentialSessionPermission.delete());
 
         // MFA is enabled, user has credential:write or is managing himself, and there's a trust key defined: enable "revoke trust devices" button
-        forgetTrustedMachine.setEnabled(multiFactorAuth && (hasCredentialWrite || selfManagement) && gwtMfaCredentialOptions.getTrustKey() != null);
+        forgetTrustedMachine.setEnabled(multiFactorAuth && (hasCredentialWrite || selfManagement) && gwtMfaCredentialOptions.getHasTrustMe());
 
         // MFA button icon & label
         if (multiFactorAuth) {

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtMfaCredentialOptions.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtMfaCredentialOptions.java
@@ -57,6 +57,14 @@ public class GwtMfaCredentialOptions extends GwtUpdatableEntityModel implements 
         set("trustKey", trustKey);
     }
 
+    public boolean getHasTrustMe() {
+        return get("hasTrustMe");
+    }
+
+    public void setHasTrustMe(boolean hasTrustMe) {
+        set("hasTrustMe", hasTrustMe);
+    }
+
     public String getAuthenticationKey() {
         return get("authenticationKey");
     }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/KapuaGwtAuthenticationModelConverter.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/KapuaGwtAuthenticationModelConverter.java
@@ -59,6 +59,7 @@ public class KapuaGwtAuthenticationModelConverter {
         gwtMfaCredentialOptions.setAuthenticationKey(mfaCredentialOptions.getMfaSecretKey());
         gwtMfaCredentialOptions.setTrustKey(mfaCredentialOptions.getTrustKey());
         gwtMfaCredentialOptions.setTrustExpirationDate(mfaCredentialOptions.getTrustExpirationDate());
+        gwtMfaCredentialOptions.setHasTrustMe(mfaCredentialOptions.getHasTrustMe());
         gwtMfaCredentialOptions.setQRCodeImage(mfaCredentialOptions.getQRCodeImage());
         gwtMfaCredentialOptions.setScratchCodes(convertScratchCodeListResult(mfaCredentialOptions.getScratchCodes()));
         return gwtMfaCredentialOptions;

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigrator.java
@@ -130,6 +130,11 @@ public class MfaOptionMigrator extends AbstractKapuaUpdatableEntity implements M
     }
 
     @Override
+    public boolean getHasTrustMe() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Date getTrustExpirationDate() {
         throw new UnsupportedOperationException();
     }

--- a/rest-api/resources/src/main/resources/openapi/userMfa/userMfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userMfa/userMfa.yaml
@@ -20,8 +20,11 @@ components:
                 - $ref: '../openapi.yaml#/components/schemas/kapuaId'
             trustKey:
               description: |
-                The key of the trusted machine.
+                The key of the trusted machine. Returned only on first activation to allow local storage.
               type: string
+            hasTrustMe:
+              type: boolean
+              description: Whether the trust key enabled present or not.
             trustExpirationDate:
               description: |
                 The moment when the machine trust will expire.

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOption.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOption.java
@@ -28,13 +28,15 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * {@link MfaOption} definition.<br>
+ * MfaOption {@link KapuaUpdatableEntity} definition.
+ * <p>
  * Used to handle {@link MfaOption} needed by the various authentication algorithms.
+ *
+ * @since 1.3.0
  */
 @XmlRootElement(name = "mfaOption")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(factoryClass = MfaOptionXmlRegistry.class, //
-        factoryMethod = "newMfaOption") //
+@XmlType(factoryClass = MfaOptionXmlRegistry.class, factoryMethod = "newMfaOption")
 public interface MfaOption extends KapuaUpdatableEntity {
 
     String TYPE = "mfaOption";
@@ -45,94 +47,106 @@ public interface MfaOption extends KapuaUpdatableEntity {
     }
 
     /**
-     * Return the user identifier
+     * Gets the {@link User#getId()}.
      *
-     * @return The user identifier.
+     * @return The {@link User#getId()}.
+     * @since 1.3.0
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     KapuaId getUserId();
 
     /**
-     * Sets the {@link User} id of this {@link MfaOption}
+     * Sets the {@link User#getId()}.
      *
-     * @param userId The {@link User} id to set.
+     * @param userId The {@link User#getId()}.
+     * @since 1.3.0
      */
     void setUserId(KapuaId userId);
 
     /**
-     * Return the {@link MfaOption} key
+     * Gets the secret key that generates access codes
      *
-     * @return
+     * @return The secret key that generates access codes
+     * @since 1.3.0
      */
     @XmlElement(name = "mfaSecretKey")
     String getMfaSecretKey();
 
     /**
-     * Sets the {@link MfaOption} key
+     * Sets the secret key that generates access codes
      *
-     * @param mfaSecretKey
+     * @param mfaSecretKey The secret key that generates access codes
+     * @since 1.3.0
      */
     void setMfaSecretKey(String mfaSecretKey);
 
     /**
-     * Return the trust key
+     * Gets the trust key for trusted machines
      *
-     * @return
+     * @return The trust key for trusted machines
+     * @since 1.3.0
      */
     @XmlElement(name = "trustKey")
     String getTrustKey();
 
     /**
-     * Sets the trust key
+     * Sets the trust key for trusted machines
      *
-     * @param trustKey
+     * @param trustKey The trust key for trusted machines
+     * @since 1.3.0
      */
     void setTrustKey(String trustKey);
 
     /**
-     * Gets the current trust key expiration date
+     * Gets the {@link #getTrustKey()}  expiration date
      *
-     * @return the current trust key expiration date
+     * @return The {@link #getTrustKey()}  expiration date
+     * @since 1.3.0
      */
     @XmlElement(name = "trustExpirationDate")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
     Date getTrustExpirationDate();
 
     /**
-     * Sets the current trust expiration date
+     * Sets the {@link #getTrustKey()}  expiration date
      *
-     * @param trustExpirationDate the current trust expiration date
+     * @param trustExpirationDate The {@link #getTrustKey()}  expiration date
+     * @since 1.3.0
      */
     void setTrustExpirationDate(Date trustExpirationDate);
 
     /**
-     * Gets the Mfa secret key in the form of a base64 QR code image
+     * Gets the {@link #getMfaSecretKey()} in the form of a base64 QR code image
      *
-     * @return the QR code image in base64
+     * @return The {@link #getMfaSecretKey()} in the form of a base64 QR code image
+     * @since 1.3.0
      */
     @XmlElement(name = "qrCodeImage")
     String getQRCodeImage();
 
     /**
-     * Sets the Mfa QR code image
+     * Sets the {@link #getMfaSecretKey()} in the form of a base64 QR code image
      *
-     * @param qrCodeImage the QR code image in base64
+     * @param qrCodeImage The {@link #getMfaSecretKey()} in the form of a base64 QR code image
+     * @since 1.3.0
      */
     void setQRCodeImage(String qrCodeImage);
 
     /**
-     * Gets the list of {@link ScratchCode} associated to this {@link MfaOption}
+     * Gets the list of {@link ScratchCode}s
      *
-     * @return the list of {@link ScratchCode}
+     * @return The list of {@link ScratchCode}s
+     * @since 1.3.0
      */
     @XmlElement(name = "scratchCodes")
     List<ScratchCode> getScratchCodes();
 
     /**
-     * Sets the list of {@link ScratchCode} associated to this {@link MfaOption}
+     * Sets the list of {@link ScratchCode}s
      *
-     * @param scratchCodes the list of {@link ScratchCode}
+     * @param scratchCodes The list of {@link ScratchCode}s
+     * @since 1.3.0
      */
     void setScratchCodes(List<ScratchCode> scratchCodes);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOption.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOption.java
@@ -99,6 +99,15 @@ public interface MfaOption extends KapuaUpdatableEntity {
     void setTrustKey(String trustKey);
 
     /**
+     * Gets whether the {@link #getTrustKey()} is present or not
+     *
+     * @return {@code true} if it is present, {@code false} otherwise
+     * @since 2.1.0
+     */
+    @XmlElement(name = "hasTrustMe")
+    boolean getHasTrustMe();
+
+    /**
      * Gets the {@link #getTrustKey()}  expiration date
      *
      * @return The {@link #getTrustKey()}  expiration date

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionAttributes.java
@@ -15,11 +15,24 @@ package org.eclipse.kapua.service.authentication.credential.mfa;
 import org.eclipse.kapua.model.KapuaUpdatableEntityAttributes;
 
 /**
- * {@link MfaOption} predicates used to build query predicates.
+ * {@link MfaOption} {@link KapuaUpdatableEntityAttributes}.
+ *
+ * @since 1.3.0
  */
 public class MfaOptionAttributes extends KapuaUpdatableEntityAttributes {
 
+    /**
+     * {@link MfaOption#getUserId()}
+     *
+     * @since 1.3.0
+     */
     public static final String USER_ID = "userId";
+
+    /**
+     * {@link MfaOption#getMfaSecretKey()}
+     *
+     * @since 1.3.0
+     */
     public static final String MFA_SECRET_KEY = "mfaSecretKey";
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionAttributes.java
@@ -35,4 +35,11 @@ public class MfaOptionAttributes extends KapuaUpdatableEntityAttributes {
      */
     public static final String MFA_SECRET_KEY = "mfaSecretKey";
 
+    /**
+     * {@link MfaOption#getHasTrustMe()}
+     *
+     * @since 2.1.0
+     */
+    public static final String HAS_TRUST_ME = "hasTrustMe";
+
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionCreator.java
@@ -15,6 +15,7 @@ package org.eclipse.kapua.service.authentication.credential.mfa;
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.user.User;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -24,7 +25,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
- * {@link MfaOption} creator service definition.
+ * {@link MfaOption} {@link KapuaEntityCreator}
+ *
+ * @since 1.3.0
  */
 @XmlRootElement(name = "mfaOptionCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -32,20 +35,20 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public interface MfaOptionCreator extends KapuaEntityCreator<MfaOption> {
 
     /**
-     * Gets the user id owner of this token
+     * Gets the {@link User#getId()}
      *
-     * @return The user id owner of this token
-     * @since 1.0
+     * @return The {@link User#getId()}
+     * @since 1.3.0
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     KapuaId getUserId();
 
     /**
-     * Sets the user id owner of this token.
+     * Sets the {@link User#getId()}
      *
-     * @param userId The user id owner of this token.
-     * @since 1.0
+     * @param userId The {@link User#getId()}
+     * @since 1.3.0
      */
     void setUserId(KapuaId userId);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionFactory.java
@@ -17,9 +17,10 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 
 /**
- * {@link MfaOptionFactory} definition.
+ * {@link MfaOption} {@link KapuaEntityFactory} definition.
  *
  * @see KapuaEntityFactory
+ * @since 1.3.0
  */
 public interface MfaOptionFactory extends KapuaEntityFactory<MfaOption, MfaOptionCreator, MfaOptionQuery, MfaOptionListResult> {
 
@@ -29,6 +30,7 @@ public interface MfaOptionFactory extends KapuaEntityFactory<MfaOption, MfaOptio
      * @param scopeId The scope {@link KapuaId} to set into the {@link MfaOptionCreator}.
      * @param userId  The {@link org.eclipse.kapua.service.user.User} {@link KapuaId} to set into the{@link AccessToken}.
      * @return The newly instantiated {@link MfaOptionCreator}
+     * @since 1.3.0
      */
     MfaOptionCreator newCreator(KapuaId scopeId, KapuaId userId);
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionListResult.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionListResult.java
@@ -20,7 +20,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link MfaOption} list result definition.
+ * {@link MfaOption} {@link KapuaListResult} definition.
+ *
+ * @since 1.3.0
  */
 @XmlRootElement(name = "mfaOptionListResult")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionRepository.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionRepository.java
@@ -19,6 +19,11 @@ import org.eclipse.kapua.storage.TxContext;
 
 import java.util.Optional;
 
+/**
+ * {@link MfaOption} {@link KapuaUpdatableEntityRepository} definition.
+ *
+ * @since 2.0.0
+ */
 public interface MfaOptionRepository
         extends KapuaUpdatableEntityRepository<MfaOption, MfaOptionListResult> {
     Optional<MfaOption> findByUserId(TxContext tx, KapuaId scopeId, KapuaId userId) throws KapuaException;

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionService.java
@@ -32,36 +32,36 @@ public interface MfaOptionService extends KapuaEntityService<MfaOption, MfaOptio
      *
      * @param scopeId The {@link User#getScopeId()}.
      * @param userId  The {@link User#getId()}
-     * @return The {@link MfaOption} of the {@link User} if found.
+     * @return The {@link MfaOption} of the {@link User}, if found.
      * @throws KapuaException
      * @since 1.3.0
      */
     MfaOption findByUserId(KapuaId scopeId, KapuaId userId) throws KapuaException;
 
     /**
-     * Enables the trust machine for the {@link KapuaId} of the {@link MfaOption}.
+     * Enables the trust machine for a {@link User}
      *
-     * @param scopeId the scopeId
-     * @param userId  the {@link KapuaId} of the User owning the {@link MfaOption}
-     * @return the value of the trust key in plain text
+     * @param scopeId The {@link User#getScopeId()}
+     * @param userId  The {@link User#getId()}
+     * @return the value of the {@link MfaOption#getTrustKey()} in plain text
      * @since 1.3.0
      */
     String enableTrust(KapuaId scopeId, KapuaId userId) throws KapuaException;
 
     /**
-     * Disable the trust machine for the given {@link MfaOption}.
+     * Disables the trust machine for the given {@link MfaOption}.
      *
-     * @param scopeId     the scopeid
-     * @param mfaOptionId the {@link KapuaId} of the {@link MfaOption}
+     * @param scopeId     The {@link MfaOption#getScopeId()}
+     * @param mfaOptionId The {@link MfaOption#getId()}
      * @since 1.3.0
      */
     void disableTrust(KapuaId scopeId, KapuaId mfaOptionId) throws KapuaException;
 
     /**
-     * Disable the trust machine for the given {@link MfaOption}.
+     * Disables the trust machine of a {@link User}
      *
-     * @param scopeId the scopeid
-     * @param userId  the {@link KapuaId} of the User owning the {@link MfaOption}
+     * @param scopeId The {@link User#getScopeId()}
+     * @param userId  The {@link User#getId()}
      * @since 1.3.0
      */
     void disableTrustByUserId(KapuaId scopeId, KapuaId userId) throws KapuaException;

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionXmlRegistry.java
@@ -22,32 +22,41 @@ public class MfaOptionXmlRegistry {
     private final MfaOptionFactory mfaOptionFactory = KapuaLocator.getInstance().getFactory(MfaOptionFactory.class);
 
     /**
-     * Creates a new {@link MfaOption} instance
+     * Instantiates a new {@link MfaOptionCreator} instance
      *
-     * @return
+     * @return The newly instantiated {@link MfaOptionCreator}
+     * @since 1.3.0
+     */
+    public MfaOptionCreator newMfaOptionCreator() {
+        return mfaOptionFactory.newCreator(null, null);
+    }
+
+    /**
+     * Instantiates a new {@link MfaOption} instance
+     *
+     * @return The newly instantiated {@link MfaOption}
+     * @since 1.3.0
      */
     public MfaOption newMfaOption() {
         return mfaOptionFactory.newEntity(null);
     }
 
     /**
-     * Creates a new {@link MfaOption} list result instance
+     * Instantiates a new {@link MfaOptionListResult} instance
      *
-     * @return
+     * @return The newly instantiated {@link MfaOptionListResult}
+     * @since 1.3.0
      */
     public MfaOptionListResult newMfaOptionListResult() {
         return mfaOptionFactory.newListResult();
     }
 
     /**
-     * Creates a new {@link MfaOption} creator instance
+     * Instantiates a new {@link MfaOptionQuery} instance.
      *
-     * @return
+     * @return The newly instantiated {@link MfaOptionQuery}
+     * @since 1.3.0
      */
-    public MfaOptionCreator newMfaOptionCreator() {
-        return mfaOptionFactory.newCreator(null, null);
-    }
-
     public MfaOptionQuery newQuery() {
         return mfaOptionFactory.newQuery(null);
     }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCode.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCode.java
@@ -15,7 +15,6 @@ package org.eclipse.kapua.service.authentication.credential.mfa;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.authentication.token.AccessToken;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCode.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCode.java
@@ -25,12 +25,13 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
- * {@link ScratchCode} definition.<br>
+ * ScratchCode {@link KapuaEntity} definition.
+ *
+ * @since 1.3.0
  */
 @XmlRootElement(name = "scratchCode")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(factoryClass = ScratchCodeXmlRegistry.class, //
-        factoryMethod = "newScratchCode") //
+@XmlType(factoryClass = ScratchCodeXmlRegistry.class, factoryMethod = "newScratchCode")
 public interface ScratchCode extends KapuaEntity {
 
     String TYPE = "scratchCode";
@@ -41,25 +42,27 @@ public interface ScratchCode extends KapuaEntity {
     }
 
     /**
-     * Return the {@link KapuaId} of the {@link MfaOption}
+     * Gets the {@link MfaOption#getId()}
      *
-     * @return The {@link MfaOption} identifier.
+     * @return The {@link MfaOption#getId()}
+     * @since 1.3.0
      */
     @XmlElement(name = "mfaOptionId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     KapuaId getMfaOptionId();
 
     /**
-     * Sets the {@link MfaOption} id of this {@link AccessToken}
+     * Sets the {@link MfaOption#getId()}
      *
-     * @param mfaOptionId The {@link MfaOption} id to set.
+     * @param mfaOptionId The {@link MfaOption#getId()}
      */
     void setMfaOptionId(KapuaId mfaOptionId);
 
     /**
-     * Return the scratch code
+     * Gets the scratch code
      *
-     * @return
+     * @return The scratch code
+     * @since 1.3.0
      */
     @XmlElement(name = "scratchCode")
     String getCode();
@@ -67,7 +70,8 @@ public interface ScratchCode extends KapuaEntity {
     /**
      * Sets the scratch code
      *
-     * @param code
+     * @param code The scratch code
+     * @since 1.3.0
      */
     void setCode(String code);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeFactory.java
@@ -18,12 +18,19 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaListResult;
 
 /**
- * {@link ScratchCodeFactory} definition.
+ * {@link ScratchCode} {@link KapuaEntityFactory} definition.
  *
  * @see KapuaEntityFactory
+ * @since 1.3.0
  */
 public interface ScratchCodeFactory extends KapuaObjectFactory {
 
+    /**
+     * Instantiates a new {@link ScratchCode}.
+     * @param scopeId The {@link ScratchCode#getScopeId()}
+     * @return The newly instantiated {@link ScratchCode}
+     * @since 1.3.0
+     */
     ScratchCode newEntity(KapuaId scopeId);
 
     /**
@@ -37,11 +44,11 @@ public interface ScratchCodeFactory extends KapuaObjectFactory {
     /**
      * Instantiates a new {@link ScratchCode}.
      *
-     * @param scopeId     The scope {@link KapuaId} to set into the {@link ScratchCode}.
-     * @param mfaOptionId The {@link MfaOption} {@link KapuaId} to set into the
-     *                    {@link ScratchCode}.
-     * @param code        The code to set into the {@link ScratchCode}.
+     * @param scopeId     The {@link ScratchCode#getScopeId()}
+     * @param mfaOptionId The {@link MfaOption#getId()}
+     * @param code        The {@link ScratchCode#getCode()}.
      * @return The newly instantiated {@link ScratchCode}
+     * @since 1.3.0
      */
     ScratchCode newScratchCode(KapuaId scopeId, KapuaId mfaOptionId, String code);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeListResult.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeListResult.java
@@ -20,7 +20,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link ScratchCode} list result definition.
+ * {@link ScratchCode} {@link KapuaListResult} definition.
  */
 @XmlRootElement(name = "scratchCodeListResult")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeRepository.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeRepository.java
@@ -15,8 +15,14 @@ package org.eclipse.kapua.service.authentication.credential.mfa;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.storage.KapuaEntityRepository;
+import org.eclipse.kapua.storage.KapuaUpdatableEntityRepository;
 import org.eclipse.kapua.storage.TxContext;
 
+/**
+ * {@link ScratchCode} {@link KapuaUpdatableEntityRepository} definition.
+ *
+ * @since 2.0.0
+ */
 public interface ScratchCodeRepository
         extends KapuaEntityRepository<ScratchCode, ScratchCodeListResult> {
     ScratchCodeListResult findByMfaOptionId(TxContext tx, KapuaId scopeId, KapuaId mfaOptionId) throws KapuaException;

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeService.java
@@ -17,19 +17,30 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 
 /**
- * {@link ScratchCode} service definition.
+ * {@link ScratchCode} {@link KapuaService} definition.
+ *
+ * @since 1.3.0
  */
 public interface ScratchCodeService extends KapuaService {
+
     /**
-     * Return the ScratchCode list result looking by {@link MfaOption} identifier (and also scope identifier)
+     * Finds the {@link ScratchCodeListResult}.
      *
-     * @param scopeId
-     * @param mfaOptionId
-     * @return
+     * @param scopeId The {@link MfaOption#getScopeId()}
+     * @param mfaOptionId The {@link MfaOption#getId()}
+     * @return A {@link ScratchCodeListResult} with matching items
      * @throws KapuaException
+     * @since 1.3.0
      */
     ScratchCodeListResult findByMfaOptionId(KapuaId scopeId, KapuaId mfaOptionId) throws KapuaException;
 
+    /**
+     * Deletes a {@link ScratchCode}
+     * @param scopeId The {@link ScratchCode#getScopeId()}
+     * @param scratchCodeId The {@link ScratchCode#getId()}
+     * @throws KapuaException
+     * @since 1.3.0
+     */
     void delete(KapuaId scopeId, KapuaId scratchCodeId) throws KapuaException;
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeXmlRegistry.java
@@ -22,18 +22,20 @@ public class ScratchCodeXmlRegistry {
     private final ScratchCodeFactory scratchCodeFactory = KapuaLocator.getInstance().getFactory(ScratchCodeFactory.class);
 
     /**
-     * Creates a new {@link ScratchCode} instance
+     * Instantiates a new {@link ScratchCode} instance.
      *
-     * @return
+     * @return The newly instantiated {@link ScratchCode}
+     * @since 1.3.0
      */
     public ScratchCode newScratchCode() {
         return scratchCodeFactory.newEntity(null);
     }
 
     /**
-     * Creates a new {@link ScratchCodeListResult} instance
+     * Instantiates a new {@link ScratchCodeListResult} instance
      *
-     * @return
+     * @return The newly instantiated {@link ScratchCodeListResult}
+     * @since 1.3.0
      */
     public ScratchCodeListResult newScratchCodeListResult() {
         return scratchCodeFactory.newListResult();

--- a/service/security/shiro/src/main/resources/liquibase/2.1.0/atht-mfa_option-has_trust_me.xml
+++ b/service/security/shiro/src/main/resources/liquibase/2.1.0/atht-mfa_option-has_trust_me.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-2.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-authentication-2.1.0-add_has_trust_me_column" author="eurotech">
+        <addColumn tableName="atht_mfa_option">
+            <column name="has_trust_me" type="boolean"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/2.1.0/changelog-authentication-2.1.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/2.1.0/changelog-authentication-2.1.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-2.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="./atht-mfa_option-has_trust_me.xml"/>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authentication-master.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authentication-master.xml
@@ -23,5 +23,6 @@
     <include relativeToChangelogFile="true" file="./1.3.0/changelog-authentication-1.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./2.0.0/atht-newTokenIdentifier.xml"/>
     <include relativeToChangelogFile="true" file="./2.0.0/changelog-authentication-2.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./2.1.0/changelog-authentication-2.1.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds `hasTrustMe` flag to `MfaOption` entity. 
This will tell whether the MfaOption has a trustKey, since we are not returning the trustKey after creation.

**Related Issue**
_None_

**Description of the solution adopted**
Added new attribute and related documentation

**Screenshots**
_None_

**Any side note on the changes made**
Updated Javadocs