### PR TITLE
🐛 [REST API] Make DuplicateNameException return `409` HTTP error code

### DIFF
--- a/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/KapuaDuplicateNameExceptionMapper.java
+++ b/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/KapuaDuplicateNameExceptionMapper.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.rest.errors;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.kapua.KapuaDuplicateNameException;
+import org.eclipse.kapua.commons.rest.model.errors.DuplicateNameExceptionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class KapuaDuplicateNameExceptionMapper implements ExceptionMapper<KapuaDuplicateNameException> {
+    private static final Logger LOG = LoggerFactory.getLogger(KapuaDuplicateNameExceptionMapper.class);
+    private final boolean showStackTrace;
+
+
+    @Inject
+    public KapuaDuplicateNameExceptionMapper(ExceptionConfigurationProvider exceptionConfigurationProvider) {
+        this.showStackTrace = exceptionConfigurationProvider.showStackTrace();
+    }
+
+
+    @Override
+    public Response toResponse(KapuaDuplicateNameException kapuaDuplicateNameException) {
+        LOG.error(kapuaDuplicateNameException.getMessage(), kapuaDuplicateNameException);
+        return Response
+                   .status(Response.Status.fromStatusCode(409))
+                   .entity(new DuplicateNameExceptionInfo(kapuaDuplicateNameException, showStackTrace))
+                   .build();
+    }
+}

--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/DuplicateNameExceptionInfo.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/DuplicateNameExceptionInfo.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.rest.model.errors;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.eclipse.kapua.KapuaDuplicateNameException;
+
+@XmlRootElement(name = "duplicateNameExceptionInfo")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class DuplicateNameExceptionInfo extends ExceptionInfo {
+
+    @XmlElement(name = "duplicatedName")
+    private String duplicatedName;
+
+
+    public DuplicateNameExceptionInfo() {
+        super();
+    }
+
+
+    public DuplicateNameExceptionInfo(KapuaDuplicateNameException kapuaDuplicateNameException, boolean showStackTrace) {
+        super(409, kapuaDuplicateNameException, showStackTrace);
+        this.duplicatedName = kapuaDuplicateNameException.getDuplicateName();
+    }
+
+
+    /**
+     * Gets the {@link KapuaDuplicateNameException#getDuplicateName()}.
+     * @return The {@link KapuaDuplicateNameException#getDuplicateName()}.
+     */
+    public String getName() {
+        return duplicatedName;
+    }
+}

--- a/service/tag/test/src/test/resources/features/TagService.feature
+++ b/service/tag/test/src/test/resources/features/TagService.feature
@@ -454,6 +454,14 @@ Feature: Tag Service
     When I assign tag "Tag1" to device "Device1"
     Then An exception was thrown
 
+  Scenario: Creating Tag With An Existing Name
+  Try to create tag with an existing name. Kapua should throw Exception.
+
+    Given I expect the exception "KapuaDuplicateNameException"
+    When I create tag with name "Tag"
+    And I create tag with name "Tag"
+    Then An exception was thrown
+
   @teardown
   Scenario: Reset Security Context for all scenarios
     Given Clean Locator Instance


### PR DESCRIPTION
### Summary
This PR addresses the issue where creating an entity with a duplicate name resulted in a 500 HTTP error. The error handling has been updated to return a 409 HTTP error code, which is more appropriate for this scenario.

### Changes Made
- Updated the error response for `DuplicateNameException` to return a 409 HTTP error code.
- Modified the response structure to include the name of the duplicate entity.

### New Response Structure
The new response for a duplicate entity creation will be as follows:
```json
{
  "type": "duplicateNameExceptionInfo",
  "httpErrorCode": 409,
  "message": "An entity with the same name <name> already exists.",
  "kapuaErrorCode": "DUPLICATE_NAME",
  "duplicatedName": "<name>"
}
```

### Steps to Reproduce
1. Create a new named entity (e.g., Role).
2. Attempt to create another named entity with the same name.