### PR TITLE
✨ [Rest API] Add `sortDir`, `sortParam` and `askTotalCount` functionality to `/{scopeId}/devices/{deviceId}/operations/{operationId}/notifications` API

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperationNotifications.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperationNotifications.java
@@ -12,23 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import com.google.common.base.Strings;
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.app.api.core.model.CountResult;
-import org.eclipse.kapua.app.api.core.model.EntityId;
-import org.eclipse.kapua.app.api.core.model.ScopeId;
-import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
-import org.eclipse.kapua.model.KapuaEntityAttributes;
-import org.eclipse.kapua.model.query.predicate.AndPredicate;
-import org.eclipse.kapua.service.KapuaService;
-import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotification;
-import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationAttributes;
-import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory;
-import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationListResult;
-import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationQuery;
-import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService;
-import org.eclipse.kapua.service.device.registry.Device;
-
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -41,6 +24,24 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import com.google.common.base.Strings;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.app.api.core.model.CountResult;
+import org.eclipse.kapua.app.api.core.model.EntityId;
+import org.eclipse.kapua.app.api.core.model.ScopeId;
+import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
+import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotification;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationAttributes;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationListResult;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationQuery;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService;
+import org.eclipse.kapua.service.device.registry.Device;
 
 @Path("{scopeId}/devices/{deviceId}/operations/{operationId}/notifications")
 public class DeviceManagementOperationNotifications extends AbstractKapuaResource {
@@ -69,6 +70,9 @@ public class DeviceManagementOperationNotifications extends AbstractKapuaResourc
             @PathParam("deviceId") EntityId deviceId,
             @PathParam("operationId") EntityId operationId,
             @QueryParam("resource") String resource,
+            @QueryParam("askTotalCount") boolean askTotalCount,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         ManagementOperationNotificationQuery query = managementOperationNotificationFactory.newQuery(scopeId);
@@ -79,10 +83,15 @@ public class DeviceManagementOperationNotifications extends AbstractKapuaResourc
             andPredicate.and(query.attributePredicate(ManagementOperationNotificationAttributes.RESOURCE, resource));
         }
 
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
+        }
+
         query.setPredicate(andPredicate);
 
         query.setOffset(offset);
         query.setLimit(limit);
+        query.setAskTotalCount(askTotalCount);
 
         return query(scopeId, deviceId, operationId, query);
     }

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId.yaml
@@ -27,6 +27,17 @@ paths:
           description: The resource of the DeviceEvent in which to search results
           schema:
             type: string
+        - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - name: sortDir
+          in: query
+          description: The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive (except for "clientId" parameter).
+          schema:
+            type: string
+            enum:
+              - ASCENDING
+              - DESCENDING
+            default: ASCENDING
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:


### PR DESCRIPTION
### Summary
This PR introduces sorting functionality to the `/{scopeId}/devices/{deviceId}/operations/{operationId}/notifications` API by adding three query parameters:
- `sortDir`: Accepts `NULL`, `ASCENDING`, or `DESCENDING` to define the sorting order.
- `sortParam`: Specifies the field on which the sorting is applied.
- `askTotalCount`: Specify if `totalCount` should be returned or not

### Changes
- Implemented `sortDir`, `sortParam` and `askTotalCount` query parameters in the `/{scopeId}/devices/{deviceId}/operations/{operationId}/notifications` API.
- When `sortDir` is `ASCENDING` or `DESCENDING`, sorting is applied to the field specified in `sortParam`.
- Mirrored the behavior from the `/devices` API to ensure consistency across similar endpoints.
- Updated the OpenAPI documentation to include details about the new query parameters for the `/{scopeId}/devices/{deviceId}/operations/{operationId}/notifications` API.