### PR TITLE
:bug: [REST API] Restore possibility to update a service configuration property with a "default" value

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/adapters/XmlPropertiesAdapter.java
@@ -42,7 +42,7 @@ public class XmlPropertiesAdapter<T extends Enum<T>, V extends XmlPropertyAdapte
                 .orElse(Collections.emptyList())
                 .stream()
                 .peek(adaptedProp -> {
-                    if (adaptedProp.getType() == null) {
+                    if (adaptedProp.getType() == null && adaptedProp.getValues() != null) {
                         throw new InternalError("null value for property.type parameter");
                     }
                 })


### PR DESCRIPTION
With previous PRs I modified the logic of service configuration unmarshalling, reporting to clients the missing "type" values inside invalid PUT request. Doing so, I did not consider the case where a client would like to update a property with a "default" value 
for example, an unlimited "password.minLength", with this block:

{
            "name": "password.minLength",
            "array": false,
            "encrypted": false
}

Here I refined the unmarshalling check logic to restore this possibility
