### PR TITLE
:bug: [CI] Fixed Sonar Scan workflow

### DIFF
--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build and analyze


### PR DESCRIPTION
This PR fixed Sonar Scan work flow.

**Related Issue**
_None_

**Description of the solution adopted**
The step was caching the whole `.m2` repository folder.
This was causing `.m2/toolchains.xml` file written by the `Set up JDK 11`  step to be overwritten (better to say deleted) from the restoring of the cache performed by `Cache Maven packages` step.

By caching only the `.m2/repository` we avoid that an Maven `settings.xml` and `toolchains.xml` files will be setup correctly for each build

**Screenshots**
_None_

**Any side note on the changes made**
_None_