### PR TITLE
🐛 [Scheduler] Fixed persistence of 'description' when creating Trigger 

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/jobTrigger.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/jobTrigger.yaml
@@ -52,6 +52,7 @@ components:
             modifiedBy: AQ
             optlock: 1
             name: cron
+            description: A trigger description
             endsOn: '2019-12-07T01:30:00+01:00'
             startsOn: '2019-12-06T12:00:00+01:00'
             triggerDefinitionId: AQ
@@ -87,6 +88,7 @@ components:
       example:
         type: triggerCreator
         name: A trigger
+        description: A trigger description
         startsOn: '2021-01-31T00:00:00.000Z'
         triggerDefinitionId: AQ
         triggerProperties:
@@ -117,6 +119,7 @@ components:
                 modifiedBy: AQ
                 optlock: 1
                 name: interval
+                description: A trigger description
                 startsOn: '2019-12-06T12:00:00+01:00'
                 triggerDefinitionId: Ag
                 triggerProperties:
@@ -138,6 +141,7 @@ components:
                 modifiedBy: AQ
                 optlock: 1
                 name: cron
+                description: A trigger description
                 endsOn: '2019-12-07T01:30:00+01:00'
                 startsOn: '2019-12-06T12:00:00+01:00'
                 triggerDefinitionId: AQ
@@ -160,6 +164,7 @@ components:
                 modifiedBy: AQ
                 optlock: 1
                 name: device_conn
+                description: A trigger description
                 startsOn: '2019-12-06T12:00:00+01:00'
                 triggerDefinitionId: Aw
                 triggerProperties:

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -152,6 +152,7 @@ public class TriggerServiceImpl implements TriggerService {
             try {
                 Trigger toBeCreated = triggerFactory.newEntity(triggerCreator.getScopeId());
                 toBeCreated.setName(triggerCreator.getName());
+                toBeCreated.setDescription(triggerCreator.getDescription());
                 toBeCreated.setStartsOn(triggerCreator.getStartsOn());
                 toBeCreated.setEndsOn(triggerCreator.getEndsOn());
                 toBeCreated.setTriggerDefinitionId(triggerCreator.getTriggerDefinitionId());

--- a/service/scheduler/test-steps/src/main/java/org/eclipse/kapua/service/scheduler/steps/JobScheduleServiceSteps.java
+++ b/service/scheduler/test-steps/src/main/java/org/eclipse/kapua/service/scheduler/steps/JobScheduleServiceSteps.java
@@ -116,6 +116,7 @@ public class JobScheduleServiceSteps extends TestBase {
         TriggerCreator triggerCreator = triggerFactory.newCreator(getCurrentScopeId());
         KapuaId triggerDefinitionId = (KapuaId) stepData.get(TRIGGER_DEFINITION_ID);
         triggerCreator.setName(schedulerName);
+        triggerCreator.setDescription("A trigger description");
         triggerCreator.setStartsOn(new Date());
         triggerCreator.setTriggerDefinitionId(triggerDefinitionId);
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
@@ -149,6 +150,7 @@ public class JobScheduleServiceSteps extends TestBase {
         KapuaId currentTriggerDefId = (KapuaId) stepData.get(TRIGGER_DEFINITION_ID);
         KapuaId jobId = (KapuaId) stepData.get("CurrentJobId");
         triggerCreator.setName(triggerName);
+        triggerCreator.setDescription("A trigger description");
         triggerCreator.setTriggerDefinitionId(currentTriggerDefId);
         triggerCreator.getTriggerProperties().add(triggerDefinitionFactory.newTriggerProperty("jobId", KAPUA_ID_CLASS_NAME, jobId.toCompactId()));
         triggerCreator.getTriggerProperties().add(triggerDefinitionFactory.newTriggerProperty("scopeId", KAPUA_ID_CLASS_NAME, getCurrentScopeId().toCompactId()));
@@ -170,6 +172,7 @@ public class JobScheduleServiceSteps extends TestBase {
         TriggerCreator triggerCreator = triggerFactory.newCreator(getCurrentScopeId());
         KapuaId currentTriggerDefId = (KapuaId) stepData.get(TRIGGER_DEFINITION_ID);
         triggerCreator.setName(triggerName);
+        triggerCreator.setDescription("A trigger description");
         triggerCreator.setTriggerDefinitionId(currentTriggerDefId);
         List<TriggerProperty> tmpPropList = new ArrayList<>();
         for (CucTriggerProperty prop : list) {
@@ -201,6 +204,7 @@ public class JobScheduleServiceSteps extends TestBase {
         try {
             Trigger trigger = (Trigger) stepData.get(TRIGGER);
             trigger.setName(newTriggerName);
+            trigger.setDescription("A trigger updated description");
             primeException();
             Trigger updatedTrigger = triggerService.update(trigger);
             stepData.put(UPDATED_TRIGGER, updatedTrigger);


### PR DESCRIPTION
This PR fixes the handling of `description` property of `TriggerCreator`

**Related Issue**
_None_

**Description of the solution adopted**
Added missing passing of `description` from `TriggerCreator` to `Trigger`

**Screenshots**
_None_

**Any side note on the changes made**
Updated test and OpenAPI examples