### PR TITLE
:bug: [Build] Fixed compilerArgs definition for Maven Compiler Plugin of Mapstruct args

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -52,12 +52,10 @@
                         </path>
                     </annotationProcessorPaths>
                     <compilerArgs>
-                        <compilerArg>
-                            -Amapstruct.unmappedTargetPolicy=ERROR
-                            -Amapstruct.unmappedSourcePolicy=WARN
-                            -Amapstruct.suppressGeneratorTimestamp=true
-                            -Amapstruct.suppressGeneratorVersionInfoComment=true
-                        </compilerArg>
+                        <compilerArg>-Amapstruct.unmappedTargetPolicy=ERROR</compilerArg>
+                        <compilerArg>-Amapstruct.unmappedSourcePolicy=WARN</compilerArg>
+                        <compilerArg>-Amapstruct.suppressGeneratorTimestamp=true</compilerArg>
+                        <compilerArg>-Amapstruct.suppressGeneratorVersionInfoComment=true</compilerArg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -101,12 +101,10 @@
                         </path>
                     </annotationProcessorPaths>
                     <compilerArgs>
-                        <compilerArg>
-                            -Amapstruct.unmappedTargetPolicy=ERROR
-                            -Amapstruct.unmappedSourcePolicy=WARN
-                            -Amapstruct.suppressGeneratorTimestamp=true
-                            -Amapstruct.suppressGeneratorVersionInfoComment=true
-                        </compilerArg>
+                        <compilerArg>-Amapstruct.unmappedTargetPolicy=ERROR</compilerArg>
+                        <compilerArg>-Amapstruct.unmappedSourcePolicy=WARN</compilerArg>
+                        <compilerArg>-Amapstruct.suppressGeneratorTimestamp=true</compilerArg>
+                        <compilerArg>-Amapstruct.suppressGeneratorVersionInfoComment=true</compilerArg>
                     </compilerArgs>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This PR fixes the definition of `compilerArgs` for `maven-compiler-plugin` 

While building the project in IntelliJ it was erroring as follow

![Screenshot 2024-12-12 at 16 12 01](https://github.com/user-attachments/assets/83a78492-b0ca-42b0-a8b4-5210666be706)

It seems that the problem it was not handling as separate values the new lines, which worked ok in maven build

**Related Issue**
_None_

**Description of the solution adopted**
Defined properly `compilerArgs`

**Screenshots**
_None_

**Any side note on the changes made**
_None_