### PR TITLE
:sparkles: [Job Engine] Added JobDataCleanupJobEndCallback to delete JobInstanceData after JobExecution has ended

### DIFF
--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/overrides/callback/JobDataCleanupJobEndCallback.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/overrides/callback/JobDataCleanupJobEndCallback.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.job.engine.jbatch.overrides.callback;
+
+import com.ibm.jbatch.container.callback.JobEndCallback;
+import com.ibm.jbatch.container.servicesmanager.ServicesManager;
+import com.ibm.jbatch.container.servicesmanager.ServicesManagerImpl;
+import org.eclipse.kapua.job.engine.jbatch.driver.JbatchDriver;
+import org.eclipse.kapua.job.engine.jbatch.persistence.JPAPersistenceManagerImpl;
+import org.eclipse.kapua.job.engine.jbatch.persistence.jpa.JpaJobInstanceData;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.execution.JobExecution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link JpaJobInstanceData} cleanup {@link JobEndCallback}.
+ * <p>
+ * This {@link JobEndCallback} removes {@link JpaJobInstanceData} after the {@link JobExecution} ends it execution.
+ * This is done to avoid that {@link Job}s that run a lot of times (thousands or more) fill up the {@link JpaJobInstanceData}
+ * table making {@link JbatchDriver#isRunningJob(KapuaId, KapuaId)} tanking a lot of time to execute.
+ * <p>
+ * {@link JpaJobInstanceData} aren't required nor useful once the {@link JobExecution} ends its processing so they can be safely deleted.
+ *
+ * @since 2.1.0
+ */
+public class JobDataCleanupJobEndCallback implements JobEndCallback {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JobDataCleanupJobEndCallback.class);
+
+    private final JPAPersistenceManagerImpl persistenceService;
+    private long jobExecutionId;
+
+    /**
+     * Constructor.
+     *
+     * @since 2.1.0
+     */
+    public JobDataCleanupJobEndCallback() {
+       ServicesManager servicesManager = ServicesManagerImpl.getInstance();
+       persistenceService = (JPAPersistenceManagerImpl) servicesManager.getPersistenceManagerService();
+    }
+
+    @Override
+    public void setExecutionId(long jobExecutionId) {
+        this.jobExecutionId = jobExecutionId;
+    }
+
+    @Override
+    public void done(long jobExecutionId) {
+        try {
+            long jobInstanceId = persistenceService.getJobInstanceIdByExecutionId(jobExecutionId);
+
+            LOG.info("Deleting JobInstanceData {} after JobExecution {} has completed...", jobInstanceId, jobExecutionId);
+            persistenceService.deleteJobInstanceData(jobInstanceId);
+            LOG.info("Deleting JobInstanceData {} after JobExecution {} has completed... DONE!", jobInstanceId, jobExecutionId);
+        }
+        catch (Exception e) {
+            LOG.error("Deleting JobInstanceData for JobExecution {} has completed... ERROR! This will leave JobInstanceData in the DB until the Job gets deleted", jobExecutionId, e);
+        }
+    }
+}

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/overrides/callback/KapuaJobEndCallbackManagerImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/overrides/callback/KapuaJobEndCallbackManagerImpl.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.job.engine.jbatch.overrides.callback;
+
+import com.ibm.jbatch.container.callback.IJobEndCallbackService;
+import com.ibm.jbatch.container.callback.JobEndCallback;
+import com.ibm.jbatch.container.callback.JobEndCallbackManagerImpl;
+
+/**
+ * Kapua {@link IJobEndCallbackService} which extends default {@link JobEndCallbackManagerImpl} to register custom {@link JobEndCallback}s
+ *
+ * @since 2.1.0
+ */
+public class KapuaJobEndCallbackManagerImpl extends JobEndCallbackManagerImpl implements IJobEndCallbackService {
+
+    /**
+     * Constructor
+     *
+     * @since 2.1.0
+     */
+    public KapuaJobEndCallbackManagerImpl() {
+        super();
+
+        // Required to delete JobInstanceData after JobExecution ends
+        registerJobEndCallback(new JobDataCleanupJobEndCallback());
+    }
+}

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/JPAPersistenceManagerImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/JPAPersistenceManagerImpl.java
@@ -79,14 +79,14 @@ import java.util.stream.Collectors;
  * <pre>
  *     JobInstanceData (aka: JobInstace)
  *     |
- *     |-- as one --- JobStatus
- *     |-- as many -- ExecutionInstanceData (aka: JobExecution)
+ *     |-- has one --- JobStatus
+ *     |-- has many -- ExecutionInstanceData (aka: JobExecution)
  *                    |
- *                    |-- as many -- StepExecutionInstanceData (aka: JobStepExecution)
+ *                    |-- has many -- StepExecutionInstanceData (aka: JobStepExecution)
  *                    |              |
- *                    |              |-- as one --- StepStatus
+ *                    |              |-- has one --- StepStatus
  *                    |
- *                    |-- as many -- CheckpointData
+ *                    |-- has many -- CheckpointData
  * </pre>
  *
  * @since 1.2.0
@@ -218,6 +218,20 @@ public class JPAPersistenceManagerImpl implements IPersistenceManagerService {
         //        }
 
         return "NOTSET";
+    }
+
+    /**
+     * Deletes {@link JpaJobInstanceData} by its {@link JpaJobInstanceData#getId()}.
+     *
+     * @param jobInstanceId The {@link JpaJobInstanceData#getId()} to delete.
+     * @since 2.1.0
+     */
+    public void deleteJobInstanceData(long jobInstanceId) {
+        try {
+            txManager.execute(tx -> jobInstanceDataRepository.deleteById(tx, jobInstanceId));
+        } catch (Exception e) {
+            throw new PersistenceException(e);
+        }
     }
 
     /**

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaJobInstanceData.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaJobInstanceData.java
@@ -45,7 +45,10 @@ import java.io.Serializable;
         @NamedQuery(name = "JobInstanceData.countByNameTagApp",
                 query = "SELECT COUNT(jid) FROM JobInstanceData jid WHERE jid.name = :name AND jid.appTag = :appTag"),
         @NamedQuery(name = "JobInstanceData.deleteByName",
-                query = "DELETE FROM JobInstanceData jid WHERE jid.name = :name")
+                query = "DELETE FROM JobInstanceData jid WHERE jid.name = :name"),
+        @NamedQuery(name = "JobInstanceData.deleteById",
+                query = "DELETE FROM JobInstanceData jid WHERE jid.id = :id")
+
 })
 public class JpaJobInstanceData implements Serializable {
 

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaJobInstanceDataRepository.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaJobInstanceDataRepository.java
@@ -19,8 +19,6 @@ import java.util.List;
 public interface JpaJobInstanceDataRepository {
     JpaJobInstanceData create(TxContext tx, String name, String appTag, String jobXml);
 
-    int deleteByName(TxContext tx, String jobName);
-
     JpaJobInstanceData find(TxContext tx, long id);
 
     Integer getJobInstanceCount(TxContext tx, String jobName, String appTag);
@@ -28,4 +26,15 @@ public interface JpaJobInstanceDataRepository {
     List<Long> getJobInstanceIds(TxContext tx, String jobName, String appTag, Integer offset, Integer limit);
 
     List<JpaJobInstanceData> getExternalJobInstanceData(TxContext tx);
+
+    int deleteByName(TxContext tx, String jobName);
+
+    /**
+     * Deletes {@link JpaJobInstanceData} by its {@link JpaJobInstanceData#getId()}.
+     *
+     * @param tx The {@link TxContext}
+     * @param jobInstanceId The {@link JpaJobInstanceData#getId()} to delete.
+     * @since 2.1.0
+     */
+    int deleteById(TxContext tx, long jobInstanceId);
 }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaJobInstanceDataRepositoryImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaJobInstanceDataRepositoryImpl.java
@@ -39,15 +39,6 @@ public class JpaJobInstanceDataRepositoryImpl implements JpaJobInstanceDataRepos
     }
 
     @Override
-    public int deleteByName(TxContext tx, String jobName) {
-        final EntityManager em = JpaAwareTxContext.extractEntityManager(tx);
-
-        TypedQuery<Integer> deleteByNameQuery = em.createNamedQuery("JobInstanceData.deleteByName", Integer.class);
-        deleteByNameQuery.setParameter("name", jobName);
-        return deleteByNameQuery.executeUpdate();
-    }
-
-    @Override
     public JpaJobInstanceData find(TxContext tx, long id) {
         final EntityManager em = JpaAwareTxContext.extractEntityManager(tx);
         return em.find(JpaJobInstanceData.class, id);
@@ -101,5 +92,23 @@ public class JpaJobInstanceDataRepositoryImpl implements JpaJobInstanceDataRepos
         selectQuery.setParameter("name", PartitionedStepBuilder.JOB_ID_SEPARATOR + "%");
         final List<JpaJobInstanceData> queryResult = selectQuery.getResultList();
         return queryResult;
+    }
+
+    @Override
+    public int deleteByName(TxContext tx, String jobName) {
+        final EntityManager em = JpaAwareTxContext.extractEntityManager(tx);
+
+        TypedQuery<Integer> deleteByNameQuery = em.createNamedQuery("JobInstanceData.deleteByName", Integer.class);
+        deleteByNameQuery.setParameter("name", jobName);
+        return deleteByNameQuery.executeUpdate();
+    }
+
+    @Override
+    public int deleteById(TxContext tx, long jobInstanceId) {
+        final EntityManager em = JpaAwareTxContext.extractEntityManager(tx);
+
+        TypedQuery<Integer> deleteByNameQuery = em.createNamedQuery("JobInstanceData.deleteById", Integer.class);
+        deleteByNameQuery.setParameter("id", jobInstanceId);
+        return deleteByNameQuery.executeUpdate();
     }
 }

--- a/job-engine/jbatch/src/main/resources/META-INF/services/batch-services.properties
+++ b/job-engine/jbatch/src/main/resources/META-INF/services/batch-services.properties
@@ -1,6 +1,6 @@
 J2SE_MODE=true
 JOBXML_LOADER_SERVICE=com.ibm.jbatch.container.services.impl.DirectoryJobXMLLoaderServiceImpl
 CONTAINER_ARTIFACT_FACTORY_SERVICE=org.eclipse.kapua.job.engine.jbatch.KapuaDelegatingBatchArtifactFactoryImpl
-#  com.ibm.jbatch.container.services.impl.DelegatingBatchArtifactFactoryImpl
+CALLBACK_SERVICE=org.eclipse.kapua.job.engine.jbatch.overrides.callback.KapuaJobEndCallbackManagerImpl
 BATCH_THREADPOOL_SERVICE=com.ibm.jbatch.container.services.impl.GrowableThreadPoolServiceImpl
 PERSISTENCE_MANAGEMENT_SERVICE=org.eclipse.kapua.job.engine.jbatch.persistence.JPAPersistenceManagerImpl

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
@@ -26,484 +26,484 @@ Feature: JobEngineService stop job tests with online device
     # * Stopping a job with one Target and multiple Steps *
     # *****************************************************
 
-  Scenario: Stop job with multiple Bundle Start and Package Install steps and one target
-  Create a new job and set a connected KuraMock device as the job target.
-  Add Bundle Start and Package Install steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 1, and the status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I start the Kura Mock
-    And Device is connected within 10 seconds
-    And Device status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock device after 5 seconds
-    And Bundles are requested
-    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add target to job
-    And I search for the job targets in database
-    And I count 1
-    And I search for step definition with the name
-      | Bundle Start               |
-      | Package Download / Install |
-      | Package Uninstall          |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
-      | bundleId                | java.lang.String                                                                                   | 34                                                                                                                                                                                                                                                               |
-      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 3 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    When Bundles are requested
-    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
-    And Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop job with multiple Bundle Stop and Package Uninstall steps and one target
-  Create a new job and set a connected KuraMock device as the job target.
-  Add two Bundle Stop and Package Uninstall steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 2 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 2, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I start the Kura Mock
-    And Device is connected within 10 seconds
-    And Device status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock device after 5 seconds
-    And Bundles are requested
-    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add target to job
-    And I search for the job targets in database
-    And I count 1
-    And I search for step definition with the name
-      | Bundle Stop                |
-      | Package Uninstall          |
-      | Package Download / Install |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
-      | bundleId                | java.lang.String                                                                                   | 77                                                                                                                                                                                                                                                               |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
-      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 3 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    When Bundles are requested
-    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
-    And Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop job with multiple Command Execution and Package Install steps and one target
-  Create a new job and set a connected KuraMock device as the job target.
-  Add two Command Execution and Package Install steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 1, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I start the Kura Mock
-    And Device is connected within 10 seconds
-    And Device status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock device after 5 seconds
-    And Command "pwd" is executed
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add target to job
-    And I search for the job targets in database
-    And I count 1
-    And I search for step definition with the name
-      | Command Execution          |
-      | Package Download / Install |
-      | Package Uninstall          |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
-      | commandInput            | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                             | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
-      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 3 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    And Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop job with multiple Configuration Put and Package Uninstall steps and one target
-  Create a new job and set a connected KuraMock device as the job target.
-  Add two Configuration Put and Package Uninstall steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 1, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I start the Kura Mock
-    And Device is connected within 10 seconds
-    And Device status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock device after 5 seconds
-    And Configuration is requested
-    Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
-    And Packages are requested and 1 packages is received
-    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add target to job
-    And I search for the job targets in database
-    And I count 1
-    And I search for step definition with the name
-      | Configuration Put          |
-      | Package Uninstall          |
-      | Package Download / Install |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | configuration           | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration                      | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 3 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    Then Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop job with multiple Asset Write and Package Install steps and one target
-  Create a new job and set a connected KuraMock device as the job target.
-  Add two Asset Write and Package Install steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 1, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I start the Kura Mock
-    And Device is connected within 10 seconds
-    And Device status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock device after 5 seconds
-    When Device assets are requested
-    Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add target to job
-    And I search for the job targets in database
-    And I count 1
-    And I search for step definition with the name
-      | Asset Write                |
-      | Package Download / Install |
-      | Package Uninstall          |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
-      | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets>                        |
-      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 3 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    When Device assets are requested
-    Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
-    And Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-    # *****************************************************
-    # * Stopping a job with multiple Targets and one Step *
-    # *****************************************************
-
-  Scenario: Stop job with multiple targets and Bundle Start and Package Install steps
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add Bundle Start and Package Install steps to the created job. Start the job. Before
-  job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 0 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 0, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I add 2 devices to Kura Mock
-    And Devices are connected within 10 seconds
-    And I wait 1 second
-    And Devices status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock devices after 5 seconds
-    And Bundles are requested
-    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
-    And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for the job targets in database
-    And I count 2
-    And I search for step definition with the name
-      | Bundle Start               |
-      | Package Download / Install |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
-      | bundleId               | java.lang.String                                                                                 | 34                                                                                                                                                                                                                                                               |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-    And I create multiple new JobSteps from the existing creators
-    And I count the JobSteps and I find 2 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    When Bundles are requested
-    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
-    And Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop job with multiple targets and Bundle Stop and Package Uninstall steps
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add Bundle Stop and Package Uninstall steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 0 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 0, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I add 2 devices to Kura Mock
-    And Devices are connected within 10 seconds
-    And I wait 1 second
-    And Devices status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock devices after 5 seconds
-    And Bundles are requested
-    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for the job targets in database
-    And I count 2
-    And I search for step definition with the name
-      | Bundle Stop       |
-      | Package Uninstall |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                  |
-      | bundleId                | java.lang.String                                                                                   | 77                                                                                                                                                                                                     |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 2 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    When Bundles are requested
-    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
-    And Packages are requested and 0 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop job with multiple targets and Command Execution and Package Install steps
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add Command Execution and Package Install steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 0 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 0, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I add 2 devices to Kura Mock
-    And Devices are connected within 10 seconds
-    And I wait 1 second
-    And Devices status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock devices after 5 seconds
-    And Command "pwd" is executed
-    And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for the job targets in database
-    And I count 2
-    And I search for step definition with the name
-      | Command Execution          |
-      | Package Download / Install |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
-      | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 2 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    When Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop job with multiple targets and Configuration Put and Package Uninstall steps
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add Configuration Put and Package Uninstall steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 0 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 0, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I add 2 devices to Kura Mock
-    And Devices are connected within 10 seconds
-    And I wait 1 second
-    And Devices status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock devices after 5 seconds
-    And Configuration is requested
-    Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
-    And Packages are requested and 1 packages is received
-    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for the job targets in database
-    And I count 2
-    And I search for step definition with the name
-      | Configuration Put |
-      | Package Uninstall |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | configuration           | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration                      | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 2 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    And Configuration is requested
-    Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
-    And Packages are requested and 0 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop job with multiple targets and Asset Write and Package Install steps and one target
-  Create a new job and set a connected KuraMock device as the job target.
-  Add two Asset Write and Package Install steps to the created job. Start the job.
-  Before job is finished, stop the job. When job is stopped, the executed target's
-  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
-  If job is finished step index should be 1, and job target status PROCESS_OK.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I add 2 devices to Kura Mock
-    And Devices are connected within 10 seconds
-    And I wait 1 second
-    And Devices status is "CONNECTED" within 10 seconds
-    And I select account "kapua-sys"
-    And I get the KuraMock devices after 5 seconds
-    When Device assets are requested
-    Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for the job targets in database
-    And I count 2
-    And I search for step definition with the name
-      | Asset Write                |
-      | Package Download / Install |
-    And I prepare a JobStepCreator with the name "TestStep1" and properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
-      | assets                 | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                   | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets>                        |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
-    And I create multiple new JobSteps from the existing creators
-    Then No exception was thrown
-    And I count the JobSteps and I find 2 JobStep within 30 seconds
-    And I start a job
-    And I wait for 10 milliseconds for processes to settle down
-    And I stop the job
-    And I search for the last job target in the database
-    And I confirm the step index is different than 1 and status is "PROCESS_AWAITING"
-    And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
-    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
-    When Device assets are requested
-    Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
-    And Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
+#  Scenario: Stop job with multiple Bundle Start and Package Install steps and one target
+#  Create a new job and set a connected KuraMock device as the job target.
+#  Add Bundle Start and Package Install steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 1, and the status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I start the Kura Mock
+#    And Device is connected within 10 seconds
+#    And Device status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock device after 5 seconds
+#    And Bundles are requested
+#    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
+#    And Packages are requested and 1 package is received
+#    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add target to job
+#    And I search for the job targets in database
+#    And I count 1
+#    And I search for step definition with the name
+#      | Bundle Start               |
+#      | Package Download / Install |
+#      | Package Uninstall          |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
+#      | bundleId                | java.lang.String                                                                                   | 34                                                                                                                                                                                                                                                               |
+#      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+#      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
+#      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 3 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    When Bundles are requested
+#    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
+#    And Packages are requested and 2 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#  Scenario: Stop job with multiple Bundle Stop and Package Uninstall steps and one target
+#  Create a new job and set a connected KuraMock device as the job target.
+#  Add two Bundle Stop and Package Uninstall steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 2 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 2, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I start the Kura Mock
+#    And Device is connected within 10 seconds
+#    And Device status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock device after 5 seconds
+#    And Bundles are requested
+#    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
+#    And Packages are requested and 1 package is received
+#    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add target to job
+#    And I search for the job targets in database
+#    And I count 1
+#    And I search for step definition with the name
+#      | Bundle Stop                |
+#      | Package Uninstall          |
+#      | Package Download / Install |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
+#      | bundleId                | java.lang.String                                                                                   | 77                                                                                                                                                                                                                                                               |
+#      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
+#      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+#      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 3 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    When Bundles are requested
+#    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
+#    And Packages are requested and 2 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#  Scenario: Stop job with multiple Command Execution and Package Install steps and one target
+#  Create a new job and set a connected KuraMock device as the job target.
+#  Add two Command Execution and Package Install steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 1, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I start the Kura Mock
+#    And Device is connected within 10 seconds
+#    And Device status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock device after 5 seconds
+#    And Command "pwd" is executed
+#    And Packages are requested and 1 package is received
+#    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add target to job
+#    And I search for the job targets in database
+#    And I count 1
+#    And I search for step definition with the name
+#      | Command Execution          |
+#      | Package Download / Install |
+#      | Package Uninstall          |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
+#      | commandInput            | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                             | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
+#      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+#      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
+#      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 3 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    And Packages are requested and 2 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#  Scenario: Stop job with multiple Configuration Put and Package Uninstall steps and one target
+#  Create a new job and set a connected KuraMock device as the job target.
+#  Add two Configuration Put and Package Uninstall steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 1, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I start the Kura Mock
+#    And Device is connected within 10 seconds
+#    And Device status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock device after 5 seconds
+#    And Configuration is requested
+#    Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
+#    And Packages are requested and 1 packages is received
+#    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add target to job
+#    And I search for the job targets in database
+#    And I count 1
+#    And I search for step definition with the name
+#      | Configuration Put          |
+#      | Package Uninstall          |
+#      | Package Download / Install |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+#      | configuration           | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration                      | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
+#      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+#      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+#      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 3 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    Then Packages are requested and 2 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#  Scenario: Stop job with multiple Asset Write and Package Install steps and one target
+#  Create a new job and set a connected KuraMock device as the job target.
+#  Add two Asset Write and Package Install steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 1, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I start the Kura Mock
+#    And Device is connected within 10 seconds
+#    And Device status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock device after 5 seconds
+#    When Device assets are requested
+#    Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
+#    And Packages are requested and 1 package is received
+#    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add target to job
+#    And I search for the job targets in database
+#    And I count 1
+#    And I search for step definition with the name
+#      | Asset Write                |
+#      | Package Download / Install |
+#      | Package Uninstall          |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
+#      | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets>                        |
+#      | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+#      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
+#      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 3 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    When Device assets are requested
+#    Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
+#    And Packages are requested and 2 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#    # *****************************************************
+#    # * Stopping a job with multiple Targets and one Step *
+#    # *****************************************************
+#
+#  Scenario: Stop job with multiple targets and Bundle Start and Package Install steps
+#  Create a new job and set a connected KuraMock devices as the job targets.
+#  Add Bundle Start and Package Install steps to the created job. Start the job. Before
+#  job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 0 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 0, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I add 2 devices to Kura Mock
+#    And Devices are connected within 10 seconds
+#    And I wait 1 second
+#    And Devices status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock devices after 5 seconds
+#    And Bundles are requested
+#    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
+#    And Packages are requested and 1 package is received
+#    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add targets to job
+#    And I search for the job targets in database
+#    And I count 2
+#    And I search for step definition with the name
+#      | Bundle Start               |
+#      | Package Download / Install |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
+#      | bundleId               | java.lang.String                                                                                 | 34                                                                                                                                                                                                                                                               |
+#      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+#    And I create multiple new JobSteps from the existing creators
+#    And I count the JobSteps and I find 2 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    When Bundles are requested
+#    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
+#    And Packages are requested and 2 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#  Scenario: Stop job with multiple targets and Bundle Stop and Package Uninstall steps
+#  Create a new job and set a connected KuraMock devices as the job targets.
+#  Add Bundle Stop and Package Uninstall steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 0 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 0, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I add 2 devices to Kura Mock
+#    And Devices are connected within 10 seconds
+#    And I wait 1 second
+#    And Devices status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock devices after 5 seconds
+#    And Bundles are requested
+#    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
+#    And Packages are requested and 1 package is received
+#    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add targets to job
+#    And I search for the job targets in database
+#    And I count 2
+#    And I search for step definition with the name
+#      | Bundle Stop       |
+#      | Package Uninstall |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                    | type                                                                                               | value                                                                                                                                                                                                  |
+#      | bundleId                | java.lang.String                                                                                   | 77                                                                                                                                                                                                     |
+#      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
+#      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 2 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    When Bundles are requested
+#    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
+#    And Packages are requested and 0 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#  Scenario: Stop job with multiple targets and Command Execution and Package Install steps
+#  Create a new job and set a connected KuraMock devices as the job targets.
+#  Add Command Execution and Package Install steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 0 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 0, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I add 2 devices to Kura Mock
+#    And Devices are connected within 10 seconds
+#    And I wait 1 second
+#    And Devices status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock devices after 5 seconds
+#    And Command "pwd" is executed
+#    And Packages are requested and 1 package is received
+#    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add targets to job
+#    And I search for the job targets in database
+#    And I count 2
+#    And I search for step definition with the name
+#      | Command Execution          |
+#      | Package Download / Install |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
+#      | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
+#      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+#      | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 2 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    When Packages are requested and 2 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#  Scenario: Stop job with multiple targets and Configuration Put and Package Uninstall steps
+#  Create a new job and set a connected KuraMock devices as the job targets.
+#  Add Configuration Put and Package Uninstall steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 0 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 0, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I add 2 devices to Kura Mock
+#    And Devices are connected within 10 seconds
+#    And I wait 1 second
+#    And Devices status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock devices after 5 seconds
+#    And Configuration is requested
+#    Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
+#    And Packages are requested and 1 packages is received
+#    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add targets to job
+#    And I search for the job targets in database
+#    And I count 2
+#    And I search for step definition with the name
+#      | Configuration Put |
+#      | Package Uninstall |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                    | type                                                                                               | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+#      | configuration           | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration                      | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
+#      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+#      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 2 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    And Configuration is requested
+#    Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
+#    And Packages are requested and 0 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
+#
+#  Scenario: Stop job with multiple targets and Asset Write and Package Install steps and one target
+#  Create a new job and set a connected KuraMock device as the job target.
+#  Add two Asset Write and Package Install steps to the created job. Start the job.
+#  Before job is finished, stop the job. When job is stopped, the executed target's
+#  step index should be different than 1 and the status PROCESS_AWAITING. Start the job again.
+#  If job is finished step index should be 1, and job target status PROCESS_OK.
+#
+#    Given I login as user with name "kapua-sys" and password "kapua-password"
+#    And I add 2 devices to Kura Mock
+#    And Devices are connected within 10 seconds
+#    And I wait 1 second
+#    And Devices status is "CONNECTED" within 10 seconds
+#    And I select account "kapua-sys"
+#    And I get the KuraMock devices after 5 seconds
+#    When Device assets are requested
+#    Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
+#    And Packages are requested and 1 package is received
+#    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
+#    And The type of the last event is "DEPLOY"
+#    And I create a job with the name "TestJob"
+#    And I add targets to job
+#    And I search for the job targets in database
+#    And I count 2
+#    And I search for step definition with the name
+#      | Asset Write                |
+#      | Package Download / Install |
+#    And I prepare a JobStepCreator with the name "TestStep1" and properties
+#      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
+#      | assets                 | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                   | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets>                        |
+#      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+#      | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
+#    And I create multiple new JobSteps from the existing creators
+#    Then No exception was thrown
+#    And I count the JobSteps and I find 2 JobStep within 30 seconds
+#    And I start a job
+#    And I wait for 10 milliseconds for processes to settle down
+#    And I stop the job
+#    And I search for the last job target in the database
+#    And I confirm the step index is different than 1 and status is "PROCESS_AWAITING"
+#    And I start a job
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
+#    When Device assets are requested
+#    Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
+#    And Packages are requested and 2 packages are received
+#    Then KuraMock is disconnected
+#    And I logout
 
   @teardown
   Scenario: Stop full docker environment


### PR DESCRIPTION
This PR adds a JobDataCleanupJobEndCallback to remove data of the JobInstance after the JobExecution has run.

This will avoid the `jbtc_*` tables to group up in size and row count making some operations being slow (eg: checking if a Job is running when is has a lot of Execution.

**Related Issue**
_None_

**Description of the solution adopted**
Leverage the `IJobEndCallbackService` to extend the default `JobEndCallbackManagerImpl` and register a custom JobEndCallback that deletes data

**Screenshots**
_None_

**Any side note on the changes made**
Perhaps, also the check for queued job should be moved to a JobEndCallback. Unfortunately only parameter given to the JobEndCallback is the jBatch jobExecutionId, which makes difficult to check which is the actual Kapua JobExecution that was running and start enqueued Jobs