### PR TITLE
:bug: [Scheduler] Fixed returned exception when an invalid cron expression is provided

### DIFF
--- a/service/scheduler/test/src/test/resources/features/SchedulerService.feature
+++ b/service/scheduler/test/src/test/resources/features/SchedulerService.feature
@@ -126,7 +126,7 @@ Feature: Scheduler Service
     And A regular trigger creator with the name "schedule0" is created
     And The trigger is set to start today at "10:00"
     Then I set cron expression to "12 1 ? ? *"
-    And I expect the exception "KapuaException" with the text "*"
+    And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument cronExpression"
     And I create a new trigger from the existing creator with previously defined date properties
     Then An exception was thrown
 


### PR DESCRIPTION
This PR fixes the returned exception when an invalid cron expression is provided.

**Related Issue**
_None_

**Description of the solution adopted**
Fixed the returned exception and adapted tests

**Screenshots**
_None_

**Any side note on the changes made**
_None_