### PR TITLE
⬆️ [Dependencies] `logback` to `1.3.12` and Update Dependencies for Compatibility

### DIFF
--- a/client/gateway/features/karaf/pom.xml
+++ b/client/gateway/features/karaf/pom.xml
@@ -27,7 +27,7 @@
     <packaging>feature</packaging>
 
     <properties>
-        <karaf.version>4.4.2</karaf.version>
+        <karaf.version>4.4.6</karaf.version>
     </properties>
 
     <dependencies>

--- a/consumer/lifecycle-app/pom.xml
+++ b/consumer/lifecycle-app/pom.xml
@@ -469,6 +469,13 @@
                                 </filter>
                             </filters>
                             <transformers>
+                                <!-- added by 2.7 -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports</resource>
+                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
                                     <resource>META-INF/persistence.xml</resource>
                                 </transformer>

--- a/consumer/lifecycle-app/src/main/java/org/eclipse/kapua/consumer/lifecycle/LifecycleApplication.java
+++ b/consumer/lifecycle-app/src/main/java/org/eclipse/kapua/consumer/lifecycle/LifecycleApplication.java
@@ -38,6 +38,7 @@ public class LifecycleApplication {
 
     public static void main(String[] args) {
         //org.springframework.context.ApplicationContext is not needed now so don't keep the SpringApplication.run return
+        System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
         SpringApplication.run(LifecycleApplication.class, args);
     }
 }

--- a/consumer/telemetry-app/pom.xml
+++ b/consumer/telemetry-app/pom.xml
@@ -421,6 +421,13 @@
                                 </filter>
                             </filters>
                             <transformers>
+                                <!-- added by 2.7 -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports</resource>
+                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
                                     <resource>META-INF/persistence.xml</resource>
                                 </transformer>

--- a/consumer/telemetry-app/src/main/java/org/eclipse/kapua/consumer/telemetry/TelemetryApplication.java
+++ b/consumer/telemetry-app/src/main/java/org/eclipse/kapua/consumer/telemetry/TelemetryApplication.java
@@ -38,6 +38,7 @@ public class TelemetryApplication {
 
     public static void main(String[] args) {
         //org.springframework.context.ApplicationContext is not needed now so don't keep the SpringApplication.run return
+        System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
         SpringApplication.run(TelemetryApplication.class, args);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <camel.version>3.21.0</camel.version> <!-- latest 3.11.0 -->
         <spring.version>5.3.23</spring.version> <!-- latest 5.3.8 -->
         <spring-security.version>5.7.5</spring-security.version> <!-- latest 5.5.1 -->
-        <spring-boot.version>2.5.14</spring-boot.version> <!-- latest 2.5.2 --> <!-- 2.3.x is not fully supported by camel (will be on camel 3.4) -->
+        <spring-boot.version>2.7.18</spring-boot.version>
 
         <aopalliance.version>1.0</aopalliance.version>
         <artemis.version>2.31.2</artemis.version>
@@ -114,7 +114,7 @@
         <liquibase.version>3.6.3</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
-        <logback.version>1.2.13</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
+        <logback.version>1.3.12</logback.version>
         <mockito.version>1.10.19</mockito.version>
         <netty.version>4.1.100.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
@@ -128,7 +128,7 @@
         <reflections.version>0.10.2</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.12.0</shiro.version>
-        <slf4j.version>1.7.33</slf4j.version>
+        <slf4j.version>2.0.0</slf4j.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <swagger-ui.version>5.3.1</swagger-ui.version>

--- a/service/authentication-app/pom.xml
+++ b/service/authentication-app/pom.xml
@@ -337,6 +337,13 @@
                                 </filter>
                             </filters>
                             <transformers>
+                                <!-- added by 2.7 -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports</resource>
+                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
                                     <resource>META-INF/persistence.xml</resource>
                                 </transformer>

--- a/service/authentication-app/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationApplication.java
+++ b/service/authentication-app/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationApplication.java
@@ -52,6 +52,7 @@ public class AuthenticationApplication {
 
     public static void main(String[] args) {
         //org.springframework.context.ApplicationContext is not needed now so don't keep the SpringApplication.run return
+        System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
         SpringApplication.run(AuthenticationApplication.class, args);
     }
 


### PR DESCRIPTION
## Summary
This pull request addresses a [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2023-6378) by upgrading Logback to version `1.3.12` and includes necessary updates to related dependencies, such as SLF4J and Spring Boot, to ensure compatibility across the project.

## Details
* Upgraded Logback to `1.3.12`
  * The primary objective of this update was to resolve a known security vulnerability (CVE) affecting all versions prior to `1.3.12`.
* Upgraded SLF4J to `2.0.0`
  * Upgrading Logback to version `1.3.x` required a corresponding update to SLF4J, as SLF4J `1.x` is incompatible with Logback `1.3.x`.
  * This change ensures smooth logging functionality and eliminates conflicts arising from older SLF4J versions.
* Updated Spring Boot Version
  * The upgrade to SLF4J `2.0.0` introduced compatibility issues with Spring Boot 2.x, leading to runtime errors when mixing SLF4J `2.x` with Spring Boot `2.x`.
  * As part of this pull request, Spring Boot has been upgraded to a version compatible with SLF4J `2.0.0` to resolve these issues.

## Background
This update is part of a larger effort to enhance the security and stability of the project by addressing known vulnerabilities and maintaining compatibility among core libraries. The changes ensure a smooth upgrade path and avoid runtime errors caused by mismatched versions.