### PR TITLE
FIX: fixed test with no more available resource url

### DIFF
--- a/commons/src/test/java/org/eclipse/kapua/commons/util/KapuaFileUtilsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/KapuaFileUtilsTest.java
@@ -92,7 +92,7 @@ public class KapuaFileUtilsTest {
     @Test
     public void getAsFileTest() {
         String[] stringUrls = new String[]{
-                "https://opensource.apple.com/source/cups/cups-218/cups/data/iso-8859-1.txt",
+                "https://opensource.apple.com/",
                 //As per 2023-09-07, this file is no longer available:
 //                "http://txt2html.sourceforge.net/sample.txt",
                 "https://www.lipsum.com/"};


### PR DESCRIPTION
I fixed one of the junit tests because a URL (https://opensource.apple.com/source/cups/cups-218/cups/data/iso-8859-1.txt) was pointing to a no more available resource