### PR TITLE
:bug: [Scheduler] Fixed update of TriggerDefinitionProperty.propertyType and definitions

### DIFF
--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/CronJobTriggerDefinition.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/CronJobTriggerDefinition.java
@@ -47,7 +47,7 @@ public class CronJobTriggerDefinition extends TriggerDefinitionRecord {
                         new TriggerPropertyRecord(
                                 CronJobTriggerDefinitionPropertyKeys.CRON_EXPRESSION,
                                 "The cron expression that defines the schedule of executions. Check documentation for CRON syntax",
-                                KapuaId.class.getName(),
+                                String.class.getName(),
                                 null)
                 )
         );

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/IntervalJobTriggerDefinition.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/IntervalJobTriggerDefinition.java
@@ -47,7 +47,7 @@ public class IntervalJobTriggerDefinition extends TriggerDefinitionRecord {
                         new TriggerPropertyRecord(
                                 IntervalJobTriggerDefinitionPropertyKeys.INTERVAL,
                                 "Fixed time between job executions in seconds",
-                                KapuaId.class.getName(),
+                                Integer.class.getName(),
                                 null)
                 )
         );

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionAligner.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionAligner.java
@@ -169,7 +169,7 @@ public class TriggerDefinitionAligner {
             if (dbTriggerDefinitionProperty == null) {
                 LOG.warn("Wired TriggerProperty '{}' of TriggerDefinition '{}' is not aligned with the database one",
                         wiredTriggerDefinitionProperty.getName(),
-                        wiredTriggerDefinitionProperty.getName());
+                        wiredTriggerDefinition.getName());
 
                 return false;
             }

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerPropertyImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerPropertyImpl.java
@@ -36,11 +36,11 @@ public class TriggerPropertyImpl implements TriggerProperty {
     private String description;
 
     @Basic
-    @Column(name = "property_type", nullable = false, updatable = false)
+    @Column(name = "property_type", nullable = false, updatable = true)
     private String propertyType;
 
     @Basic
-    @Column(name = "property_value", nullable = false, updatable = false)
+    @Column(name = "property_value", nullable = false, updatable = true)
     private String propertyValue;
 
     /**


### PR DESCRIPTION
TriggerDefinitionProperty.propertyType and TriggerDefinitionProperty.propertyValue were not updatable and some TriggerDefinitions were wrong.

**Related Issue**
_None_

**Description of the solution adopted**

Fixed JPA definition of JobStepPropertyImpl

Fixed following Trigger Definitions:
- IntervalJobTriggerDefinition
- CronJobTriggerDefinition.java

**Screenshots**
_None_

**Any side note on the changes made**
_None_