### PR TITLE
⬆️ [Dependencies] `com.google.protobuf:protobuf-java` to `3.25.5` to fix `CVE-2024-7254`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <owasp-encoder.version>1.2.3</owasp-encoder.version>
         <opencsv.version>3.7</opencsv.version>
         <paho.version>1.2.1</paho.version>
-        <protobuf.version>3.23.2</protobuf.version>
+        <protobuf.version>3.25.5</protobuf.version>
         <qpid-jms-client.version>1.7.0</qpid-jms-client.version>
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
         <reflections.version>0.10.2</reflections.version>


### PR DESCRIPTION
### Overview
This pull request addresses the vulnerability identified in CVE-2024-7254 related to the `com.google.protobuf:protobuf-java` library. This library is a language-neutral, platform-neutral, extensible mechanism for serializing structured data developed by Google.

### Details
The affected versions of `com.google.protobuf:protobuf-java` are vulnerable to a stack-based buffer overflow when parsing nested groups or series of `SGROUP` tags as unknown fields. This vulnerability can lead to Denial of Service (DoS) attacks, where an attacker can exploit the flaw by sending malicious Protocol Buffer data, potentially causing infinite recursion and making the system inaccessible to legitimate users.

### Remediation
To remediate this vulnerability, we could upgraded the `com.google.protobuf:protobuf-java` library to version `3.25.5`, `4.27.5`, `4.28.2`, or higher. This upgrade addresses the vulnerability and enhances the stability of our application.

---

This PR ensures that our application remains secure and resilient against potential DoS attacks stemming from this vulnerability. Please review and merge at your earliest convenience.
