### PR TITLE
✨ Data store queries now allow for multiple client ids

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataChannels.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataChannels.java
@@ -12,7 +12,23 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import com.google.common.base.Strings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
@@ -32,19 +48,10 @@ import org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredic
 import org.eclipse.kapua.service.storable.model.query.SortDirection;
 import org.eclipse.kapua.service.storable.model.query.SortField;
 import org.eclipse.kapua.service.storable.model.query.predicate.AndPredicate;
-import org.eclipse.kapua.service.storable.model.query.predicate.TermPredicate;
+import org.eclipse.kapua.service.storable.model.query.predicate.OrPredicate;
+import org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicate;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import java.util.Collections;
+import com.google.common.base.Strings;
 
 @Path("{scopeId}/data/channels")
 public class DataChannels extends AbstractKapuaResource {
@@ -59,31 +66,47 @@ public class DataChannels extends AbstractKapuaResource {
     /**
      * Gets the {@link ChannelInfo} list in the scope.
      *
-     * @param scopeId   The {@link ScopeId} in which to search results.
-     * @param clientId  The client id to filter results.
-     * @param name      The channel name to filter results. It allows '#' wildcard in last channel level
-     * @param sortParam The name of the parameter that will be used as a sorting key
-     * @param sortDir   The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
-     * @param offset    The result set offset.
-     * @param limit     The result set limit.
+     * @param scopeId
+     *         The {@link ScopeId} in which to search results.
+     * @param clientId
+     *         The client id to filter results.
+     * @param name
+     *         The channel name to filter results. It allows '#' wildcard in last channel level
+     * @param sortParam
+     *         The name of the parameter that will be used as a sorting key
+     * @param sortDir
+     *         The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
+     * @param offset
+     *         The result set offset.
+     * @param limit
+     *         The result set limit.
      * @return The {@link ChannelInfoListResult} of all the channelInfos associated to the current selected scope.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @GET
-    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public ChannelInfoListResult simpleQuery(@PathParam("scopeId") ScopeId scopeId,
-                                             @QueryParam("clientId") String clientId,
-                                             @QueryParam("name") String name,
-                                             @QueryParam("sortParam") String sortParam,
-                                             @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
-                                             @QueryParam("offset") @DefaultValue("0") int offset,
-                                             @QueryParam("limit") @DefaultValue("50") int limit)
+            @QueryParam("clientId") List<String> clientIds,
+            @QueryParam("name") String name,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit)
             throws KapuaException {
         AndPredicate andPredicate = datastorePredicateFactory.newAndPredicate();
-        if (!Strings.isNullOrEmpty(clientId)) {
-            TermPredicate clientIdPredicate = datastorePredicateFactory.newTermPredicate(ChannelInfoField.CLIENT_ID, clientId);
-            andPredicate.getPredicates().add(clientIdPredicate);
+        final List<StorablePredicate> clientPredicates = Optional.ofNullable(clientIds)
+                .orElse(new ArrayList<>())
+                .stream()
+                .filter(v -> !Strings.isNullOrEmpty(v))
+                .map(clientId -> datastorePredicateFactory.newTermPredicate(ChannelInfoField.CLIENT_ID, clientId))
+                .collect(Collectors.toList());
+
+        if (!clientPredicates.isEmpty()) {
+            final OrPredicate orPredicate = datastorePredicateFactory.newOrPredicate();
+            orPredicate.setPredicates(clientPredicates);
+            andPredicate.addPredicate(orPredicate);
         }
 
         if (!Strings.isNullOrEmpty(name)) {
@@ -105,18 +128,21 @@ public class DataChannels extends AbstractKapuaResource {
     /**
      * Queries the results with the given {@link ChannelInfoQuery} parameter.
      *
-     * @param scopeId The {@link ScopeId} in which to search results.
-     * @param query   The {@link ChannelInfoQuery} to used to filter results.
+     * @param scopeId
+     *         The {@link ScopeId} in which to search results.
+     * @param query
+     *         The {@link ChannelInfoQuery} to used to filter results.
      * @return The {@link ChannelInfoListResult} of all the result matching the given {@link ChannelInfoQuery} parameter.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @POST
     @Path("_query")
-    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     public ChannelInfoListResult query(@PathParam("scopeId") ScopeId scopeId,
-                                       ChannelInfoQuery query)
+            ChannelInfoQuery query)
             throws KapuaException {
         query.setScopeId(scopeId);
         query.addFetchAttributes(ChannelInfoField.TIMESTAMP.field());
@@ -126,18 +152,21 @@ public class DataChannels extends AbstractKapuaResource {
     /**
      * Counts the results with the given {@link ChannelInfoQuery} parameter.
      *
-     * @param scopeId The {@link ScopeId} in which to search results.
-     * @param query   The {@link ChannelInfoQuery} to used to filter results.
+     * @param scopeId
+     *         The {@link ScopeId} in which to search results.
+     * @param query
+     *         The {@link ChannelInfoQuery} to used to filter results.
      * @return The count of all the result matching the given {@link ChannelInfoQuery} parameter.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @POST
     @Path("_count")
-    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     public CountResult count(@PathParam("scopeId") ScopeId scopeId,
-                             ChannelInfoQuery query)
+            ChannelInfoQuery query)
             throws KapuaException {
         query.setScopeId(scopeId);
 
@@ -147,16 +176,18 @@ public class DataChannels extends AbstractKapuaResource {
     /**
      * Returns the ChannelInfo specified by the "channelInfoId" path parameter.
      *
-     * @param channelInfoId The id of the requested ChannelInfo.
+     * @param channelInfoId
+     *         The id of the requested ChannelInfo.
      * @return The requested ChannelInfo object.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @GET
     @Path("{channelInfoId}")
-    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public ChannelInfo find(@PathParam("scopeId") ScopeId scopeId,
-                            @PathParam("channelInfoId") StorableEntityId channelInfoId)
+            @PathParam("channelInfoId") StorableEntityId channelInfoId)
             throws KapuaException {
         ChannelInfo channelInfo = channelInfoRegistryService.find(scopeId, channelInfoId);
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataChannels.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataChannels.java
@@ -68,8 +68,8 @@ public class DataChannels extends AbstractKapuaResource {
      *
      * @param scopeId
      *         The {@link ScopeId} in which to search results.
-     * @param clientId
-     *         The client id to filter results.
+     * @param clientIds
+     *         The client id(s) to filter results.
      * @param name
      *         The channel name to filter results. It allows '#' wildcard in last channel level
      * @param sortParam

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataClients.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataClients.java
@@ -62,8 +62,8 @@ public class DataClients extends AbstractKapuaResource {
      *
      * @param scopeId
      *         The {@link ScopeId} in which to search results.
-     * @param clientId
-     *         The client id to filter results
+     * @param clientIds
+     *         The client id(s) to filter results.
      * @param offset
      *         The result set offset.
      * @param limit

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -12,7 +12,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import com.google.common.base.Strings;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
@@ -38,24 +55,11 @@ import org.eclipse.kapua.service.storable.model.query.SortDirection;
 import org.eclipse.kapua.service.storable.model.query.SortField;
 import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
 import org.eclipse.kapua.service.storable.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.service.storable.model.query.predicate.OrPredicate;
 import org.eclipse.kapua.service.storable.model.query.predicate.RangePredicate;
 import org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicate;
-import org.eclipse.kapua.service.storable.model.query.predicate.TermPredicate;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import com.google.common.base.Strings;
 
 @Path("{scopeId}/data/messages")
 public class DataMessages extends AbstractKapuaResource {
@@ -70,57 +74,65 @@ public class DataMessages extends AbstractKapuaResource {
     /**
      * Gets the {@link DatastoreMessage} list in the scope.
      *
-     * @param scopeId        The {@link ScopeId} in which to search results.
-     * @param clientId       The client id to filter results.
-     * @param channel        The channel id to filter results. It allows '#' wildcard in last channel level.
-     * @param strictChannel  Restrict the search only to this channel ignoring its children. Only meaningful if channel is set.
-     * @param startDateParam The start date to filter the results. Must come before endDate parameter.
-     * @param endDateParam   The end date to filter the results. Must come after startDate parameter
-     * @param offset         The result set offset.
-     * @param limit          The result set limit.
+     * @param scopeId
+     *         The {@link ScopeId} in which to search results.
+     * @param clientId
+     *         The client id to filter results.
+     * @param channel
+     *         The channel id to filter results. It allows '#' wildcard in last channel level.
+     * @param strictChannel
+     *         Restrict the search only to this channel ignoring its children. Only meaningful if channel is set.
+     * @param startDateParam
+     *         The start date to filter the results. Must come before endDate parameter.
+     * @param endDateParam
+     *         The end date to filter the results. Must come after startDate parameter
+     * @param offset
+     *         The result set offset.
+     * @param limit
+     *         The result set limit.
      * @return The {@link MessageListResult} of all the datastoreMessages associated to the current selected scope.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @GET
-    @Produces({MediaType.APPLICATION_XML})
+    @Produces({ MediaType.APPLICATION_XML })
     public <V extends Comparable<V>> MessageListResult simpleQuery(@PathParam("scopeId") ScopeId scopeId,
-                                                                   @QueryParam("clientId") String clientId,
-                                                                   @QueryParam("channel") String channel,
-                                                                   @QueryParam("strictChannel") boolean strictChannel,
-                                                                   @QueryParam("startDate") DateParam startDateParam,
-                                                                   @QueryParam("endDate") DateParam endDateParam,
-                                                                   @QueryParam("metricName") String metricName,
-                                                                   @QueryParam("metricType") String metricType,
-                                                                   @QueryParam("metricMin") String metricMinValue,
-                                                                   @QueryParam("metricMax") String metricMaxValue,
-                                                                   @QueryParam("sortDir") @DefaultValue("DESC") SortDirection sortDir,
-                                                                   @QueryParam("offset") @DefaultValue("0") int offset,
-                                                                   @QueryParam("limit") @DefaultValue("50") int limit)
+            @QueryParam("clientId") List<String> clientIds,
+            @QueryParam("channel") String channel,
+            @QueryParam("strictChannel") boolean strictChannel,
+            @QueryParam("startDate") DateParam startDateParam,
+            @QueryParam("endDate") DateParam endDateParam,
+            @QueryParam("metricName") String metricName,
+            @QueryParam("metricType") String metricType,
+            @QueryParam("metricMin") String metricMinValue,
+            @QueryParam("metricMax") String metricMaxValue,
+            @QueryParam("sortDir") @DefaultValue("DESC") SortDirection sortDir,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit)
             throws KapuaException {
         MetricType<V> internalMetricType = new MetricType<>(metricType);
-        MessageQuery query = parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientId, channel, strictChannel, startDateParam, endDateParam, metricName, internalMetricType, metricMinValue, metricMaxValue, sortDir, offset, limit);
+        MessageQuery query = parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientIds, channel, strictChannel, startDateParam, endDateParam, metricName, internalMetricType,
+                metricMinValue, metricMaxValue, sortDir, offset, limit);
 
         return query(scopeId, query);
     }
 
-
     /**
-     * Stores a new Message under the account of the currently connected user.
-     * In this case, the provided message will only be stored in the back-end
-     * database and it will not be forwarded to the message broker.
+     * Stores a new Message under the account of the currently connected user. In this case, the provided message will only be stored in the back-end database and it will not be forwarded to the
+     * message broker.
      *
-     * @param message The {@link KapuaDataMessage } to be stored
-     * @return an {@link InsertResponse} object encapsulating the response from
-     * the datastore
-     * @throws KapuaException Whenever something bad happens. See specific
-     *                        {@link KapuaService} exceptions.
+     * @param message
+     *         The {@link KapuaDataMessage } to be stored
+     * @return an {@link InsertResponse} object encapsulating the response from the datastore
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      */
     @POST
-    @Consumes({MediaType.APPLICATION_XML})
-    @Produces({MediaType.APPLICATION_XML})
+    @Consumes({ MediaType.APPLICATION_XML })
+    @Produces({ MediaType.APPLICATION_XML })
     public Response storeMessage(@PathParam("scopeId") ScopeId scopeId,
-                                 KapuaDataMessage message)
+            KapuaDataMessage message)
             throws KapuaException {
         message.setScopeId(scopeId);
         return returnCreated(new StorableEntityId(messageStoreService.store(message).toString()));
@@ -129,18 +141,21 @@ public class DataMessages extends AbstractKapuaResource {
     /**
      * Queries the results with the given {@link MessageQuery} parameter.
      *
-     * @param scopeId The {@link ScopeId} in which to search results.
-     * @param query   The {@link MessageQuery} to used to filter results.
+     * @param scopeId
+     *         The {@link ScopeId} in which to search results.
+     * @param query
+     *         The {@link MessageQuery} to used to filter results.
      * @return The {@link MessageListResult} of all the result matching the given {@link MessageQuery} parameter.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @POST
     @Path("_query")
-    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    @Produces({MediaType.APPLICATION_XML})
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML })
     public MessageListResult query(@PathParam("scopeId") ScopeId scopeId,
-                                   MessageQuery query)
+            MessageQuery query)
             throws KapuaException {
         query.setScopeId(scopeId);
 
@@ -150,18 +165,21 @@ public class DataMessages extends AbstractKapuaResource {
     /**
      * Counts the results with the given {@link MessageQuery} parameter.
      *
-     * @param scopeId The {@link ScopeId} in which to search results.
-     * @param query   The {@link MessageQuery} to used to filter results.
+     * @param scopeId
+     *         The {@link ScopeId} in which to search results.
+     * @param query
+     *         The {@link MessageQuery} to used to filter results.
      * @return The count of all the result matching the given {@link MessageQuery} parameter.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @POST
     @Path("_count")
-    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     public CountResult count(@PathParam("scopeId") ScopeId scopeId,
-                             MessageQuery query)
+            MessageQuery query)
             throws KapuaException {
         query.setScopeId(scopeId);
 
@@ -171,29 +189,30 @@ public class DataMessages extends AbstractKapuaResource {
     /**
      * Returns the DatastoreMessage specified by the "datastoreMessageId" path parameter.
      *
-     * @param datastoreMessageId The id of the requested DatastoreMessage.
+     * @param datastoreMessageId
+     *         The id of the requested DatastoreMessage.
      * @return The requested DatastoreMessage object.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @GET
     @Path("{datastoreMessageId}")
-    @Produces({MediaType.APPLICATION_XML})
+    @Produces({ MediaType.APPLICATION_XML })
     public DatastoreMessage find(@PathParam("scopeId") ScopeId scopeId,
-                                 @PathParam("datastoreMessageId") StorableEntityId datastoreMessageId)
+            @PathParam("datastoreMessageId") StorableEntityId datastoreMessageId)
             throws KapuaException {
         DatastoreMessage datastoreMessage = messageStoreService.find(scopeId, datastoreMessageId, StorableFetchStyle.SOURCE_FULL);
 
         return returnNotNullEntity(datastoreMessage);
     }
 
-
     //TODO: move this logic within the service, or at least in a collaborator shared with DataMessagesJson
     protected static <V extends Comparable<V>> MessageQuery parametersToQuery(
             DatastorePredicateFactory datastorePredicateFactory,
             MessageStoreFactory messageStoreFactory,
             ScopeId scopeId,
-            String clientId,
+            List<String> clientIds,
             String channel,
             boolean strictChannel,
             DateParam startDateParam,
@@ -206,11 +225,18 @@ public class DataMessages extends AbstractKapuaResource {
             int offset,
             int limit) throws KapuaIllegalNullArgumentException {
         AndPredicate andPredicate = datastorePredicateFactory.newAndPredicate();
-        if (!Strings.isNullOrEmpty(clientId)) {
-            TermPredicate clientIdPredicate = datastorePredicateFactory.newTermPredicate(MessageField.CLIENT_ID, clientId);
-            andPredicate.getPredicates().add(clientIdPredicate);
-        }
+        final List<StorablePredicate> clientPredicates = Optional.ofNullable(clientIds)
+                .orElse(new ArrayList<>())
+                .stream()
+                .filter(v -> !Strings.isNullOrEmpty(v))
+                .map(clientId -> datastorePredicateFactory.newTermPredicate(MessageField.CLIENT_ID, clientId))
+                .collect(Collectors.toList());
 
+        if (!clientPredicates.isEmpty()) {
+            final OrPredicate orPredicate = datastorePredicateFactory.newOrPredicate();
+            orPredicate.setPredicates(clientPredicates);
+            andPredicate.addPredicate(orPredicate);
+        }
         if (!Strings.isNullOrEmpty(channel)) {
             andPredicate.getPredicates().add(getChannelPredicate(datastorePredicateFactory, channel, strictChannel));
         }
@@ -247,7 +273,8 @@ public class DataMessages extends AbstractKapuaResource {
         return channelPredicate;
     }
 
-    private static <V extends Comparable<V>> StorablePredicate getMetricPredicate(DatastorePredicateFactory datastorePredicateFactory, String metricName, MetricType<V> metricType, String metricMinValue, String metricMaxValue) throws KapuaIllegalNullArgumentException {
+    private static <V extends Comparable<V>> StorablePredicate getMetricPredicate(DatastorePredicateFactory datastorePredicateFactory, String metricName, MetricType<V> metricType,
+            String metricMinValue, String metricMaxValue) throws KapuaIllegalNullArgumentException {
         if (metricMinValue == null && metricMaxValue == null) {
             Class<V> type = metricType != null ? metricType.getType() : null;
             return datastorePredicateFactory.newMetricExistsPredicate(metricName, type);

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -76,8 +76,8 @@ public class DataMessages extends AbstractKapuaResource {
      *
      * @param scopeId
      *         The {@link ScopeId} in which to search results.
-     * @param clientId
-     *         The client id to filter results.
+     * @param clientIds
+     *         The client id(s) to filter results.
      * @param channel
      *         The channel id to filter results. It allows '#' wildcard in last channel level.
      * @param strictChannel

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -12,6 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.DateParam;
 import org.eclipse.kapua.app.api.core.model.MetricType;
@@ -39,20 +54,6 @@ import org.eclipse.kapua.service.storable.model.query.SortField;
 import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
 import org.eclipse.kapua.service.storable.model.query.XmlAdaptedSortField;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * @see JsonSerializationFixed
  */
@@ -71,37 +72,47 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
     /**
      * Gets the {@link DatastoreMessage} list in the scope.
      *
-     * @param scopeId        The {@link ScopeId} in which to search results.
-     * @param clientId       The client id to filter results.
-     * @param channel        The channel id to filter results. It allows '#' wildcard in last channel level.
-     * @param strictChannel  Restrict the search only to this channel ignoring its children. Only meaningful if channel is set.
-     * @param startDateParam The start date to filter the results. Must come before endDate parameter.
-     * @param endDateParam   The end date to filter the results. Must come after startDate parameter
-     * @param offset         The result set offset.
-     * @param limit          The result set limit.
+     * @param scopeId
+     *         The {@link ScopeId} in which to search results.
+     * @param clientId
+     *         The client id to filter results.
+     * @param channel
+     *         The channel id to filter results. It allows '#' wildcard in last channel level.
+     * @param strictChannel
+     *         Restrict the search only to this channel ignoring its children. Only meaningful if channel is set.
+     * @param startDateParam
+     *         The start date to filter the results. Must come before endDate parameter.
+     * @param endDateParam
+     *         The end date to filter the results. Must come after startDate parameter
+     * @param offset
+     *         The result set offset.
+     * @param limit
+     *         The result set limit.
      * @return The {@link MessageListResult} of all the datastoreMessages associated to the current selected scope.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON})
+    @Produces({ MediaType.APPLICATION_JSON })
     public <V extends Comparable<V>> JsonMessageListResult simpleQueryJson(@PathParam("scopeId") ScopeId scopeId,
-                                                                           @QueryParam("clientId") String clientId,
-                                                                           @QueryParam("channel") String channel,
-                                                                           @QueryParam("strictChannel") boolean strictChannel,
-                                                                           @QueryParam("startDate") DateParam startDateParam,
-                                                                           @QueryParam("endDate") DateParam endDateParam,
-                                                                           @QueryParam("metricName") String metricName,
-                                                                           @QueryParam("metricType") String metricType,
-                                                                           @QueryParam("metricMin") String metricMinValue,
-                                                                           @QueryParam("metricMax") String metricMaxValue,
-                                                                           @QueryParam("sortDir") @DefaultValue("DESC") SortDirection sortDir,
-                                                                           @QueryParam("offset") @DefaultValue("0") int offset,
-                                                                           @QueryParam("limit") @DefaultValue("50") int limit)
+            @QueryParam("clientId") List<String> clientIds,
+            @QueryParam("channel") String channel,
+            @QueryParam("strictChannel") boolean strictChannel,
+            @QueryParam("startDate") DateParam startDateParam,
+            @QueryParam("endDate") DateParam endDateParam,
+            @QueryParam("metricName") String metricName,
+            @QueryParam("metricType") String metricType,
+            @QueryParam("metricMin") String metricMinValue,
+            @QueryParam("metricMax") String metricMaxValue,
+            @QueryParam("sortDir") @DefaultValue("DESC") SortDirection sortDir,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit)
             throws KapuaException {
         MetricType<V> internalMetricType = new MetricType<>(metricType);
-        MessageQuery query = DataMessages.parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientId, channel, strictChannel, startDateParam, endDateParam, metricName, internalMetricType , metricMinValue, metricMaxValue, sortDir, offset, limit);
+        MessageQuery query = DataMessages.parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientIds, channel, strictChannel, startDateParam, endDateParam, metricName,
+                internalMetricType, metricMinValue, metricMaxValue, sortDir, offset, limit);
         query.setScopeId(scopeId);
         final MessageListResult result = messageStoreService.query(query);
 
@@ -115,21 +126,20 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
     }
 
     /**
-     * Stores a new Message under the account of the currently connected user.
-     * In this case, the provided message will only be stored in the back-end
-     * database and it will not be forwarded to the message broker.
+     * Stores a new Message under the account of the currently connected user. In this case, the provided message will only be stored in the back-end database and it will not be forwarded to the
+     * message broker.
      *
-     * @param jsonKapuaDataMessage The {@link KapuaDataMessage } to be stored
-     * @return an {@link StorableEntityId} object encapsulating the response from
-     * the datastore
-     * @throws KapuaException Whenever something bad happens. See specific
-     *                        {@link KapuaService} exceptions.
+     * @param jsonKapuaDataMessage
+     *         The {@link KapuaDataMessage } to be stored
+     * @return an {@link StorableEntityId} object encapsulating the response from the datastore
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      */
     @POST
-    @Consumes({MediaType.APPLICATION_JSON})
-    @Produces({MediaType.APPLICATION_JSON})
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
     public Response storeMessageJson(@PathParam("scopeId") ScopeId scopeId,
-                                     JsonKapuaDataMessage jsonKapuaDataMessage)
+            JsonKapuaDataMessage jsonKapuaDataMessage)
             throws KapuaException {
 
         KapuaDataMessage kapuaDataMessage = kapuaDataMessageFactory.newKapuaDataMessage();
@@ -165,18 +175,21 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
     /**
      * Queries the results with the given {@link MessageQuery} parameter.
      *
-     * @param scopeId The {@link ScopeId} in which to search results.
-     * @param query   The {@link MessageQuery} to used to filter results.
+     * @param scopeId
+     *         The {@link ScopeId} in which to search results.
+     * @param query
+     *         The {@link MessageQuery} to used to filter results.
      * @return The {@link MessageListResult} of all the result matching the given {@link MessageQuery} parameter.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @POST
     @Path("_query")
-    @Consumes({MediaType.APPLICATION_JSON})
-    @Produces({MediaType.APPLICATION_JSON})
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
     public JsonMessageListResult queryJson(@PathParam("scopeId") ScopeId scopeId,
-                                           JsonMessageQuery query)
+            JsonMessageQuery query)
             throws KapuaException {
         query.setScopeId(scopeId);
 
@@ -195,16 +208,18 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
     /**
      * Returns the DatastoreMessage specified by the "datastoreMessageId" path parameter.
      *
-     * @param datastoreMessageId The id of the requested DatastoreMessage.
+     * @param datastoreMessageId
+     *         The id of the requested DatastoreMessage.
      * @return The requested DatastoreMessage object.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws KapuaException
+     *         Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @GET
     @Path("{datastoreMessageId}")
-    @Produces({MediaType.APPLICATION_JSON})
+    @Produces({ MediaType.APPLICATION_JSON })
     public JsonDatastoreMessage findJson(@PathParam("scopeId") ScopeId scopeId,
-                                         @PathParam("datastoreMessageId") StorableEntityId datastoreMessageId)
+            @PathParam("datastoreMessageId") StorableEntityId datastoreMessageId)
             throws KapuaException {
         DatastoreMessage datastoreMessage = returnNotNullEntity(messageStoreService.find(scopeId, datastoreMessageId, StorableFetchStyle.SOURCE_FULL));
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -74,8 +74,8 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
      *
      * @param scopeId
      *         The {@link ScopeId} in which to search results.
-     * @param clientId
-     *         The client id to filter results.
+     * @param clientIds
+     *         The client id(s) to filter results.
      * @param channel
      *         The channel id to filter results. It allows '#' wildcard in last channel level.
      * @param strictChannel

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMetrics.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMetrics.java
@@ -64,8 +64,8 @@ public class DataMetrics extends AbstractKapuaResource {
      *
      * @param scopeId
      *         The {@link ScopeId} in which to search results.
-     * @param clientId
-     *         The client id to filter results.
+     * @param clientIds
+     *         The client id(s) to filter results.
      * @param channel
      *         The channel id to filter results. It allows '#' wildcard in last channel level
      * @param name

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId.yaml
@@ -22,8 +22,12 @@ paths:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - name: clientId
           in: query
+          required: false
+          collectionFormat: multi
           schema:
-            type: string
+            type: array
+            items:
+              type: string
           description: The ClientID to filter results
         - name: name
           in: query

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId.yaml
@@ -22,8 +22,12 @@ paths:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - name: clientId
           in: query
+          required: false
+          collectionFormat: multi
           schema:
-            type: string
+            type: array
+            items:
+              type: string
           description: The ClientID to filter results
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId.yaml
@@ -20,11 +20,15 @@ paths:
       operationId: dataMessageQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - description: The ClientID to use as a filter for messages
-          name: clientId
+        - name: clientId
           in: query
+          required: false
+          collectionFormat: multi
           schema:
-            type: string
+            type: array
+            items:
+              type: string
+          description: The ClientID to use as a filter for messages
         - description: The Channel to use as a filter for messages
           name: channel
           in: query

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId.yaml
@@ -22,9 +22,13 @@ paths:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - name: clientId
           in: query
+          required: false
+          collectionFormat: multi
           schema:
-            type: string
-          description: The client ID to filter results
+            type: array
+            items:
+              type: string
+          description: The ClientID to filter results
         - name: channel
           in: query
           schema:

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacadeImpl.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -30,11 +36,6 @@ import org.eclipse.kapua.service.storable.model.query.predicate.IdsPredicate;
 import org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Metric information registry facade
@@ -63,10 +64,10 @@ public class MetricInfoRegistryFacadeImpl extends AbstractDatastoreFacade implem
      */
     @Inject
     public MetricInfoRegistryFacadeImpl(ConfigurationProvider configProvider,
-                                        StorableIdFactory storableIdFactory,
-                                        StorablePredicateFactory storablePredicateFactory,
-                                        MetricInfoRepository metricInfoRepository,
-                                        DatastoreCacheManager datastoreCacheManager) {
+            StorableIdFactory storableIdFactory,
+            StorablePredicateFactory storablePredicateFactory,
+            MetricInfoRepository metricInfoRepository,
+            DatastoreCacheManager datastoreCacheManager) {
         super(configProvider);
         this.storableIdFactory = storableIdFactory;
         this.storablePredicateFactory = storablePredicateFactory;


### PR DESCRIPTION
✨ Data store queries now allow for multiple client ids to be queried at once

Data store queries in the rest apis now accept multiple client ids at once, making it easier to fetch data for multiple devices, instead of having to perform multiple queries (one per device).