### PR TITLE
🐛 [test] Fix GuiceLocator Instantiation Errors in `MfaAuthenticatorServiceLocatorTest`

### DIFF
--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -25,6 +25,11 @@
     <artifactId>kapua-security-shiro</artifactId>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-server</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Implemented service interfaces -->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/TestModule.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/TestModule.java
@@ -13,13 +13,12 @@
 package org.eclipse.kapua.service.authentication;
 
 import java.util.Collections;
-
 import javax.inject.Named;
 
+import org.apache.activemq.artemis.spi.core.security.jaas.UserPrincipal;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
 import org.eclipse.kapua.commons.util.xml.JAXBContextProviderImpl;
-
 import com.google.inject.Provides;
 
 public class TestModule extends AbstractKapuaModule {
@@ -27,6 +26,7 @@ public class TestModule extends AbstractKapuaModule {
     @Override
     protected void configureModule() {
         bind(JAXBContextProvider.class).toInstance(new JAXBContextProviderImpl(Collections.emptySet()));
+        bind(UserPrincipal.class).toInstance(new UserPrincipal(""));
     }
 
     @Provides


### PR DESCRIPTION
This PR addresses an issue in the `MfaAuthenticatorServiceLocatorTest` where Guice was unable to locate the `org.apache.activemq.artemis.spi.core.security.jaas.UserPrincipal` class. The fix ensures that the necessary dependencies are correctly resolved, allowing the test to run successfully.