### PR TITLE
✨ [Job] Improve descriptions for keystore management job steps properties

### DIFF
--- a/service/device/management/keystore/job/src/main/java/org/eclipse/kapua/service/device/management/keystore/job/definition/DeviceKeystoreCertificateCreateJobStepDefinition.java
+++ b/service/device/management/keystore/job/src/main/java/org/eclipse/kapua/service/device/management/keystore/job/definition/DeviceKeystoreCertificateCreateJobStepDefinition.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.keystore.job.definition;
 
-import com.beust.jcommander.internal.Lists;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService;
 import org.eclipse.kapua.service.device.management.keystore.job.DeviceKeystoreCertificateCreateTargetProcessor;
@@ -22,6 +21,7 @@ import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionRecord;
 import org.eclipse.kapua.service.job.step.definition.JobStepPropertyRecord;
 import org.eclipse.kapua.service.job.step.definition.JobStepType;
 import org.eclipse.kapua.service.job.step.definition.device.management.TimeoutJobStepPropertyRecord;
+import com.beust.jcommander.internal.Lists;
 
 /**
  * {@link JobStepDefinition} to perform {@link DeviceKeystoreManagementService#createKeystoreCertificate(KapuaId, KapuaId, DeviceKeystoreCertificate, Long)}.
@@ -43,7 +43,7 @@ public class DeviceKeystoreCertificateCreateJobStepDefinition extends JobStepDef
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DeviceKeystoreCertificateCreatePropertyKeys.KEYSTORE_ID,
-                                "Identifier of the device keystore where the certificate will be added",
+                                "Identifier of the device keystore where the certificate will be added. The identifier can be found in the Key Stores view within the Device Overview page or can be retrieved via the REST API",
                                 String.class.getName(),
                                 null,
                                 "SSLKeystore",

--- a/service/device/management/keystore/job/src/main/java/org/eclipse/kapua/service/device/management/keystore/job/definition/DeviceKeystoreItemDeleteJobStepDefinition.java
+++ b/service/device/management/keystore/job/src/main/java/org/eclipse/kapua/service/device/management/keystore/job/definition/DeviceKeystoreItemDeleteJobStepDefinition.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.keystore.job.definition;
 
-import com.beust.jcommander.internal.Lists;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService;
 import org.eclipse.kapua.service.device.management.keystore.job.DeviceKeystoreItemDeleteTargetProcessor;
@@ -21,6 +20,7 @@ import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionRecord;
 import org.eclipse.kapua.service.job.step.definition.JobStepPropertyRecord;
 import org.eclipse.kapua.service.job.step.definition.JobStepType;
 import org.eclipse.kapua.service.job.step.definition.device.management.TimeoutJobStepPropertyRecord;
+import com.beust.jcommander.internal.Lists;
 
 /**
  * {@link JobStepDefinition} to perform {@link DeviceKeystoreManagementService#deleteKeystoreItem(KapuaId, KapuaId, String, String, Long)}
@@ -42,7 +42,7 @@ public class DeviceKeystoreItemDeleteJobStepDefinition extends JobStepDefinition
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DeviceKeystoreItemDeletePropertyKeys.KEYSTORE_ID,
-                                "Identifier of the device keystore where the certificate will be removed",
+                                "Identifier of the device keystore where the certificate will be removed. The identifier can be found in the Key Stores view within the Device Overview page or can be retrieved via the REST API",
                                 String.class.getName(),
                                 null,
                                 "SSLKeystore",
@@ -55,7 +55,7 @@ public class DeviceKeystoreItemDeleteJobStepDefinition extends JobStepDefinition
                                 null),
                         new JobStepPropertyRecord(
                                 DeviceKeystoreItemDeletePropertyKeys.ALIAS,
-                                "Alias of the certificate in the destination keystore",
+                                "Alias of the certificate. The Alias can be found in the Key Stores view within the Device Overview page or can be retrieved via the REST API",
                                 String.class.getName(),
                                 null,
                                 "ssl-eclipse",

--- a/service/device/management/keystore/job/src/main/java/org/eclipse/kapua/service/device/management/keystore/job/definition/DeviceKeystoreKeypairCreateJobStepDefinition.java
+++ b/service/device/management/keystore/job/src/main/java/org/eclipse/kapua/service/device/management/keystore/job/definition/DeviceKeystoreKeypairCreateJobStepDefinition.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.keystore.job.definition;
 
-import com.beust.jcommander.internal.Lists;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService;
 import org.eclipse.kapua.service.device.management.keystore.job.DeviceKeystoreKeypairCreateTargetProcessor;
@@ -22,6 +21,7 @@ import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionRecord;
 import org.eclipse.kapua.service.job.step.definition.JobStepPropertyRecord;
 import org.eclipse.kapua.service.job.step.definition.JobStepType;
 import org.eclipse.kapua.service.job.step.definition.device.management.TimeoutJobStepPropertyRecord;
+import com.beust.jcommander.internal.Lists;
 
 /**
  * {@link JobStepDefinition} to perform {@link DeviceKeystoreManagementService#createKeystoreKeypair(KapuaId, KapuaId, DeviceKeystoreKeypair, Long)}
@@ -43,7 +43,7 @@ public class DeviceKeystoreKeypairCreateJobStepDefinition extends JobStepDefinit
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DeviceKeystoreKeypairCreatePropertyKeys.KEYSTORE_ID,
-                                "Identifier of the device keystore where the certificate will be added",
+                                "Identifier of the device keystore where the certificate will be added. The identifier can be found in the Key Stores view within the Device Overview page or can be retrieved via the REST API",
                                 String.class.getName(),
                                 null,
                                 "SSLKeystore",


### PR DESCRIPTION
# Description
This PR enhances the descriptions for various properties used in job steps related to keystore management. The changes aim to provide clearer guidance for users, helping them retrieve the correct values for their use cases. 

- Updated the description for the `KEYSTORE_ID` property in the "Key Store Certificate Create" and "Key Store Keypair Create" steps to clarify its purpose and retrieval method.
- Improved the descriptions for the `KEYSTORE_ID` and `ALIAS` properties in the "Key Store Item Delete" step to ensure users understand where to find these identifiers.

These improvements contribute to a better user experience by making the documentation more intuitive and accessible.
# Before this changes screenshots
<p align="center">
<img width="33%" src="https://github.com/user-attachments/assets/c84fdb8d-03ab-483f-a259-9fe0fcc44048" />
<img width="33%"src="https://github.com/user-attachments/assets/23976786-652d-43e0-872b-6695547bc413" />
<img width="33%" src="https://github.com/user-attachments/assets/f565337f-378e-4453-89c8-0d41f8698434" />
</p>

# After this changes screenshots
<p align="center">
<img width="33%" src="https://github.com/user-attachments/assets/78b416f8-a357-41a6-8051-9c09687a7cb6" />
<img width="33%" src="https://github.com/user-attachments/assets/37f737e0-e47d-4701-9dda-39cb4fe68fd4" />
<img width="33%" src="https://github.com/user-attachments/assets/bf52063b-1588-4b3e-a3d6-440d00c5d449" />
</p>
