### PR TITLE
:bug: [Job] Fixed JobStepDefinitionProperty.description for Bundle Start and Bundle Stop

### DIFF
--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStartJobStepDefinition.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStartJobStepDefinition.java
@@ -42,7 +42,7 @@ public class DeviceBundleStartJobStepDefinition extends JobStepDefinitionRecord 
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DeviceBundlePropertyKeys.BUNDLE_ID,
-                                "Numeric identifier of the bundle installed in the device",
+                                "Numeric identifier of the bundle to be started. The identifier can be found in the Bundles view within the Device Overview page or can be retrieved via the REST API",
                                 String.class.getName(),
                                 null,
                                 null,

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStopJobStepDefinition.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStopJobStepDefinition.java
@@ -42,7 +42,7 @@ public class DeviceBundleStopJobStepDefinition extends JobStepDefinitionRecord {
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DeviceBundlePropertyKeys.BUNDLE_ID,
-                                "Numeric identifier of the bundle installed in the device",
+                                "Numeric identifier of the bundle to be started. The identifier can be found in the Bundles view within the Device Overview page or can be retrieved via the REST API",
                                 String.class.getName(),
                                 null,
                                 null,


### PR DESCRIPTION
Another fix to the `description` of the JobStepDefinitionProperty of Bundle Start and Bundle Stop

**Related Issue**
_None_

**Description of the solution adopted**
Changed the description

**Screenshots**
_None_

**Any side note on the changes made**
_None_