### PR TITLE
 🐛 [checkstyle] Update checkstyle to dynamically handle copyright years

### DIFF
--- a/build-tools/src/main/resources/checkstyle/kapua.xml
+++ b/build-tools/src/main/resources/checkstyle/kapua.xml
@@ -80,7 +80,7 @@
 
     <module name="RegexpHeader">
         <property name="header"
-            value="^/\*{79}$\n^ \* Copyright \(c\) (|\d{4}, )2022 (.*) and others\.?$\n^ \*$\n^ \* This program and the accompanying materials are made$\n^ \* available under the terms of the Eclipse Public License 2.0$\n^ \* which is available at https://www.eclipse.org/legal/epl-2.0/$\n^ \*$\n^ \* SPDX-License-Identifier: EPL-2.0$\n^ \*$\n^ \* Contributors:$\n^ \*     (.*)(| - .*)$\n^ \*{79}/\n^package" />
+            value="^/\*{79}$\n^ \* Copyright \(c\) (|\d{4}, )\d{4} (.*) and others\.?$\n^ \*$\n^ \* This program and the accompanying materials are made$\n^ \* available under the terms of the Eclipse Public License 2.0$\n^ \* which is available at https://www.eclipse.org/legal/epl-2.0/$\n^ \*$\n^ \* SPDX-License-Identifier: EPL-2.0$\n^ \*$\n^ \* Contributors:$\n^ \*     (.*)(| - .*)$\n^ \*{79}/\n^package" />
         <property name="charset" value="UTF-8" />
         <property name="multiLines" value="11" />
         <property name="fileExtensions" value="java" />
@@ -88,7 +88,7 @@
 
     <module name="RegexpHeader">
         <property name="header"
-            value="^&lt;\?xml.*&gt;$\n^&lt;!--$\n^    Copyright \(c\) (|\d{4}, )2022 (.*) and others\.?$\n^$\n^    This program and the accompanying materials are made$\n^    available under the terms of the Eclipse Public License 2\.0$\n^    which is available at https\:\/\/www.eclipse.org/legal/epl-2.0/$\n^$\n^    SPDX-License-Identifier: EPL-2.0$\n^$\n^    Contributors\:$\n^        (.*)(| - .*)$\n^ ?--&gt;$" />
+            value="^&lt;\?xml.*&gt;$\n^&lt;!--$\n^    Copyright \(c\) (|\d{4}, )\d{4} (.*) and others\.?$\n^$\n^    This program and the accompanying materials are made$\n^    available under the terms of the Eclipse Public License 2\.0$\n^    which is available at https\:\/\/www.eclipse.org/legal/epl-2.0/$\n^$\n^    SPDX-License-Identifier: EPL-2.0$\n^$\n^    Contributors\:$\n^        (.*)(| - .*)$\n^ ?--&gt;$" />
         <property name="charset" value="UTF-8" />
         <property name="multiLines" value="12" />
         <property name="fileExtensions" value="xml" />

--- a/dev-tools/header/update_year_header.sh
+++ b/dev-tools/header/update_year_header.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Check for the correct number of arguments
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <path_to_directory>"
+    exit 1
+fi
+
+# Set variables from arguments
+root="$1"
+currentYear=$(date +%Y)
+
+# Initialize a counter for changed files
+changedFiles=0
+
+# Loop through all .java files in the specified directory recursively
+for file in $(find "$root" -type f -name "*.java"); do
+    fileChanged=false
+
+    # Create a temporary file for modified content
+    tempFile="${file}.tmp"
+
+    # Capture the first line and the second line
+    line1=$(head -n 1 "$file")  # First line
+    line2=$(head -2 "$file" | tail -n 1)  # Second line
+
+    {
+        # Check for the second header pattern with two years (e.g., "2016, 2022")
+        if [[ "$line2" =~ Copyright\ \(c\)\ ([0-9]{4}),\ ([0-9]{4})\ .+\ and\ others ]]; then
+            # Replace the last year with the current year
+            line2=$(echo "$line2" | sed -E 's/([0-9]{4}), ([0-9]{4})/\1, '"$currentYear"'/')
+            fileChanged=true
+        # Check for the first header pattern with a single year (e.g., "2016")
+        elif [[ "$line2" =~ Copyright\ \(c\)\ ([0-9]{4})\ .+\ and\ others ]]; then
+            # Append the current year to the existing year
+            line2=$(echo "$line2" | sed -E "s/([0-9]{4})/\1, $currentYear/")
+            fileChanged=true
+        fi
+
+        # Write the first line (unchanged) to the temporary file
+        echo "$line1" > "$tempFile"
+        # Write the modified second line
+        echo "$line2" >> "$tempFile"
+
+        # Write the rest of the file unchanged, starting from the third line
+        tail -n +3 "$file" >> "$tempFile"
+    }
+
+    # If the file was changed, replace the original file
+    if [ "$fileChanged" = true ]; then
+        mv "$tempFile" "$file"
+        echo "File changed: $file"
+        ((changedFiles++))
+    else
+        rm "$tempFile"
+    fi
+done
+
+# Print the total number of changed files
+echo "Total files changed: $changedFiles"


### PR DESCRIPTION
### Description:
This PR modifies the checkstyle for the copyright header to no longer enforce the year `2022`. The checkstyle has been updated to dynamically handle the copyright years by either appending the current year to a single year or replacing the second year in a two-year range. 

Additionally, a script has been provided to automate the process of updating the copyright years across multiple files. The script:
- Appends the current year if there is a single year in the header.
- Replaces the second year in a two-year range with the current year.

### Example:
1. **Before:**
    ``` 
     * Copyright (c) 2016 Eurotech and/or its affiliates and others
    ```

    **After** (assuming the current year is 2024):
    ```java
    * Copyright (c) 2016, 2024 Eurotech and/or its affiliates and others
    ```


2. **Before**:
    ```
     * Copyright (c) 2019 Eurotech and/or its affiliates and others
    ```
    **After** (assuming the current year is 2024):
    ```
     * Copyright (c) 2019, 2024 Eurotech and/or its affiliates and others
     ```



### Script
Below is the script used to apply these changes:
```bash
#!/bin/bash

# Check for the correct number of arguments
if [ "$#" -ne 1 ]; then
    echo "Usage: $0 <path_to_directory>"
    exit 1
fi

# Set variables from arguments
root="$1"
currentYear=$(date +%Y)  # Get the current year

# Initialize a counter for changed files
changedFiles=0

# Loop through all .java files in the specified directory recursively
for file in $(find "$root" -type f -name "*.java"); do
    fileChanged=false

    # Create a temporary file for modified content
    tempFile="${file}.tmp"

    # Capture the first line and the second line
    line1=$(head -n 1 "$file")  # First line
    line2=$(head -2 "$file" | tail -n 1)  # Second line

    {
        # Check for the second header pattern with two years (e.g., "2016, 2022")
        if [[ "$line2" =~ Copyright\ \(c\)\ ([0-9]{4}),\ ([0-9]{4})\ .+\ and\ others ]]; then
            # Replace the last year with the current year
            line2=$(echo "$line2" | sed -E 's/([0-9]{4}), ([0-9]{4})/\1, '"$currentYear"'/')
            fileChanged=true
        # Check for the first header pattern with a single year (e.g., "2016")
        elif [[ "$line2" =~ Copyright\ \(c\)\ ([0-9]{4})\ .+\ and\ others ]]; then
            # Append the current year to the existing year
            line2=$(echo "$line2" | sed -E "s/([0-9]{4})/\1, $currentYear/")
            fileChanged=true
        fi

        # Write the first line (unchanged) to the temporary file
        echo "$line1" > "$tempFile"
        # Write the modified second line
        echo "$line2" >> "$tempFile"

        # Write the rest of the file unchanged, starting from the third line
        tail -n +3 "$file" >> "$tempFile"
    }

    # If the file was changed, replace the original file
    if [ "$fileChanged" = true ]; then
        mv "$tempFile" "$file"
        echo "File changed: $file"
        ((changedFiles++))
    else
        rm "$tempFile"
    fi
done

# Print the total number of changed files
echo "Total files changed: $changedFiles"
```

This script ensures that the copyright header is updated with the current year, either by appending it or replacing the second year in a two-year range, based on the existing header format.

### Note
I did not set a dynamic current-year variable in the checkstyle configuration, as checkstyle does not support runtime variables in its configuration files. Since the RegexpHeader module only allows static regular expressions, setting the current year dynamically within the configuration file is not possible. Consequently, the header pattern must be updated manually each year if set to a fixed value.
