### PR TITLE
:white_check_mark: [Job Engine] Decrease max time to completion for Job Engine tests

### DIFF
--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
@@ -47,7 +47,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
@@ -78,7 +78,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
@@ -136,7 +136,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 3 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 3 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for events from device "rpione3" in account "kapua-sys" I find 5 events within 30 seconds
     And KuraMock is disconnected

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -47,10 +47,10 @@ Feature: JobEngineService restart job tests with online device
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
     And I create a new JobStep from the existing creator
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 2 or more events within 30 seconds
     Then KuraMock is disconnected
@@ -82,10 +82,10 @@ Feature: JobEngineService restart job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Bundles are requested
@@ -119,10 +119,10 @@ Feature: JobEngineService restart job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Bundles are requested
@@ -154,10 +154,10 @@ Feature: JobEngineService restart job tests with online device
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
     When I create a new JobStep from the existing creator
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search for events from device "rpione3" in account "kapua-sys" I find 2 or more events within 30 seconds
     Then Packages are requested and 0 packages are received
@@ -198,10 +198,10 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then KuraMock is disconnected
@@ -241,10 +241,10 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 4 or more events within 30 seconds
     And Bundles are requested
@@ -282,10 +282,10 @@ Feature: JobEngineService restart job tests with online device
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
     And I create a new JobStep from the existing creator
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     Then KuraMock is disconnected
@@ -318,10 +318,10 @@ Feature: JobEngineService restart job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Bundles are requested
@@ -356,10 +356,10 @@ Feature: JobEngineService restart job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     Then Bundles are requested
@@ -392,10 +392,10 @@ Feature: JobEngineService restart job tests with online device
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
     When I create a new JobStep from the existing creator
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 2 or more events are found
     And Packages are requested and 0 packages are received
@@ -437,10 +437,10 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 2 packages are received
@@ -482,10 +482,10 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 4 or more events are found
     And Bundles are requested

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -49,10 +49,10 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     Then I create a new JobStep from the existing creator
     And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     When I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     When I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Configuration is requested
@@ -84,10 +84,10 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
     When I create a new JobStep from the existing creator
     And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Then I query for the job with the name "TestJob" and I count 1 execution item or more and I confirm the executed job is finished within 20 seconds
     When I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Then I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     When Packages are requested and 2 packages are received
@@ -119,10 +119,10 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
     When I create a new JobStep from the existing creator
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Device assets are requested
@@ -165,10 +165,10 @@ Feature: JobEngineService restart job tests with online device - second part
     And No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item or more and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Configuration is requested
@@ -207,10 +207,10 @@ Feature: JobEngineService restart job tests with online device - second part
     And No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Device assets are requested
@@ -248,10 +248,10 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     When I create a new JobStep from the existing creator
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events are found
     Then Configuration is requested
@@ -282,10 +282,10 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
     When I create a new JobStep from the existing creator
     And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Then I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Then I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events is found
     When Packages are requested and 2 packages are received
@@ -318,10 +318,10 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
     When I create a new JobStep from the existing creator
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events is found
     And Device assets are requested
@@ -366,10 +366,10 @@ Feature: JobEngineService restart job tests with online device - second part
     And No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events is found
     Then Configuration is requested
@@ -409,10 +409,10 @@ Feature: JobEngineService restart job tests with online device - second part
     And No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events is found
     And Device assets are requested

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -48,7 +48,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
@@ -80,7 +80,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And Bundles are requested
@@ -114,7 +114,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And Bundles are requested
@@ -147,7 +147,7 @@ Feature: JobEngineService start job tests with online device
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     Then I create a new JobStep from the existing creator
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     When I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "CONFIGURATION"
@@ -181,7 +181,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 2 packages are received
@@ -214,7 +214,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     When Device assets are requested
@@ -247,7 +247,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 0 packages are received
@@ -288,7 +288,7 @@ Feature: JobEngineService start job tests with online device
     Then No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     When I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 2 packages are received
@@ -328,7 +328,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And Bundles are requested
@@ -368,7 +368,7 @@ Feature: JobEngineService start job tests with online device
     And No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 5 events within 30 seconds
     And Configuration is requested
@@ -407,7 +407,7 @@ Feature: JobEngineService start job tests with online device
     And No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     When Device assets are requested
@@ -446,7 +446,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     When KuraMock is disconnected
@@ -479,7 +479,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     And Bundles are requested
@@ -514,7 +514,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_FAILED" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 2 events are found
     And Bundles are requested
@@ -549,7 +549,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     Then Bundles are requested
@@ -581,7 +581,7 @@ Feature: JobEngineService start job tests with online device
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     When I create a new JobStep from the existing creator
     Then I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     Then Configuration is requested
@@ -616,7 +616,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution items and I confirm the executed jobs is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     And Device assets are requested
@@ -649,7 +649,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 0 packages are received
@@ -681,7 +681,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events are found
     When Packages are requested and 2 packages are received
@@ -723,7 +723,7 @@ Feature: JobEngineService start job tests with online device
     Then No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 2 packages are received
@@ -764,7 +764,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new JobStep from the existing creator
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search events from devices in account "kapua-sys" and 4 events are found
     And Bundles are requested
@@ -805,7 +805,7 @@ Feature: JobEngineService start job tests with online device
     And No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search events from devices in account "kapua-sys" and 5 events are found
     Then Configuration is requested
@@ -845,7 +845,7 @@ Feature: JobEngineService start job tests with online device
     And No exception was thrown
     And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
     And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Device assets are requested

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
@@ -67,7 +67,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    When Bundles are requested
 #    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -116,7 +116,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    When Bundles are requested
 #    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -164,7 +164,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    And Packages are requested and 2 packages are received
 #    Then KuraMock is disconnected
@@ -211,7 +211,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    Then Packages are requested and 2 packages are received
 #    Then KuraMock is disconnected
@@ -258,7 +258,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 2 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    When Device assets are requested
 #    Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
@@ -308,7 +308,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    When Bundles are requested
 #    Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -356,7 +356,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    When Bundles are requested
 #    And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -403,7 +403,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    When Packages are requested and 2 packages are received
 #    Then KuraMock is disconnected
@@ -449,7 +449,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    And Configuration is requested
 #    Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -497,7 +497,7 @@ Feature: JobEngineService stop job tests with online device
 #    And I search for the last job target in the database
 #    And I confirm the step index is different than 1 and status is "PROCESS_AWAITING"
 #    And I start a job
-#    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+#    And I confirm job target has step index 1 and status "PROCESS_OK" within 31 seconds
 #    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
 #    When Device assets are requested
 #    Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received


### PR DESCRIPTION
This PR decreases the max time to wait for a Job run to complete. 
180 second was way too long and it was making tests unnecessarily long in case of error/failures. 

**Related Issue**
_None_

**Description of the solution adopted**
Decreased all 180 seconds waits to 31 seconds.
31 seconds are more the enough to complete a Job run for our tests.
31 seconds values was used to mark all "old" 180 definitions.

**Screenshots**
_None_

**Any side note on the changes made**
_None_