### PR TITLE
✨ [REST-API] Add support to query operations by `status` in `GET /{scopeId}/devices/{deviceId}/operations`

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
@@ -26,6 +26,7 @@ paths:
           description: The resource of the DeviceManagementOperation in which to search results
           schema:
             type: string
+        - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/status'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - name: sortDir

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation.yaml
@@ -22,6 +22,12 @@ components:
       schema:
         $ref: '../openapi.yaml#/components/schemas/kapuaId'
       required: true
+    status:
+      name: status
+      in: query
+      description: The status of the Registry Operation on which to perform the operation
+      schema:
+        $ref: './deviceOperation.yaml#/components/schemas/operationStatus'
   schemas:
     deviceOperation:
       allOf:


### PR DESCRIPTION
### Description
This PR implements the capability to search operations by their status using the `GET /{scopeId}/devices/{deviceId}/operations` endpoint.

### Changes Made
- **New Feature**: Added functionality to filter operations based on their status.
- **Refactor**: Modified the `DeviceManagementOperations` query method to support additional predicates.

The current query method was refactored because it was enforcing a "filter by device ID" constraint on all queries, regardless of any other predicates provided. This limitation prevented any other filtering criteria (e.g., status) from being applied, so the method has been updated to allow flexible filtering based on multiple criteria.