### PR TITLE
:sparkles: [Scheduler] Added 'description' to TriggerrDefinition.triggerProperty

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -125,7 +125,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         retryInterval = new KapuaNumberField();
         cronExpression = new KapuaTextField<String>();
 
-        DialogUtils.resizeDialog(this, 500, 350);
+        DialogUtils.resizeDialog(this, 500, 370);
     }
 
     @Override
@@ -273,6 +273,19 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
             retryInterval.setMaxLength(9);
             retryInterval.setToolTip(JOB_MSGS.dialogAddScheduleRetryIntervalTooltip());
             triggerPropertiesPanel.add(retryInterval);
+
+            GwtTriggerProperty triggerProperty = gwtTriggerDefinition.getTriggerProperty("interval");
+
+            if (triggerProperty != null && triggerProperty.getDescription() != null) {
+                LabelField fieldTooltip = new LabelField();
+                fieldTooltip.setStyleAttribute("margin-top", "-5px");
+                fieldTooltip.setStyleAttribute("color", "gray");
+                fieldTooltip.setStyleAttribute("font-size", "10px");
+                fieldTooltip.setValue(triggerProperty.getDescription());
+
+                triggerPropertiesPanel.add(fieldTooltip);
+            }
+
         } else if (TRIGGER_DEFINITION_NAME_CRON.equals(gwtTriggerDefinition.getTriggerDefinitionName())) {
             cronExpression.clearInvalid();
             cronExpression.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleCronScheduleLabel());
@@ -287,6 +300,18 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
             cronExpressionLabel.setStyleAttribute("color", "gray");
             cronExpressionLabel.setStyleAttribute("font-size", "10px");
             triggerPropertiesPanel.add(cronExpressionLabel);
+
+            GwtTriggerProperty triggerProperty = gwtTriggerDefinition.getTriggerProperty("cronExpression");
+
+            if (triggerProperty != null && triggerProperty.getDescription() != null) {
+                LabelField fieldTooltip = new LabelField();
+                fieldTooltip.setStyleAttribute("margin-top", "-5px");
+                fieldTooltip.setStyleAttribute("color", "gray");
+                fieldTooltip.setStyleAttribute("font-size", "10px");
+                fieldTooltip.setValue(triggerProperty.getDescription());
+
+                triggerPropertiesPanel.add(fieldTooltip);
+            }
 
             cronExpression.addListener(Events.Blur, new Listener<BaseEvent>() {
                 @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTriggerProperty.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTriggerProperty.java
@@ -33,6 +33,14 @@ public class GwtTriggerProperty extends KapuaBaseModel {
         set("propertyName", propertyName);
     }
 
+    public String getDescription() {
+        return get("description");
+    }
+
+    public void setDescription(String description) {
+        set("description", description);
+    }
+
     public String getPropertyType() {
         return get("propertyType");
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/definition/GwtTriggerDefinition.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/definition/GwtTriggerDefinition.java
@@ -72,6 +72,20 @@ public class GwtTriggerDefinition extends GwtEntityModel {
         return get("triggerProperties");
     }
 
+    public GwtTriggerProperty getTriggerProperty(String name) {
+        if (getTriggerProperties() == null) {
+            return null;
+        }
+
+        for (GwtTriggerProperty gwtTriggerProperty : getTriggerProperties()) {
+            if (gwtTriggerProperty.getPropertyName().equals(name)) {
+                return gwtTriggerProperty;
+            }
+        }
+
+        return null;
+    }
+
     public void setTriggerProperties(List<GwtTriggerProperty> triggerProperties) {
         set("triggerProperties", triggerProperties);
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
@@ -164,6 +164,7 @@ public class KapuaGwtJobModelConverter {
         for (TriggerProperty triggerProperty : triggerPropertyList) {
             GwtTriggerProperty gwtTriggerProperty = new GwtTriggerProperty();
             gwtTriggerProperty.setPropertyName(triggerProperty.getName());
+            gwtTriggerProperty.setDescription(triggerProperty.getDescription());
             gwtTriggerProperty.setPropertyType(triggerProperty.getPropertyType());
             gwtTriggerProperty.setPropertyValue(triggerProperty.getPropertyValue());
             gwtTriggerPropertyList.add(gwtTriggerProperty);

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition.yaml
@@ -28,6 +28,9 @@ components:
       properties:
         name:
           type: string
+        description:
+          type: string
+          description: The description that may contain textual information for the user on how to input this property
         propertyType:
           type: string
         propertyValue:
@@ -71,10 +74,13 @@ components:
         triggerProperties:
           - name: cronExpression
             propertyType: java.lang.String
+            description: The cron expression that defines the schedule of executions. Check documentation for CRON syntax.
           - name: jobId
             propertyType: org.eclipse.kapua.model.id.KapuaId
+            description: Identifier of the job this schedule will be applied to
           - name: scopeId
             propertyType: org.eclipse.kapua.model.id.KapuaId
+            description: Identifier of the scope of the job this schedule will be applied to
         triggerType: TIMER
     triggerDefinitionListResult:
       allOf:
@@ -104,10 +110,13 @@ components:
                 triggerProperties:
                   - name: cronExpression
                     propertyType: java.lang.String
+                    description: The cron expression that defines the schedule of executions. Check documentation for CRON syntax.
                   - name: jobId
                     propertyType: org.eclipse.kapua.model.id.KapuaId
+                    description: Identifier of the job this schedule will be applied to
                   - name: scopeId
                     propertyType: org.eclipse.kapua.model.id.KapuaId
+                    description: Identifier of the scope of the job this schedule will be applied to
                 triggerType: TIMER
               - type: triggerDefinition
                 id: Ag
@@ -123,10 +132,13 @@ components:
                 triggerProperties:
                   - name: interval
                     propertyType: java.lang.Integer
+                    description: Fixed time between job executions in seconds
                   - name: jobId
                     propertyType: org.eclipse.kapua.model.id.KapuaId
+                    description: Identifier of the job this schedule will be applied to
                   - name: scopeId
                     propertyType: org.eclipse.kapua.model.id.KapuaId
+                    description: Identifier of the scope of the job this schedule will be applied to
                 triggerType: TIMER
               - type: triggerDefinition
                 id: Aw
@@ -140,10 +152,10 @@ components:
                 description: Starts the job when the device target connects
                 processorName: '???'
                 triggerProperties:
-                  - name: delay
-                    propertyType: java.lang.Integer
                   - name: jobId
                     propertyType: org.eclipse.kapua.model.id.KapuaId
+                    description: Identifier of the job this schedule will be applied to
                   - name: scopeId
                     propertyType: org.eclipse.kapua.model.id.KapuaId
+                    description: Identifier of the scope of the job this schedule will be applied to
                 triggerType: EVENT

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/AppModule.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/AppModule.java
@@ -32,6 +32,7 @@ import org.eclipse.kapua.locator.LocatorConfig;
 
 import com.google.inject.Provides;
 import com.google.inject.multibindings.ProvidesIntoSet;
+import org.eclipse.kapua.service.scheduler.trigger.definition.quartz.TriggerDefinitionAligner;
 
 public class AppModule extends AbstractKapuaModule {
 
@@ -39,6 +40,8 @@ public class AppModule extends AbstractKapuaModule {
     protected void configureModule() {
         bind(DatabaseCheckUpdate.class).in(Singleton.class);
         bind(KapuaApiCoreSetting.class).in(Singleton.class);
+
+        bind(TriggerDefinitionAligner.class).in(Singleton.class);
 
         // Switching manually-configured JAXBContextProvider to autodiscovery one below
         // bind(JAXBContextProvider.class).to(RestApiJAXBContextProvider.class).in(Singleton.class);

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionRecord.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionRecord.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition;
+
+import org.eclipse.kapua.entity.EntityPropertiesReadException;
+import org.eclipse.kapua.entity.EntityPropertiesWriteException;
+import org.eclipse.kapua.model.id.KapuaId;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+public class TriggerDefinitionRecord implements TriggerDefinition {
+
+    private KapuaId scopeId;
+    private String name;
+    private String description;
+
+    private TriggerType triggerType;
+
+    private String processorName;
+
+    private List<TriggerProperty> triggerProperties;
+
+    public TriggerDefinitionRecord(KapuaId scopeId,
+                                    String name,
+                                    String description,
+                                    TriggerType triggerType,
+                                    String processorName,
+                                    List<TriggerProperty> triggerProperties) {
+        this.scopeId = scopeId;
+        this.name = name;
+        this.description = description;
+        this.triggerType = triggerType;
+        this.processorName = processorName;
+        this.triggerProperties = triggerProperties;
+    }
+
+    @Override
+    public KapuaId getScopeId() {
+        return scopeId;
+    }
+
+    @Override
+    public void setScopeId(KapuaId scopeId) {
+        this.scopeId = scopeId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public TriggerType getTriggerType() {
+        return triggerType;
+    }
+
+    @Override
+    public void setTriggerType(TriggerType triggerType) {
+        this.triggerType = triggerType;
+    }
+
+    @Override
+    public String getProcessorName() {
+        return processorName;
+    }
+
+    @Override
+    public void setProcessorName(String processorName) {
+        this.processorName = processorName;
+    }
+
+    @Override
+    public List<TriggerProperty> getTriggerProperties() {
+        return triggerProperties;
+    }
+
+    @Override
+    public void setTriggerProperties(List<TriggerProperty> triggerProperties) {
+        this.triggerProperties = triggerProperties;
+    }
+
+    @Override
+    public KapuaId getId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setId(KapuaId id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getCreatedOn() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public KapuaId getCreatedBy() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getModifiedOn() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public KapuaId getModifiedBy() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getOptlock() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setOptlock(int optlock) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Properties getEntityAttributes() throws EntityPropertiesReadException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setEntityAttributes(Properties props) throws EntityPropertiesWriteException {
+
+    }
+
+    @Override
+    public Properties getEntityProperties() throws EntityPropertiesReadException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setEntityProperties(Properties props) throws EntityPropertiesWriteException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TriggerProperty getTriggerProperty(String name) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerProperty.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerProperty.java
@@ -46,6 +46,22 @@ public interface TriggerProperty {
     void setName(String name);
 
     /**
+     * Gets the description
+     *
+     * @return The description
+     * @since 2.1.0
+     */
+    String getDescription();
+
+    /**
+     * Sets the description
+     *
+     * @param description The description
+     * @since 2.1.0
+     */
+    void setDescription(String description);
+
+    /**
      * Gets the property type.
      *
      * @return The property type.

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerPropertyRecord.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerPropertyRecord.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition;
+
+public class TriggerPropertyRecord implements TriggerProperty {
+
+    private String name;
+    private String description;
+    private String propertyType;
+    private String propertyValue;
+
+    public TriggerPropertyRecord(String name,
+            String description,
+            String propertyType,
+            String propertyValue) {
+        this.name = name;
+        this.description = description;
+        this.propertyType = propertyType;
+        this.propertyValue = propertyValue;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getPropertyType() {
+        return propertyType;
+    }
+
+    @Override
+    public void setPropertyType(String propertyType) {
+        this.propertyType = propertyType;
+    }
+
+    @Override
+    public String getPropertyValue() {
+        return propertyValue;
+    }
+
+    @Override
+    public void setPropertyValue(String propertyValue) {
+        this.propertyValue = propertyValue;
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/CronJobTriggerDefinition.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/CronJobTriggerDefinition.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import com.beust.jcommander.internal.Lists;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.scheduler.quartz.job.KapuaJobLauncher;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionRecord;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerPropertyRecord;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerType;
+
+/**
+ * Interval {@link Job} {@link TriggerDefinitionRecord}
+ *
+ * @since 2.1.0
+ */
+public class CronJobTriggerDefinition extends TriggerDefinitionRecord {
+
+    public CronJobTriggerDefinition() {
+        super(null,
+                "Cron Job",
+                "Job executions are scheduled through a CRON expression. Only CRON events occurring between the start time and end time will trigger executions",
+                TriggerType.TIMER,
+                KapuaJobLauncher.class.getName(),
+                Lists.newArrayList(
+                        new TriggerPropertyRecord(
+                                CronJobTriggerDefinitionPropertyKeys.SCOPE_ID,
+                                "Identifier of the job this schedule will be applied to",
+                                KapuaId.class.getName(),
+                                null),
+                        new TriggerPropertyRecord(
+                                CronJobTriggerDefinitionPropertyKeys.JOB_ID,
+                                "Identifier of the scope of the job this schedule will be applied to",
+                                KapuaId.class.getName(),
+                                null),
+                        new TriggerPropertyRecord(
+                                CronJobTriggerDefinitionPropertyKeys.CRON_EXPRESSION,
+                                "The cron expression that defines the schedule of executions. Check documentation for CRON syntax",
+                                KapuaId.class.getName(),
+                                null)
+                )
+        );
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/CronJobTriggerDefinitionPropertyKeys.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/CronJobTriggerDefinitionPropertyKeys.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import org.eclipse.kapua.service.job.step.definition.JobPropertyKey;
+
+public class CronJobTriggerDefinitionPropertyKeys implements JobPropertyKey {
+
+    public static final String SCOPE_ID = "scopeId";
+    public static final String JOB_ID = "jobId";
+    public static final String CRON_EXPRESSION = "cronExpression";
+
+    private CronJobTriggerDefinitionPropertyKeys() {
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/DeviceConnectTriggerDefinition.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/DeviceConnectTriggerDefinition.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import com.beust.jcommander.internal.Lists;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionRecord;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerPropertyRecord;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerType;
+
+/**
+ * Interval {@link Job} {@link TriggerDefinitionRecord}
+ *
+ * @since 2.1.0
+ */
+public class DeviceConnectTriggerDefinition extends TriggerDefinitionRecord {
+
+    public DeviceConnectTriggerDefinition() {
+        super(null,
+                "Device Connect",
+                "Job execution is triggered each time the device connects to the platform. Only connections occurring between the start time and end time will trigger executions",
+                TriggerType.EVENT,
+                null,
+                Lists.newArrayList(
+                        new TriggerPropertyRecord(
+                                DeviceConnectTriggerDefinitionPropertyKeys.SCOPE_ID,
+                                "Identifier of the job this schedule will be applied to",
+                                KapuaId.class.getName(),
+                                null),
+                        new TriggerPropertyRecord(
+                                DeviceConnectTriggerDefinitionPropertyKeys.JOB_ID,
+                                "Identifier of the scope of the job this schedule will be applied to",
+                                KapuaId.class.getName(),
+                                null)
+                )
+        );
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/DeviceConnectTriggerDefinitionPropertyKeys.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/DeviceConnectTriggerDefinitionPropertyKeys.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import org.eclipse.kapua.service.job.step.definition.JobPropertyKey;
+
+public class DeviceConnectTriggerDefinitionPropertyKeys implements JobPropertyKey {
+
+    public static final String SCOPE_ID = "scopeId";
+    public static final String JOB_ID = "jobId";
+
+    private DeviceConnectTriggerDefinitionPropertyKeys() {
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/IntervalJobTriggerDefinition.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/IntervalJobTriggerDefinition.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import com.beust.jcommander.internal.Lists;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.scheduler.quartz.job.KapuaJobLauncher;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionRecord;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerPropertyRecord;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerType;
+
+/**
+ * Interval {@link Job} {@link TriggerDefinitionRecord}
+ *
+ * @since 2.1.0
+ */
+public class IntervalJobTriggerDefinition extends TriggerDefinitionRecord {
+
+    public IntervalJobTriggerDefinition() {
+        super(null,
+                "Interval Job",
+                "Job executions are scheduled at fixed time intervals beginning from schedule start time. Executions will stop when the schedule end time is reached",
+                TriggerType.TIMER,
+                KapuaJobLauncher.class.getName(),
+                Lists.newArrayList(
+                        new TriggerPropertyRecord(
+                                IntervalJobTriggerDefinitionPropertyKeys.SCOPE_ID,
+                                "Identifier of the job this schedule will be applied to",
+                                KapuaId.class.getName(),
+                                null),
+                        new TriggerPropertyRecord(
+                                IntervalJobTriggerDefinitionPropertyKeys.JOB_ID,
+                                "Identifier of the scope of the job this schedule will be applied to",
+                                KapuaId.class.getName(),
+                                null),
+                        new TriggerPropertyRecord(
+                                IntervalJobTriggerDefinitionPropertyKeys.INTERVAL,
+                                "Fixed time between job executions in seconds",
+                                KapuaId.class.getName(),
+                                null)
+                )
+        );
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/IntervalJobTriggerDefinitionPropertyKeys.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/IntervalJobTriggerDefinitionPropertyKeys.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import org.eclipse.kapua.service.job.step.definition.JobPropertyKey;
+
+public class IntervalJobTriggerDefinitionPropertyKeys implements JobPropertyKey {
+
+    public static final String SCOPE_ID = "scopeId";
+    public static final String JOB_ID = "jobId";
+    public static final String INTERVAL = "interval";
+
+    private IntervalJobTriggerDefinitionPropertyKeys() {
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/SchedulerTriggerDefinitionModule.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/SchedulerTriggerDefinitionModule.java
@@ -13,15 +13,19 @@
 package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
 
 import com.google.inject.Provides;
+import com.google.inject.multibindings.ProvidesIntoSet;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
 import org.eclipse.kapua.commons.jpa.KapuaJpaTxManagerFactory;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinition;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionRepository;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService;
+import org.eclipse.kapua.storage.TxManager;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 public class SchedulerTriggerDefinitionModule extends AbstractKapuaModule {
@@ -35,13 +39,14 @@ public class SchedulerTriggerDefinitionModule extends AbstractKapuaModule {
     TriggerDefinitionService triggerDefinitionService(
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
+            @Named("schedulerTxManager") TxManager txManager,
             TriggerDefinitionRepository triggerDefinitionRepository,
             TriggerDefinitionFactory triggerDefinitionFactory,
             KapuaJpaTxManagerFactory jpaTxManagerFactory) {
         return new TriggerDefinitionServiceImpl(
                 authorizationService,
                 permissionFactory,
-                jpaTxManagerFactory.create("kapua-scheduler"),
+                txManager,
                 triggerDefinitionRepository,
                 triggerDefinitionFactory);
     }
@@ -51,4 +56,21 @@ public class SchedulerTriggerDefinitionModule extends AbstractKapuaModule {
     TriggerDefinitionRepository triggerDefinitionRepository(KapuaJpaRepositoryConfiguration jpaRepoConfig) {
         return new TriggerDefinitionImplJpaRepository(jpaRepoConfig);
     }
+
+
+    @ProvidesIntoSet
+    public TriggerDefinition cronJobTriggerDefinition() {
+        return new CronJobTriggerDefinition();
+    }
+
+    @ProvidesIntoSet
+    public TriggerDefinition deviceConnectTriggerDefinition() {
+        return new DeviceConnectTriggerDefinition();
+    }
+
+    @ProvidesIntoSet
+    public TriggerDefinition intervalJobTriggerDefinition() {
+        return new IntervalJobTriggerDefinition();
+    }
+
 }

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionAligner.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionAligner.java
@@ -1,0 +1,276 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.JpaAwareTxContext;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.locator.initializers.KapuaInitializingMethod;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinition;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionRepository;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerProperty;
+import org.eclipse.kapua.storage.TxContext;
+import org.eclipse.kapua.storage.TxManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This aligner aligns the declared {@link TriggerDefinition}s in each module with the database.
+ *
+ * @since 2.1.0
+ */
+public class TriggerDefinitionAligner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TriggerDefinitionAligner.class);
+    private final TxManager txManager;
+    private final TriggerDefinitionRepository triggerDefinitionRepository;
+    private final Set<TriggerDefinition> wiredTriggerDefinitions;
+    private final Comparator<TriggerDefinition> triggerDefinitionComparator;
+    private final Comparator<TriggerProperty> triggerPropertyComparator;
+
+    @Inject
+    public TriggerDefinitionAligner(
+            @Named("schedulerTxManager") TxManager txManager,
+            TriggerDefinitionRepository domainRepository,
+            Set<TriggerDefinition> wiredTriggerDefinitions) {
+        this.txManager = txManager;
+        this.triggerDefinitionRepository = domainRepository;
+        this.wiredTriggerDefinitions = wiredTriggerDefinitions;
+
+        triggerDefinitionComparator = Comparator
+                .comparing((TriggerDefinition triggerDefinition) ->
+                                Optional.ofNullable(triggerDefinition.getScopeId())
+                                        .map(KapuaId::getId)
+                                        .orElse(null),
+                        Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(TriggerDefinition::getName, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(TriggerDefinition::getDescription, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(TriggerDefinition::getTriggerType, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(TriggerDefinition::getProcessorName, Comparator.nullsFirst(Comparator.naturalOrder()));
+
+        triggerPropertyComparator = Comparator
+                .comparing(TriggerProperty::getName, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(TriggerProperty::getDescription, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(TriggerProperty::getPropertyType, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(TriggerProperty::getPropertyValue, Comparator.nullsFirst(Comparator.naturalOrder()));
+    }
+
+    @KapuaInitializingMethod(priority = 20)
+    public void populate() {
+        LOG.info("TriggerDefinition alignment commencing. Found {} TriggerDefinition declarations in wiring", wiredTriggerDefinitions.size());
+        Map<String, TriggerDefinition> wiredTriggerDefinitionsByName = wiredTriggerDefinitions
+                .stream()
+                .collect(Collectors.toMap(KapuaNamedEntity::getName, d -> d));
+
+        List<String> wireTriggerDefinitionsNotInDb = new ArrayList<>(wiredTriggerDefinitionsByName.keySet());
+        try {
+            KapuaSecurityUtils.doPrivileged(() -> {
+                txManager.execute(tx -> {
+                    // Retrieve all TriggerDefinition from the database
+                    List<TriggerDefinitionImpl> dbTriggerDefinitions = triggerDefinitionRepository.query(tx, new TriggerDefinitionQueryImpl(null)).getItems()
+                            .stream()
+                            .map(dbTriggrDefinition -> (TriggerDefinitionImpl) dbTriggrDefinition)
+                            .collect(Collectors.toList());
+                    LOG.info("Found {} TriggerDefinition declarations in database", dbTriggerDefinitions.size());
+
+                    // Check all TriggerDefinition from the database against the wired ones
+                    for (TriggerDefinitionImpl dbTriggerDefinition : dbTriggerDefinitions) {
+                        if (!wiredTriggerDefinitionsByName.containsKey(dbTriggerDefinition.getName())) {
+                            // Leave it be. As we share the database with other components, it might have been created by such components and be hidden from us
+                            LOG.warn("TriggerDefinition '{}' is only present in the database but it isn't wired in loaded modules!", dbTriggerDefinition.getName());
+                            continue;
+                        }
+
+                        // Good news, it's both declared in wiring and present in the db!
+                        wireTriggerDefinitionsNotInDb.remove(dbTriggerDefinition.getName());
+
+                        // Trigger fetch of Actions collection from db, otherwise the toString would not show the details
+                        dbTriggerDefinition.getTriggerProperties();
+
+                        // Check alignment between known and database TriggerProperty
+                        TriggerDefinition wiredTriggerDefinition = wiredTriggerDefinitionsByName.get(dbTriggerDefinition.getName());
+
+                        if (triggerDefinitionComparator.compare(dbTriggerDefinition, wiredTriggerDefinition) == 0) {
+                            LOG.info("TriggerDefinition '{}' basic properties are aligned... proceeding checking TriggerProperties...", dbTriggerDefinition.getName());
+
+                            if (triggerDefinitionPropertiesAreEqual(dbTriggerDefinition, wiredTriggerDefinition)) {
+                                //We are happy!
+                                LOG.info("TriggerDefinition '{}' is aligned!", dbTriggerDefinition.getName());
+                                continue;
+                            }
+                        }
+
+                        LOG.info("TriggerDefinition '{}' is not aligned!", dbTriggerDefinition.getName());
+
+                        // Align them!
+                        alignTriggerDefinitions(tx, dbTriggerDefinition, wiredTriggerDefinition);
+                    }
+
+                    if (wireTriggerDefinitionsNotInDb.isEmpty()) {
+                        LOG.info("All wired TriggerDefinition were already present in the database");
+                    } else {
+                        LOG.info("There are {} wired TriggerDefinition not present on the database", wireTriggerDefinitionsNotInDb.size());
+
+                        for (String wiredTriggerDefinitionsNotInDbName : wireTriggerDefinitionsNotInDb) {
+                            LOG.info("Creating new TriggerDefinition '{}'...", wiredTriggerDefinitionsNotInDbName);
+
+                            createNewTriggerDefinition(tx, wiredTriggerDefinitionsByName.get(wiredTriggerDefinitionsNotInDbName));
+
+                            LOG.info("Creating new TriggerDefinition '{}'... DONE!", wiredTriggerDefinitionsNotInDbName);
+                        }
+                    }
+
+                    LOG.info("TriggerDefinition alignment complete!");
+                    return null;
+                });
+            });
+        } catch (KapuaException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Checks if the given {@link TriggerDefinition} from the database matches the {@link TriggerDefinition} wired in the module.
+     *
+     * @param dbTriggerDefinition
+     *         The {@link TriggerDefinition} from the database
+     * @param wiredTriggerDefinition
+     *         The {@link TriggerDefinition} wired in the module
+     * @return {@code true} if they match, {@code false} otherwise
+     * @since 2.1.0
+     */
+    private boolean triggerDefinitionPropertiesAreEqual(TriggerDefinition dbTriggerDefinition, TriggerDefinition wiredTriggerDefinition) {
+        for (TriggerProperty wiredTriggerDefinitionProperty : wiredTriggerDefinition.getTriggerProperties()) {
+            TriggerProperty dbTriggerDefinitionProperty = dbTriggerDefinition.getTriggerProperty(wiredTriggerDefinitionProperty.getName());
+
+            if (dbTriggerDefinitionProperty == null) {
+                LOG.warn("Wired TriggerProperty '{}' of TriggerDefinition '{}' is not aligned with the database one",
+                        wiredTriggerDefinitionProperty.getName(),
+                        wiredTriggerDefinitionProperty.getName());
+
+                return false;
+            }
+
+            if (triggerPropertyComparator.compare(dbTriggerDefinitionProperty, wiredTriggerDefinitionProperty) != 0) {
+                LOG.warn("Database TriggerProperty '{}' of TriggerDefinition '{}' is not aligned with the wired one",
+                        dbTriggerDefinitionProperty.getName(),
+                        dbTriggerDefinition.getName());
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Aligns the {@link TriggerProperty} from the database to match the {@link TriggerDefinition} wired in the modules.
+     *
+     * @param txContext
+     *         The {@link TxContext} of the transaction.
+     * @param dbTriggerDefinition
+     *         The {@link TriggerDefinition} from the database to align
+     * @param wiredTriggerDefinition
+     *         The {@link TriggerDefinition} wired in the modules with the correct values.
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    private void alignTriggerDefinitions(TxContext txContext, TriggerDefinitionImpl dbTriggerDefinition, TriggerDefinition wiredTriggerDefinition) throws KapuaException {
+        LOG.info("TriggerDefinition '{}' aligning...", dbTriggerDefinition.getName());
+
+        dbTriggerDefinition.setScopeId(wiredTriggerDefinition.getScopeId());
+        dbTriggerDefinition.setName(wiredTriggerDefinition.getName());
+        dbTriggerDefinition.setDescription(wiredTriggerDefinition.getDescription());
+        dbTriggerDefinition.setTriggerType(wiredTriggerDefinition.getTriggerType());
+        dbTriggerDefinition.setProcessorName(wiredTriggerDefinition.getProcessorName());
+
+        EntityManager entityManager = JpaAwareTxContext.extractEntityManager(txContext);
+
+        Map<String, TriggerDefinitionPropertyImpl> dbPropertiesByName = dbTriggerDefinition.getTriggerPropertiesEntities()
+                .stream()
+                .collect(Collectors.toMap(triggerProperty -> triggerProperty.getId().getName(), triggerDefinitionProperty -> triggerDefinitionProperty));
+
+        for (TriggerProperty wiredTriggerProperty : wiredTriggerDefinition.getTriggerProperties()) {
+            TriggerDefinitionPropertyImpl dbTriggerPropertyEntity = dbPropertiesByName.get(wiredTriggerProperty.getName());
+
+            if (dbTriggerPropertyEntity == null) {
+                LOG.info("Wired TriggerProperty '{}' is not present in the database... Adding to database", wiredTriggerProperty.getName());
+                TriggerDefinitionPropertyImpl dbMissingTriggerProperty = new TriggerDefinitionPropertyImpl(dbTriggerDefinition, wiredTriggerProperty);
+                entityManager.persist(dbMissingTriggerProperty);
+            } else {
+                LOG.info("Wired TriggerProperty '{}' is in the database, but is not aligned... Aligning database", wiredTriggerProperty.getName());
+                dbTriggerPropertyEntity.getTriggerProperty().setDescription(wiredTriggerProperty.getDescription());
+                dbTriggerPropertyEntity.getTriggerProperty().setPropertyType(wiredTriggerProperty.getPropertyType());
+                dbTriggerPropertyEntity.getTriggerProperty().setPropertyValue(wiredTriggerProperty.getPropertyValue());
+
+                entityManager.merge(dbTriggerPropertyEntity);
+            }
+        }
+
+        // Removing from database what is not wired in the application
+        Map<String, TriggerProperty> wiredPropertiesByName = wiredTriggerDefinition.getTriggerProperties()
+                .stream()
+                .collect(Collectors.toMap(TriggerProperty::getName, triggerProperty -> triggerProperty));
+
+        dbTriggerDefinition.getTriggerPropertiesEntities()
+                .removeIf(dbTriggerPropertyEntity -> {
+                    TriggerProperty triggerProperty = wiredPropertiesByName.get(dbTriggerPropertyEntity.getTriggerProperty().getName());
+
+                    if (triggerProperty == null) {
+                        LOG.info("Database TriggerProperty '{}' is not wired... Removing from database", dbTriggerPropertyEntity.getTriggerProperty().getName());
+                        return true;
+                    }
+                    else {
+                        return false;
+                    }
+                });
+
+        LOG.info("TriggerDefinition '{}' aligning... DONE!", dbTriggerDefinition.getName());
+    }
+
+    /**
+     * Creates a new {@link TriggerDefinition} into the database from the given wired {@link TriggerDefinition}
+     *
+     * @param tx
+     *         The {@link TxContext} of the transaction
+     * @param wiredTriggerDefinitionNotInDb
+     *         The wired {@link TriggerDefinition}
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    private void createNewTriggerDefinition(TxContext tx, TriggerDefinition wiredTriggerDefinitionNotInDb) throws KapuaException {
+
+        TriggerDefinitionImpl newTriggerDefinition = new TriggerDefinitionImpl();
+        newTriggerDefinition.setScopeId(wiredTriggerDefinitionNotInDb.getScopeId());
+        newTriggerDefinition.setName(wiredTriggerDefinitionNotInDb.getName());
+        newTriggerDefinition.setDescription(wiredTriggerDefinitionNotInDb.getDescription());
+        newTriggerDefinition.setTriggerType(wiredTriggerDefinitionNotInDb.getTriggerType());
+        newTriggerDefinition.setProcessorName(wiredTriggerDefinitionNotInDb.getProcessorName());
+        newTriggerDefinition.setTriggerProperties(wiredTriggerDefinitionNotInDb.getTriggerProperties());
+
+        triggerDefinitionRepository.create(tx, newTriggerDefinition);
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionImpl.java
@@ -12,24 +12,29 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
 
-import com.google.common.collect.Lists;
+import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinition;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerProperty;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerType;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
 import javax.persistence.Basic;
-import javax.persistence.CollectionTable;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
-import javax.persistence.ElementCollection;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * {@link TriggerDefinition} implementation.
@@ -42,17 +47,29 @@ public class TriggerDefinitionImpl extends AbstractKapuaNamedEntity implements T
 
     private static final long serialVersionUID = 3747451706859757246L;
 
+
+    /**
+     * This overrides the {@link AbstractKapuaEntity#scopeId} JPA mapping which prevents the field to be updated. The {@link TriggerDefinitionAligner} may require to change the
+     * {@link TriggerDefinition#getScopeId()}.
+     *
+     * @since 2.0.0
+     */
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "eid", column = @Column(name = "scope_id", nullable = true, updatable = true))
+    })
+    protected KapuaEid scopeId;
+
     @Enumerated(EnumType.STRING)
-    @Column(name = "trigger_type", nullable = false, updatable = false)
+    @Column(name = "trigger_type", nullable = false, updatable = true)
     private TriggerType triggerType;
 
     @Basic
-    @Column(name = "processor_name", nullable = false, updatable = false)
+    @Column(name = "processor_name", nullable = false, updatable = true)
     private String processorName;
 
-    @ElementCollection
-    @CollectionTable(name = "schdl_trigger_definition_properties", joinColumns = @JoinColumn(name = "trigger_definition_id", referencedColumnName = "id"))
-    private List<TriggerPropertyImpl> triggerProperties;
+    @OneToMany(mappedBy = "triggerDefinition", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TriggerDefinitionPropertyImpl> triggerProperties;
 
     /**
      * Constructor.
@@ -86,6 +103,31 @@ public class TriggerDefinitionImpl extends AbstractKapuaNamedEntity implements T
         setTriggerProperties(triggerDefinition.getTriggerProperties());
     }
 
+    /**
+     * Gets the {@link TriggerDefinitionImpl#scopeId} instead of the {@link AbstractKapuaEntity#scopeId}.
+     *
+     * @return The {@link TriggerDefinitionImpl#scopeId}
+     * @see #scopeId
+     * @since 2.1.0
+     */
+    @Override
+    public KapuaEid getScopeId() {
+        return scopeId;
+    }
+
+    /**
+     * Sets the {@link TriggerDefinitionImpl#scopeId} instead of the {@link AbstractKapuaEntity#scopeId}.
+     *
+     * @param scopeId
+     *         The {@link TriggerDefinitionImpl#scopeId}
+     * @see #scopeId
+     * @since 2.1.0
+     */
+    @Override
+    public void setScopeId(KapuaId scopeId) {
+        this.scopeId = KapuaEid.parseKapuaId(scopeId);
+    }
+
     @Override
     public TriggerType getTriggerType() {
         return triggerType;
@@ -113,20 +155,53 @@ public class TriggerDefinitionImpl extends AbstractKapuaNamedEntity implements T
             triggerProperties = new ArrayList<>();
         }
 
-        return Lists.newArrayList(triggerProperties);
+        return triggerProperties.stream()
+                .map(TriggerDefinitionPropertyImpl::getTriggerProperty)
+                .collect(Collectors.toList());
     }
 
     @Override
     public TriggerProperty getTriggerProperty(String name) {
-        return getTriggerProperties().stream().filter(tp -> tp.getName().equals(name)).findAny().orElse(null);
+        return Optional.ofNullable(getTriggerProperties())
+                .flatMap(triggerProperties -> triggerProperties
+                        .stream()
+                        .filter(triggerProperty -> triggerProperty.getName().equals(name))
+                        .findAny())
+                .orElse(null);
     }
 
     @Override
     public void setTriggerProperties(List<TriggerProperty> triggerProperties) {
         this.triggerProperties = new ArrayList<>();
 
-        for (TriggerProperty sp : triggerProperties) {
-            this.triggerProperties.add(TriggerPropertyImpl.parse(sp));
+        for (TriggerProperty triggerProperty : triggerProperties) {
+            this.triggerProperties.add(TriggerDefinitionPropertyImpl.parse(this, triggerProperty));
         }
+    }
+
+    /**
+     * Gets the reference to the JPA-mapped {@link List} of {@link TriggerDefinitionPropertyImpl}.
+     *
+     * @return The reference to the JPA-mapped {@link List} of {@link TriggerDefinitionPropertyImpl}.
+     * @since 2.1.0
+     */
+    public List<TriggerDefinitionPropertyImpl> getTriggerPropertiesEntities() {
+        return triggerProperties;
+    }
+
+    /**
+     * Parses the given {@link TriggerDefinition} into a {@link TriggerDefinitionImpl}.
+     *
+     * @param triggerDefinition
+     *         The {@link TriggerDefinition} to parse.
+     * @return The parsed {@link TriggerDefinitionImpl}.
+     * @since 2.1.0
+     */
+    public static TriggerDefinitionImpl parse(TriggerDefinition triggerDefinition) {
+        return triggerDefinition != null ?
+                (triggerDefinition instanceof TriggerDefinitionImpl ?
+                        (TriggerDefinitionImpl) triggerDefinition :
+                        new TriggerDefinitionImpl(triggerDefinition))
+                : null;
     }
 }

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionPropertyId.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionPropertyId.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinition;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerProperty;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import java.io.Serializable;
+
+/**
+ * The {@link EmbeddedId} for {@link TriggerDefinitionPropertyImpl}.
+ * <p>
+ * It is composed by the {@link TriggerDefinition#getId()} and {@link TriggerProperty#getName()} which are unique.
+ *
+ * @since 2.0.0
+ */
+@Embeddable
+public class TriggerDefinitionPropertyId implements Serializable {
+
+    private static final long serialVersionUID = -6533866941432301617L;
+
+    protected KapuaEid triggerDefinitionId;
+
+    @Basic
+    @Column(name = "name", nullable = false, updatable = false)
+    private String name;
+
+    /**
+     * Constructor.
+     *
+     * @since 2.1.0
+     */
+    public TriggerDefinitionPropertyId() {
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param triggerDefinitionId
+     *         The {@link TriggerDefinition#getId()} part
+     * @param name
+     *         The {@link TriggerProperty#getName()} part
+     * @since 2.1.0
+     */
+    public TriggerDefinitionPropertyId(KapuaId triggerDefinitionId, String name) {
+        this.triggerDefinitionId = KapuaEid.parseKapuaId(triggerDefinitionId);
+        this.name = name;
+    }
+
+    /**
+     * Gets the {@link TriggerDefinition#getId()} part
+     *
+     * @return The {@link TriggerDefinition#getId()} part
+     * @since 2.1.0
+     */
+    public KapuaEid getTriggerDefinitionId() {
+        return triggerDefinitionId;
+    }
+
+    /**
+     * Sets the {@link TriggerDefinition#getId()} part
+     *
+     * @param triggerDefinitionId
+     *         The {@link TriggerDefinition#getId()} part
+     * @since 2.1.0
+     */
+    public void setTriggerDefinitionId(KapuaEid triggerDefinitionId) {
+        this.triggerDefinitionId = triggerDefinitionId;
+    }
+
+    /**
+     * Gets the {@link TriggerProperty#getName()} part
+     *
+     * @return The {@link TriggerProperty#getName()} part
+     * @since 2.1.0
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the {@link TriggerProperty#getName()} part
+     *
+     * @param name
+     *         The {@link TriggerProperty#getName()} part
+     * @since 2.1.0
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionPropertyImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionPropertyImpl.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinition;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerProperty;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.Table;
+import java.util.Optional;
+
+/**
+ * The {@link TriggerProperty} implementation for {@link TriggerDefinitionImpl}.
+ *
+ * @since 2.1.0
+ */
+@Entity(name = "TriggerDefinitionProperty")
+@Table(name = "schdl_trigger_definition_properties")
+public class TriggerDefinitionPropertyImpl {
+
+    @EmbeddedId
+    public TriggerDefinitionPropertyId id;
+
+    @MapsId("triggerDefinitionId")
+    @JoinColumns({
+            @JoinColumn(name = "trigger_definition_id", referencedColumnName = "id"),
+    })
+    @ManyToOne
+    public TriggerDefinitionImpl triggerDefinition;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "name", column = @Column(insertable = false, updatable = false))
+    })
+    private TriggerPropertyImpl triggerProperty;
+
+    /**
+     * Constructor.
+     *
+     * @since 2.1.0
+     */
+    public TriggerDefinitionPropertyImpl() {
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param triggerDefinition
+     *         The {@link TriggerDefinition} owner of the {@link TriggerProperty}
+     * @param triggerProperty
+     *         The {@link TriggerProperty}
+     * @since 2.1.0
+     */
+    public TriggerDefinitionPropertyImpl(TriggerDefinition triggerDefinition, TriggerProperty triggerProperty) {
+        setId(new TriggerDefinitionPropertyId(triggerDefinition.getId(), triggerProperty.getName()));
+        setTriggerDefinition(triggerDefinition);
+        setTriggerProperty(triggerProperty);
+    }
+
+    /**
+     * Gets the {@link TriggerDefinitionPropertyId}
+     *
+     * @return The {@link TriggerDefinitionPropertyId}
+     * @since 2.0.0
+     */
+    public TriggerDefinitionPropertyId getId() {
+        return id;
+    }
+
+    /**
+     * Sets the {@link TriggerDefinitionPropertyId}
+     *
+     * @param id
+     *         The {@link TriggerDefinitionPropertyId}
+     * @since 2.0.0
+     */
+    public void setId(TriggerDefinitionPropertyId id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the {@link TriggerDefinition}
+     *
+     * @return The {@link TriggerDefinition}
+     * @since 2.0.0
+     */
+    public TriggerDefinition getTriggerDefinition() {
+        return triggerDefinition;
+    }
+
+    /**
+     * Sets the {@link TriggerDefinition}
+     *
+     * @param triggerDefinition
+     *         the {@link TriggerDefinition}
+     * @since 2.0.0
+     */
+    public void setTriggerDefinition(TriggerDefinition triggerDefinition) {
+        this.triggerDefinition = TriggerDefinitionImpl.parse(triggerDefinition);
+    }
+
+    /**
+     * Gets the {@link TriggerProperty}
+     *
+     * @return The {@link TriggerProperty}
+     * @since 2.0.0
+     */
+    public TriggerProperty getTriggerProperty() {
+        return triggerProperty;
+    }
+
+    /**
+     * Sets the {@link TriggerProperty}
+     *
+     * @param triggerProperty
+     *         The {@link TriggerProperty}
+     * @since 2.1.0
+     */
+    public void setTriggerProperty(TriggerProperty triggerProperty) {
+        this.triggerProperty = Optional.ofNullable(triggerProperty)
+                .map(jsp -> jsp instanceof TriggerPropertyImpl ?
+                        (TriggerPropertyImpl) jsp :
+                        TriggerPropertyImpl.parse(jsp)
+                ).orElse(null);
+    }
+
+    /**
+     * Parses the given {@link TriggerDefinition} and the {@link TriggerProperty} into a {@link TriggerDefinitionPropertyImpl}.
+     *
+     * @param triggerDefinition
+     *         The {@link TriggerDefinition} to parse.
+     * @param triggerProperty
+     *         The {@link TriggerProperty} to parse.
+     * @return The parsed {@link TriggerDefinitionPropertyImpl}
+     * @since 2.1.0
+     */
+    public static TriggerDefinitionPropertyImpl parse(TriggerDefinition triggerDefinition, TriggerProperty triggerProperty) {
+        if (triggerProperty == null) {
+            return null;
+        }
+        if (triggerProperty instanceof TriggerDefinitionPropertyImpl) {
+            return (TriggerDefinitionPropertyImpl) triggerProperty;
+        }
+        return new TriggerDefinitionPropertyImpl(triggerDefinition, triggerProperty);
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionServiceImpl.java
@@ -67,7 +67,6 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
         ArgumentValidator.notNull(triggerDefinitionCreator.getScopeId(), "triggerDefinitionCreator.scopeId");
         ArgumentValidator.notNull(triggerDefinitionCreator.getTriggerType(), "triggerDefinitionCreator.stepType");
         ArgumentValidator.validateEntityName(triggerDefinitionCreator.getName(), "triggerDefinitionCreator.name");
-        ArgumentValidator.notEmptyOrNull(triggerDefinitionCreator.getProcessorName(), "triggerDefinitionCreator.processorName");
 
         // Check access
         authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, null));
@@ -88,7 +87,7 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
         ArgumentValidator.notNull(triggerDefinition.getScopeId(), "stepDefinition.scopeId");
         ArgumentValidator.notNull(triggerDefinition.getTriggerType(), "triggerDefinition.stepType");
         ArgumentValidator.validateEntityName(triggerDefinition.getName(), "triggerDefinition.name");
-        ArgumentValidator.notEmptyOrNull(triggerDefinition.getProcessorName(), "triggerDefinition.processorName");
+
         // Check access
         authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, null));
 

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerPropertyImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerPropertyImpl.java
@@ -32,6 +32,10 @@ public class TriggerPropertyImpl implements TriggerProperty {
     private String name;
 
     @Basic
+    @Column(name = "description", nullable = false, updatable = true)
+    private String description;
+
+    @Basic
     @Column(name = "property_type", nullable = false, updatable = false)
     private String propertyType;
 
@@ -55,6 +59,7 @@ public class TriggerPropertyImpl implements TriggerProperty {
      */
     private TriggerPropertyImpl(TriggerProperty triggerProperty) {
         setName(triggerProperty.getName());
+        setDescription(triggerProperty.getDescription());
         setPropertyType(triggerProperty.getPropertyType());
         setPropertyValue(triggerProperty.getPropertyValue());
     }
@@ -81,6 +86,16 @@ public class TriggerPropertyImpl implements TriggerProperty {
     @Override
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     @Override

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/quartz/SchedulerTriggerFiredModule.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/quartz/SchedulerTriggerFiredModule.java
@@ -22,7 +22,9 @@ import org.eclipse.kapua.service.scheduler.trigger.TriggerRepository;
 import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerFactory;
 import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerRepository;
 import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerService;
+import org.eclipse.kapua.storage.TxManager;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 public class SchedulerTriggerFiredModule extends AbstractKapuaModule {
@@ -36,6 +38,7 @@ public class SchedulerTriggerFiredModule extends AbstractKapuaModule {
     FiredTriggerService firedTriggerService(
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
+            @Named("schedulerTxManager") TxManager txManager,
             FiredTriggerRepository firedTriggerRepository,
             FiredTriggerFactory firedTriggerFactory,
             TriggerRepository triggerRepository,
@@ -43,7 +46,7 @@ public class SchedulerTriggerFiredModule extends AbstractKapuaModule {
         return new FiredTriggerServiceImpl(
                 authorizationService,
                 permissionFactory,
-                jpaTxManagerFactory.create("kapua-scheduler"),
+                txManager,
                 firedTriggerRepository,
                 firedTriggerFactory,
                 triggerRepository);

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/SchedulerQuartzModule.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/SchedulerQuartzModule.java
@@ -28,7 +28,9 @@ import org.eclipse.kapua.service.scheduler.trigger.TriggerRepository;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerService;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionRepository;
+import org.eclipse.kapua.storage.TxManager;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 public class SchedulerQuartzModule extends AbstractKapuaModule {
@@ -44,9 +46,19 @@ public class SchedulerQuartzModule extends AbstractKapuaModule {
 
     @Provides
     @Singleton
+    @Named("schedulerTxManager")
+    TxManager jobTxManager(
+            KapuaJpaTxManagerFactory jpaTxManagerFactory
+    ) {
+        return jpaTxManagerFactory.create("kapua-scheduler");
+    }
+
+    @Provides
+    @Singleton
     TriggerService triggerService(
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
+            @Named("schedulerTxManager") TxManager txManager,
             TriggerRepository triggerRepository,
             TriggerFactory triggerFactory,
             TriggerDefinitionRepository triggerDefinitionRepository,
@@ -55,7 +67,7 @@ public class SchedulerQuartzModule extends AbstractKapuaModule {
         return new TriggerServiceImpl(
                 authorizationService,
                 permissionFactory,
-                jpaTxManagerFactory.create("kapua-scheduler"),
+                txManager,
                 triggerRepository,
                 triggerFactory,
                 triggerDefinitionRepository,

--- a/service/scheduler/quartz/src/main/resources/META-INF/persistence.xml
+++ b/service/scheduler/quartz/src/main/resources/META-INF/persistence.xml
@@ -21,6 +21,8 @@
 
         <class>org.eclipse.kapua.service.scheduler.trigger.quartz.TriggerImpl</class>
         <class>org.eclipse.kapua.service.scheduler.trigger.definition.quartz.TriggerDefinitionImpl</class>
+        <class>org.eclipse.kapua.service.scheduler.trigger.definition.quartz.TriggerDefinitionPropertyImpl</class>
+        <class>org.eclipse.kapua.service.scheduler.trigger.definition.quartz.TriggerPropertyImpl</class>
         <class>org.eclipse.kapua.service.scheduler.trigger.fired.quartz.FiredTriggerImpl</class>
         <class>org.eclipse.kapua.commons.configuration.ServiceConfigImpl</class>
 

--- a/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/changelog-scheduler-2.1.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/changelog-scheduler-2.1.0.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-2.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="trigger_properties-description.xml"/>
+    <include relativeToChangelogFile="true" file="trigger_definition_properties-description.xml"/>
+
+</databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/changelog-scheduler-2.1.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/changelog-scheduler-2.1.0.xml
@@ -16,9 +16,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-job-2.1.0.xml">
+        logicalFilePath="KapuaDB/changelog-scheduler-2.1.0.xml">
 
     <include relativeToChangelogFile="true" file="trigger_properties-description.xml"/>
+    <include relativeToChangelogFile="true" file="trigger_definition-nullable_processor.xml"/>
     <include relativeToChangelogFile="true" file="trigger_definition_properties-description.xml"/>
 
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/trigger_definition-nullable_processor.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/trigger_definition-nullable_processor.xml
@@ -21,9 +21,7 @@
 
     <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
-    <changeSet id="changelog-trigger_properties-2.1.0_addDescription" author="eurotech">
-        <addColumn tableName="schdl_trigger_properties">
-            <column name="description" type="text"/>
-        </addColumn>
+    <changeSet id="changelog-trigger_definition-2.1.0-nullable_processor_name" author="eurotech">
+        <dropNotNullConstraint tableName="schdl_trigger_definition" columnName="processor_name" columnDataType="varchar(255)"/>
     </changeSet>
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/trigger_definition_properties-description.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/trigger_definition_properties-description.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+        logicalFilePath="KapuaDB/changelog-job-2.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-trigger_definition_properties-2.1.0_addDescription" author="eurotech">
+        <addColumn tableName="schdl_trigger_definition_properties">
+            <column name="description" type="text"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/trigger_definition_properties-description.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/trigger_definition_properties-description.xml
@@ -17,7 +17,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
 
-        logicalFilePath="KapuaDB/changelog-job-2.1.0.xml">
+        logicalFilePath="KapuaDB/changelog-scheduler-2.1.0.xml">
 
     <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 

--- a/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/trigger_properties-description.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/2.1.0/trigger_properties-description.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+        logicalFilePath="KapuaDB/changelog-job-2.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-trigger_properties-2.1.0_addDescription" author="eurotech">
+        <addColumn tableName="schdl_trigger_properties">
+            <column name="description" type="text"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.xml
@@ -21,5 +21,6 @@
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-scheduler-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-scheduler-1.2.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.5.0/changelog-scheduler-1.5.0.xml"/>
+    <include relativeToChangelogFile="true" file="./2.1.0/changelog-scheduler-2.1.0.xml"/>
 
 </databaseChangeLog>

--- a/service/scheduler/test/src/test/java/org/eclipse/kapua/service/scheduler/test/SchedulerLocatorConfiguration.java
+++ b/service/scheduler/test/src/test/java/org/eclipse/kapua/service/scheduler/test/SchedulerLocatorConfiguration.java
@@ -61,6 +61,7 @@ import org.eclipse.kapua.service.scheduler.trigger.definition.quartz.TriggerDefi
 import org.eclipse.kapua.service.scheduler.trigger.quartz.TriggerFactoryImpl;
 import org.eclipse.kapua.service.scheduler.trigger.quartz.TriggerImplJpaRepository;
 import org.eclipse.kapua.service.scheduler.trigger.quartz.TriggerServiceImpl;
+import org.eclipse.kapua.storage.TxManager;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
@@ -126,13 +127,14 @@ public class SchedulerLocatorConfiguration {
                 final JobImplJpaRepository jobRepository = new JobImplJpaRepository(jpaRepoConfig);
                 final TriggerImplJpaRepository triggerRepository = new TriggerImplJpaRepository(jpaRepoConfig);
 
+                final TxManager schedulerTxManager = new KapuaJpaTxManagerFactory(maxInsertAttempts).create("kapua-scheduler");
                 final TriggerDefinitionFactoryImpl triggerDefinitionFactory = new TriggerDefinitionFactoryImpl();
                 final TriggerDefinitionImplJpaRepository triggerDefinitionRepository = new TriggerDefinitionImplJpaRepository(jpaRepoConfig);
                 final TriggerFactoryImpl triggerFactory = new TriggerFactoryImpl();
                 final TriggerServiceImpl triggerService = new TriggerServiceImpl(
                         mockedAuthorization,
                         permissionFactory,
-                        new KapuaJpaTxManagerFactory(maxInsertAttempts).create("kapua-scheduler"),
+                        schedulerTxManager,
                         triggerRepository,
                         triggerFactory,
                         triggerDefinitionRepository,
@@ -152,7 +154,7 @@ public class SchedulerLocatorConfiguration {
                 bind(TriggerDefinitionService.class).toInstance(new TriggerDefinitionServiceImpl(
                         mockedAuthorization,
                         permissionFactory,
-                        new KapuaJpaTxManagerFactory(maxInsertAttempts).create("kapua-scheduler"),
+                        schedulerTxManager,
                         triggerDefinitionRepository,
                         triggerDefinitionFactory));
                 bind(TriggerDefinitionFactory.class).toInstance(triggerDefinitionFactory);


### PR DESCRIPTION
This PR adds a new `description` attribute to TriggerProperty that contains info about the TriggerPropetty

**Related Issue**
_None_

**Description of the solution adopted**
Added the new field and introduced TriggerDefinition.

View in the Console GWT:

![Screenshot 2024-11-15 at 11 37 16](https://github.com/user-attachments/assets/59717277-01d7-4d96-b6f7-dc7ee2223e87)
![Screenshot 2024-11-15 at 11 37 30](https://github.com/user-attachments/assets/8ed15172-6612-4d30-a5ef-b5a20569bc34)
![Screenshot 2024-11-15 at 11 37 40](https://github.com/user-attachments/assets/7cd1ead3-e930-40bd-8a75-c0bd06490cd6)


**Screenshots**
_None_

**Any side note on the changes made**
_None_