### PR TITLE
:bug: [Scheduler] Fixed exception message when Trigger schedule is invalid

### DIFF
--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -219,7 +219,7 @@ Feature: Trigger service tests
     And A regular trigger creator with the name "schedule0" is created
     And The trigger is set to start on "12-12-2020" at "11:00"
     And The trigger is set to end on "12-12-2020" at "10:00"
-    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with startsOn 12/12/20, 11:00 AM, endsOn 12/12/20, 10:00 AM will never fire according to the current date"
+    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with given startsOn and endsOn will never fire according to the current date"
     And I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -235,7 +235,7 @@ Feature: Trigger service tests
     And A regular trigger creator with the name "schedule0" is created
     And The trigger is set to start on "12-12-2020" at "10:00"
     And The trigger is set to end on "12-12-2020" at "10:00"
-    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with startsOn 12/12/20, 10:00 AM, endsOn 12/12/20, 10:00 AM will never fire according to the current date"
+    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with given startsOn and endsOn will never fire according to the current date"
     And I create a new trigger from the existing creator with previously defined date properties
     And  An exception was thrown
     And I logout
@@ -474,7 +474,7 @@ Feature: Trigger service tests
     And The trigger is set to start on "12-12-2020" at "11:00"
     And The trigger is set to end on "12-12-2020" at "10:00"
     Then I set retry interval to 1
-    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with startsOn 12/12/20, 11:00 AM, endsOn 12/12/20, 10:00 AM will never fire according to the current date"
+    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with given startsOn and endsOn will never fire according to the current date"
     And I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -491,7 +491,7 @@ Feature: Trigger service tests
     And The trigger is set to start on "12-12-2020" at "10:00"
     And The trigger is set to end on "12-12-2020" at "10:00"
     Then I set retry interval to 1
-    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with startsOn 12/12/20, 10:00 AM, endsOn 12/12/20, 10:00 AM will never fire according to the current date"
+    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with given startsOn and endsOn will never fire according to the current date"
     And I create a new trigger from the existing creator with previously defined date properties
     And  An exception was thrown
     And I logout
@@ -697,7 +697,7 @@ Feature: Trigger service tests
     And The trigger is set to start on "12-12-2020" at "12:00"
     And The trigger is set to end on "10-12-2020" at "10:00"
     Then I set cron expression to "0 15 10 * * ?"
-    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with startsOn 12/12/20, 12:00 PM, endsOn 10/12/20, 10:00 AM will never fire according to the current date"
+    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with given startsOn and endsOn will never fire according to the current date"
     And I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout
@@ -714,7 +714,7 @@ Feature: Trigger service tests
     And The trigger is set to start on "12-12-2020" at "10:00"
     And The trigger is set to end on "12-12-2020" at "10:00"
     Then I set cron expression to "0 15 10 * * ?"
-    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with startsOn 12/12/20, 10:00 AM, endsOn 12/12/20, 10:00 AM will never fire according to the current date"
+    When I expect the exception "TriggerInvalidDatesException" with the text "Trigger with given startsOn and endsOn will never fire according to the current date"
     And I create a new trigger from the existing creator with previously defined date properties
     And  An exception was thrown
     And I logout

--- a/service/scheduler/api/pom.xml
+++ b/service/scheduler/api/pom.xml
@@ -29,6 +29,29 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-service-api</artifactId>
         </dependency>
+
+        <!-- -->
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/exception/TriggerInvalidDatesException.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/exception/TriggerInvalidDatesException.java
@@ -35,9 +35,9 @@ public class TriggerInvalidDatesException extends TriggerCannotFireException {
      * @param currentDate The current {@link Date}
      */
     public TriggerInvalidDatesException(Date startsOn, Date endsOn, Date currentDate) {
-        super(SchedulerServiceErrorCodes.TRIGGER_INVALID_DATES, null, startsOn, endsOn, currentDate);
+        super(SchedulerServiceErrorCodes.TRIGGER_INVALID_DATES, null);
 
-        this.startsOn = endsOn;
+        this.startsOn = startsOn;
         this.endsOn = endsOn;
         this.currentDate = currentDate;
     }

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/exception/TriggerInvalidSchedulingException.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/exception/TriggerInvalidSchedulingException.java
@@ -33,20 +33,20 @@ public class TriggerInvalidSchedulingException extends TriggerCannotFireExceptio
     /**
      * Constructor.
      *
-     * @param cause              The root {@link Throwable} of this {@link TriggerInvalidSchedulingException}.
-     * @param startsOn           The {@link Trigger#getStartsOn()}
-     * @param endsOn             The {@link Trigger#getEndsOn()}
-     * @param triggerDefintionId The {@link Trigger#getTriggerDefinitionId()}
-     * @param scheduling         The scheduling extracted from the {@link Trigger#getTriggerProperties()}
+     * @param cause               The root {@link Throwable} of this {@link TriggerInvalidSchedulingException}.
+     * @param startsOn            The {@link Trigger#getStartsOn()}
+     * @param endsOn              The {@link Trigger#getEndsOn()}
+     * @param triggerDefinitionId The {@link Trigger#getTriggerDefinitionId()}
+     * @param scheduling          The scheduling extracted from the {@link Trigger#getTriggerProperties()}
      * @since 1.5.0
      */
 
-    public TriggerInvalidSchedulingException(Throwable cause, Date startsOn, Date endsOn, KapuaId triggerDefintionId, String scheduling) {
-        super(SchedulerServiceErrorCodes.TRIGGER_INVALID_SCHEDULE, cause, startsOn, endsOn, triggerDefintionId, scheduling);
+    public TriggerInvalidSchedulingException(Throwable cause, Date startsOn, Date endsOn, KapuaId triggerDefinitionId, String scheduling) {
+        super(SchedulerServiceErrorCodes.TRIGGER_INVALID_SCHEDULE, cause, triggerDefinitionId, scheduling);
 
-        this.startsOn = endsOn;
+        this.startsOn = startsOn;
         this.endsOn = endsOn;
-        this.triggerDefinitionId = triggerDefintionId;
+        this.triggerDefinitionId = triggerDefinitionId;
         this.scheduling = scheduling;
     }
 

--- a/service/scheduler/api/src/main/resources/scheduler-service-error-messages.properties
+++ b/service/scheduler/api/src/main/resources/scheduler-service-error-messages.properties
@@ -11,5 +11,5 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-TRIGGER_INVALID_DATES=Trigger with startsOn {0,date,dd/MM/yy, hh:mm aaa}, endsOn {1,date,dd/MM/yy, hh:mm aaa} will never fire according to the current date {2,date,dd/MM/yy, hh:mm aaa}
-TRIGGER_INVALID_SCHEDULE=Trigger with startsOn {0,date,dd/MM/yy, hh:mm aaa}, endsOn  {1,date,dd/MM/yy, hh:mm aaa}, triggerDefinitionId {2} will never fire according to the given schedule {3}
+TRIGGER_INVALID_DATES=Trigger with given startsOn and endsOn will never fire according to the current date
+TRIGGER_INVALID_SCHEDULE=Trigger given startsOn and endsOn triggerDefinitionId '{0}' will never fire according to the given schedule '{1}'

--- a/service/scheduler/api/src/main/resources/scheduler-service-error-messages.properties
+++ b/service/scheduler/api/src/main/resources/scheduler-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2021, 2024 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -12,4 +12,4 @@
 #
 ###############################################################################
 TRIGGER_INVALID_DATES=Trigger with given startsOn and endsOn will never fire according to the current date
-TRIGGER_INVALID_SCHEDULE=Trigger given startsOn and endsOn triggerDefinitionId '{0}' will never fire according to the given schedule '{1}'
+TRIGGER_INVALID_SCHEDULE=Trigger with given startsOn and endsOn triggerDefinitionId ''{0}'' will never fire according to the given schedule ''{1}''

--- a/service/scheduler/api/src/test/java/org/eclipse/kapua/service/scheduler/exception/SchedulerServiceExceptionTest.java
+++ b/service/scheduler/api/src/test/java/org/eclipse/kapua/service/scheduler/exception/SchedulerServiceExceptionTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.exception;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.scheduler.exception.model.TestSchedulerServiceException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * {@link SchedulerServiceException}s tests.
+ *
+ * @since 2.1.0
+ */
+@Category(JUnitTests.class)
+public class SchedulerServiceExceptionTest {
+
+    private final Throwable aCause = new Throwable("This is the cause");
+
+    DateFormat dataFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+
+    private final Date startsOn = dataFormat.parse("2020/01/01 00:00:00");
+    private final Date endOn = dataFormat.parse("2025/01/01 00:00:00");
+
+    private final Date currentDate = dataFormat.parse("2024/01/01 00:00:00");
+
+    private final KapuaId aTriggerDefinitionId = KapuaId.ONE;
+    private final String aSchedule = "1 1 1 1 1 ? 2024";
+
+    public SchedulerServiceExceptionTest() throws ParseException {
+    }
+
+    @Test
+    public void testDeviceCallErrorCodesHaveMessages() {
+        for (SchedulerServiceErrorCodes errorCode : SchedulerServiceErrorCodes.values()) {
+            SchedulerServiceException schedulerServiceException = new TestSchedulerServiceException(errorCode);
+
+            Assert.assertNotEquals("SchedulerServiceErrorCodes." + errorCode + " doesn't have an error message", "Error: ", schedulerServiceException.getMessage());
+            Assert.assertNotEquals("SchedulerServiceErrorCodes." + errorCode + " doesn't have an error message", "Error: ", schedulerServiceException.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void testTriggerInvalidDatesException() {
+        String exceptionMessage = "Trigger with given startsOn and endsOn will never fire according to the current date";
+
+        TriggerInvalidDatesException triggerInvalidDatesException = new TriggerInvalidDatesException(startsOn, endOn, currentDate);
+
+        Assert.assertEquals(SchedulerServiceErrorCodes.TRIGGER_INVALID_DATES, triggerInvalidDatesException.getCode());
+        Assert.assertNull(triggerInvalidDatesException.getCause());
+        Assert.assertEquals(startsOn, triggerInvalidDatesException.getStartsOn());
+        Assert.assertEquals(endOn, triggerInvalidDatesException.getEndsOn());
+        Assert.assertEquals(currentDate, triggerInvalidDatesException.getCurrentDate());
+        Assert.assertEquals(exceptionMessage, triggerInvalidDatesException.getMessage());
+        Assert.assertEquals(exceptionMessage, triggerInvalidDatesException.getLocalizedMessage());
+    }
+
+    @Test
+    public void testTriggerInvalidSchedulingException() {
+        String exceptionMessage = "Trigger with given startsOn and endsOn triggerDefinitionId '" + aTriggerDefinitionId + "' will never fire according to the given schedule '" + aSchedule + "'";
+
+        TriggerInvalidSchedulingException triggerInvalidDatesException = new TriggerInvalidSchedulingException(aCause, startsOn, endOn, aTriggerDefinitionId, aSchedule);
+
+        Assert.assertEquals(SchedulerServiceErrorCodes.TRIGGER_INVALID_SCHEDULE, triggerInvalidDatesException.getCode());
+        Assert.assertEquals(aCause, triggerInvalidDatesException.getCause());
+        Assert.assertEquals(startsOn, triggerInvalidDatesException.getStartsOn());
+        Assert.assertEquals(endOn, triggerInvalidDatesException.getEndsOn());
+        Assert.assertEquals(aTriggerDefinitionId, triggerInvalidDatesException.getTriggerDefinitionId());
+        Assert.assertEquals(aSchedule, triggerInvalidDatesException.getScheduling());
+        Assert.assertEquals(exceptionMessage, triggerInvalidDatesException.getMessage());
+        Assert.assertEquals(exceptionMessage, triggerInvalidDatesException.getLocalizedMessage());
+    }
+}

--- a/service/scheduler/api/src/test/java/org/eclipse/kapua/service/scheduler/exception/model/TestSchedulerServiceException.java
+++ b/service/scheduler/api/src/test/java/org/eclipse/kapua/service/scheduler/exception/model/TestSchedulerServiceException.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.exception.model;
+
+import org.eclipse.kapua.service.scheduler.exception.SchedulerServiceErrorCodes;
+import org.eclipse.kapua.service.scheduler.exception.SchedulerServiceException;
+import org.eclipse.kapua.service.scheduler.exception.SchedulerServiceExceptionTest;
+
+/**
+ * {@link SchedulerServiceException} for testing.
+ *
+ * @see SchedulerServiceExceptionTest#testDeviceCallErrorCodesHaveMessages()
+ * @since 2.1.0
+ */
+public class TestSchedulerServiceException extends SchedulerServiceException {
+
+    /**
+     * Constructor.
+     *
+     * @param code The {@link SchedulerServiceErrorCodes} to test.
+     * @since 2.1.0
+     */
+    public TestSchedulerServiceException(SchedulerServiceErrorCodes code) {
+        super(code, null);
+    }
+}

--- a/service/scheduler/test/src/test/resources/features/SchedulerService.feature
+++ b/service/scheduler/test/src/test/resources/features/SchedulerService.feature
@@ -93,7 +93,7 @@ Feature: Scheduler Service
     And A regular trigger creator with the name "triggerExample" is created
     And The trigger is set to start on "10-10-2018" at "6:00"
     And The trigger is set to end on "09-10-2018" at "6:00"
-    And I expect the exception "TriggerInvalidDatesException" with the text "*"
+    And I expect the exception "TriggerInvalidDatesException" with the text "Trigger with given startsOn and endsOn will never fire according to the current date"
     Then I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
 


### PR DESCRIPTION
This PR fixes the exception messages of SchedulerServiceExceptions to not report date parameters in the message.

**Related Issue**
_None_

**Description of the solution adopted**
Changed the message for SchedulerServiceExceptions

**Screenshots**
_None_

**Any side note on the changes made**
Added test on SchedulerServiceException