### PR TITLE
:bug: [OpenAPI] Fixed example value for `POST /{scopeId}/devices/{deviceId}/packages/_uninstall`

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
@@ -64,11 +64,6 @@ paths:
             application/json:
               schema:
                 $ref: '../deviceOperation/deviceOperation.yaml#/components/schemas/deviceOperation'
-        204:
-          description: |
-            The Package Install request has been successfully received. However, this does NOT mean that the package has been successfully installed, since the Package Install
-            is an asynchronous operation and may still be in progress. APIs are available at `device/{deviceId}/operations` and `device/{deviceId}/operations/{operationId}/notifications`
-            to track asynchronous operations.
         400:
           $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
@@ -49,11 +49,33 @@ paths:
             application/json:
               schema:
                 $ref: '../deviceOperation/deviceOperation.yaml#/components/schemas/deviceOperation'
-        204:
-          description: |
-            The Package Install request has been successfully received. However, this does NOT mean that the package has been successfully installed, since the Package Install
-            is an asynchronous operation and may still be in progress. APIs are available at `device/{deviceId}/operations` and `device/{deviceId}/operations/{operationId}/notifications`
-            to track asynchronous operations.
+              example:
+                type: deviceManagementOperation
+                id: daGd5aiInCU
+                scopeId: AQ
+                createdOn: '2019-11-15T11:27:24.857Z'
+                createdBy: AQ
+                modifiedOn: '2019-11-15T11:30:01.975Z'
+                modifiedBy: Ag
+                optlock: 1
+                action: EXECUTE
+                appId: DEPLOY
+                deviceId: UVjeGkGVT3A
+                operationId: I-1DnL467js
+                startedOn: '2019-11-15T11:27:24.842Z'
+                resource: UNINSTALL
+                status: RUNNING
+                operationProperties:
+                  - name: kapua.package.operation.id
+                    propertyType: org.eclipse.kapua.commons.model.id.KapuaEid
+                    propertyValue: '2588799701293395515'
+                  - name: kapua.package.download.name
+                    propertyType: string
+                    propertyValue: heater
+                  - name: kapua.package.download.version
+                    propertyType: string
+                    propertyValue: 1.0.500
+                log: ''
         400:
           $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:


### PR DESCRIPTION
Fixed the example value of the response of the `POST /{scopeId}/devices/{deviceId}/packages/_uninstall` documentation

**Related Issue**
_None_

**Description of the solution adopted**
Fixed the example
Removed wrong 204 return codes

**Screenshots**
_None_

**Any side note on the changes made**
_None_