### PR TITLE
:bug: [Core] Fixed handling of null KapuaSession on prePersist and preUpdate operation in KapuaEntity

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
@@ -165,7 +165,9 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
     @PrePersist
     protected void prePersistsAction() {
         setId(new KapuaEid(IdGenerator.generate()));
-        setCreatedBy(KapuaSecurityUtils.getSession().getUserId());
+        if (KapuaSecurityUtils.getSession() != null) {
+            setCreatedBy(KapuaSecurityUtils.getSession().getUserId());
+        }
         setCreatedOn(new Date());
     }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
@@ -212,7 +212,9 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
      */
     @PreUpdate
     protected void preUpdateAction() {
-        setModifiedBy(KapuaSecurityUtils.getSession().getUserId());
+        if (KapuaSecurityUtils.getSession() != null) {
+            setModifiedBy(KapuaSecurityUtils.getSession().getUserId());
+        }
         setModifiedOn(new Date());
     }
 }


### PR DESCRIPTION
Fixed handling of KapuaSession when `null`

**Related Issue**
_None_

**Description of the solution adopted**
Added a `null` check

**Screenshots**
_None_

**Any side note on the changes made**
_None_