### PR TITLE
:white_check_mark: [Job] Improved test execution times for Job / JobEngine tests

### DIFF
--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/InitShiro.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/InitShiro.java
@@ -27,26 +27,25 @@ import io.cucumber.java.en.Given;
 @ScenarioScoped
 public class InitShiro {
 
-    private static final Logger logger = LoggerFactory.getLogger(InitShiro.class);
+    private static final Logger LOG = LoggerFactory.getLogger(InitShiro.class);
 
     @Given("^Init Security Context$")
     public void start() throws IOException {
-        logger.info("Init shiro security manager...");
+        LOG.info("Init shiro security manager...");
         try {
             SecurityManager securityManager = SecurityUtils.getSecurityManager();
-            logger.info("Found Shiro security manager {}", securityManager);
+            LOG.info("Found Shiro security manager {}", securityManager);
         } catch (UnavailableSecurityManagerException e) {
-            logger.info("Init shiro security manager...");
+            LOG.info("Init shiro security manager...");
             SecurityUtil.initSecurityManager();
         }
-        logger.info("Init shiro security manager... DONE");
+        LOG.info("Init shiro security manager... DONE");
     }
 
     @Given("^Reset Security Context$")
     public void stop() {
-        logger.info("Reset shiro security manager...");
+        LOG.info("Reset shiro security manager...");
         SecurityUtils.setSecurityManager(null);
-        logger.info("Reset shiro security manager... DONE");
+        LOG.info("Reset shiro security manager... DONE");
     }
-
 }

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.qa.integration.steps;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.inject.Singleton;
@@ -49,7 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.BufferedReader;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -254,30 +251,54 @@ public class DockerSteps {
 
         for (String dockerContainer : dockerContainers) {
             switch (dockerContainer) {
-                case "db":
+                case "db": {
                     startDBContainer(BasicSteps.DB_CONTAINER_NAME);
                     synchronized (this) {
                         this.wait(WAIT_FOR_DB);
                     }
-                    break;
-                case "es":
+                } break;
+                case "es": {
                     startESContainer(BasicSteps.ES_CONTAINER_NAME);
                     synchronized (this) {
                         this.wait(WAIT_FOR_ES);
                     }
-                    break;
-                case "events-broker":
+                } break;
+                case "events-broker": {
                     startEventBrokerContainer(BasicSteps.EVENTS_BROKER_CONTAINER_NAME);
                     synchronized (this) {
                         this.wait(WAIT_FOR_EVENTS_BROKER);
                     }
-                    break;
-                case "job-engine":
+                } break;
+                case "job-engine": {
                     startJobEngineContainer(BasicSteps.JOB_ENGINE_CONTAINER_NAME);
                     synchronized (this) {
                         this.wait(WAIT_FOR_JOB_ENGINE);
                     }
-                    break;
+                } break;
+                case "message-broker": {
+                    startMessageBrokerContainer(BasicSteps.MESSAGE_BROKER_CONTAINER_NAME);
+                    synchronized (this) {
+                        this.wait(WAIT_FOR_BROKER);
+                    }
+                } break;
+                case "broker-auth-service": {
+                    startAuthServiceContainer(BasicSteps.AUTH_SERVICE_CONTAINER_NAME);
+
+                    long timeout = System.currentTimeMillis();
+                    while (System.currentTimeMillis() - timeout < 30000) {
+                        isServiceReady(AUTH_SERVICE_CHECK_WEB_APP);
+                        Thread.sleep(500);
+                    }
+                } break;
+                case "consumer-lifecycle": {
+                    startLifecycleConsumerContainer(BasicSteps.LIFECYCLE_CONSUMER_CONTAINER_NAME);
+
+                    long timeout = System.currentTimeMillis();
+                    while (System.currentTimeMillis() - timeout < 30000) {
+                        isServiceReady(LIFECYCLE_CHECK_WEB_APP);
+                        Thread.sleep(500);
+                    }
+                } break;
                 default:
                     throw new UnsupportedOperationException("Unknown container resource: " + dockerContainer);
             }

--- a/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
@@ -18,9 +18,12 @@ Feature: Job Execution service CRUD tests
   The Job service is responsible for maintaining the status of the target step executions.
 
   @setup
-  Scenario: Init Security Context for all scenarios
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start base docker environment
+    And Start Docker environment with resources
+      | db            |
+      | events-broker |
+      | job-engine    |
 
   Scenario: Regular job execution creation
 

--- a/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
@@ -18,9 +18,12 @@ Feature: Job service CRUD tests
   The Job service is responsible for executing scheduled actions on various targets.
 
   @setup
-  Scenario: Init Security Context for all scenarios
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start base docker environment
+    And Start Docker environment with resources
+      | db            |
+      | events-broker |
+      | job-engine    |
 
   Scenario: Regular job creation
 

--- a/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
@@ -18,9 +18,12 @@ Feature: Job Target service CRUD tests
   The Job service is responsible for maintaining a list of job targets.
 
   @setup
-  Scenario: Init Security Context for all scenarios
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start base docker environment
+    And Start Docker environment with resources
+      | db            |
+      | events-broker |
+      | job-engine    |
 
   Scenario: Regular target creation
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
@@ -17,9 +17,15 @@
 Feature: Job Engine Service - Keystore Step Definitions
 
   @setup
-  Scenario: Start full docker environment
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start full docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
+      | message-broker      |
+      | broker-auth-service |
+      | consumer-lifecycle  |
 
   #
   # Tests

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
@@ -16,9 +16,15 @@
 Feature: JobEngineService tests for restarting job with offline device
 
   @setup
-  Scenario: Start full docker environment
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start full docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
+      | message-broker      |
+      | broker-auth-service |
+      | consumer-lifecycle  |
 
     # *************************************************
     # * Restarting a job with one Target and one Step *

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -16,9 +16,15 @@
 Feature: JobEngineService restart job tests with online device
 
   @setup
-  Scenario: Start full docker environment
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start full docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
+      | message-broker      |
+      | broker-auth-service |
+      | consumer-lifecycle  |
 
     # *************************************************
     # * Restarting a job with one Target and one Step *

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -16,9 +16,15 @@
 Feature: JobEngineService restart job tests with online device - second part
 
   @setup
-  Scenario: Start full docker environment
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start full docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
+      | message-broker      |
+      | broker-auth-service |
+      | consumer-lifecycle  |
 
     # *************************************************
     # * Restarting a job with one Target and one Step *

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -16,9 +16,15 @@
 Feature: JobEngineService tests for starting job with offline device
 
   @setup
-  Scenario: Start full docker environment
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start full docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
+      | message-broker      |
+      | broker-auth-service |
+      | consumer-lifecycle  |
 
     # ***********************************************
     # * Starting a job with one Target and one Step *

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -16,9 +16,15 @@
 Feature: JobEngineService start job tests with online device
 
   @setup
-  Scenario: Start full docker environment
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start full docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
+      | message-broker      |
+      | broker-auth-service |
+      | consumer-lifecycle  |
 
     # ***********************************************
     # * Starting a job with one Target and one Step *

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
@@ -18,9 +18,15 @@ Feature: JobEngineService stop job tests with online device
   one target and multiple steps, multiple targets and one step and multiple targets and multiple steps.
 
   @setup
-  Scenario: Start full docker environment
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start full docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
+      | message-broker      |
+      | broker-auth-service |
+      | consumer-lifecycle  |
 
     # *****************************************************
     # * Stopping a job with one Target and multiple Steps *

--- a/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
@@ -16,9 +16,15 @@
 Feature: JobEngineService execute job on device connect
 
   @setup
-  Scenario: Start full docker environment
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start full docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
+      | message-broker      |
+      | broker-auth-service |
+      | consumer-lifecycle  |
 
   Scenario: Executing Job When Device Connected After The Specified Start Date And Time
   Login as the kapua-sys user and create a new job with a Command Execution job step.

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -16,9 +16,12 @@
 Feature: Trigger service tests
 
   @setup
-  Scenario: Init Security Context for all scenarios
+  Scenario: Setup test resources
     Given Init Security Context
-    And Start base docker environment
+    And Start Docker environment with resources
+      | db                  |
+      | events-broker       |
+      | job-engine          |
 
   Scenario: Adding "Device Connect" Schedule With All Valid Parameters
   Login as kapua-sys user and create a job with name job0.


### PR DESCRIPTION
This PR improves the test execution time for Job and JobEngine Services.

Improvement was performed on startup of component.

**Related Issue**
_None_

**Description of the solution adopted**
Currently we are starting a lot of unnecessary resources (i.e: Elasticsearch for Job CRUD). 
By simply starting only required resources, we can save a lot of time

Job CRUD test performances on my local machine:

Before
![Screenshot 2024-12-16 at 12 18 35](https://github.com/user-attachments/assets/9da51ad5-da2f-45c7-b000-40b8848671b3)
After (30s less over a 4 min test set just removing Elasticsearch init)
![Screenshot 2024-12-16 at 12 13 36](https://github.com/user-attachments/assets/2d72abb5-345e-4209-aa92-7313542a43f1)




**Screenshots**
_None_

**Any side note on the changes made**
_None_