### PR TITLE
🐛 [REST API] Fix trigger property description definitions

### DIFF
--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/CronJobTriggerDefinition.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/CronJobTriggerDefinition.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
 
-import com.beust.jcommander.internal.Lists;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.Job;
 import org.eclipse.kapua.service.scheduler.quartz.job.KapuaJobLauncher;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionRecord;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerPropertyRecord;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerType;
+import com.beust.jcommander.internal.Lists;
 
 /**
  * Interval {@link Job} {@link TriggerDefinitionRecord}
@@ -36,12 +36,12 @@ public class CronJobTriggerDefinition extends TriggerDefinitionRecord {
                 Lists.newArrayList(
                         new TriggerPropertyRecord(
                                 CronJobTriggerDefinitionPropertyKeys.SCOPE_ID,
-                                "Identifier of the job this schedule will be applied to",
+                                "Identifier of the scope of the job this schedule will be applied to",
                                 KapuaId.class.getName(),
                                 null),
                         new TriggerPropertyRecord(
                                 CronJobTriggerDefinitionPropertyKeys.JOB_ID,
-                                "Identifier of the scope of the job this schedule will be applied to",
+                                "Identifier of the job this schedule will be applied to",
                                 KapuaId.class.getName(),
                                 null),
                         new TriggerPropertyRecord(

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/IntervalJobTriggerDefinition.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/IntervalJobTriggerDefinition.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
 
-import com.beust.jcommander.internal.Lists;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.Job;
 import org.eclipse.kapua.service.scheduler.quartz.job.KapuaJobLauncher;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionRecord;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerPropertyRecord;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerType;
+import com.beust.jcommander.internal.Lists;
 
 /**
  * Interval {@link Job} {@link TriggerDefinitionRecord}
@@ -36,12 +36,12 @@ public class IntervalJobTriggerDefinition extends TriggerDefinitionRecord {
                 Lists.newArrayList(
                         new TriggerPropertyRecord(
                                 IntervalJobTriggerDefinitionPropertyKeys.SCOPE_ID,
-                                "Identifier of the job this schedule will be applied to",
+                                "Identifier of the scope of the job this schedule will be applied to",
                                 KapuaId.class.getName(),
                                 null),
                         new TriggerPropertyRecord(
                                 IntervalJobTriggerDefinitionPropertyKeys.JOB_ID,
-                                "Identifier of the scope of the job this schedule will be applied to",
+                                "Identifier of the job this schedule will be applied to",
                                 KapuaId.class.getName(),
                                 null),
                         new TriggerPropertyRecord(


### PR DESCRIPTION
### Description
This pull request addresses the issue where the descriptions for the `jobId` and `scopeId` properties in the trigger definitions were incorrectly defined. The descriptions have been switched to accurately reflect their respective properties.

### Changes Made
- Updated the description for `jobId` to: "Identifier of the job this schedule will be applied to."
- Updated the description for `scopeId` to: "Identifier of the scope of the job this schedule will be applied to."

### How to Test
1. Execute the GET request to `/{scopeId}/triggerDefinitions`.
2. Verify that the descriptions for `jobId` and `scopeId` are now correctly defined as per the expected results.
