### PR TITLE
♻️  [CI] Improved Kapua CI workflow artifacts and dependency caching 

### DIFF
--- a/.github/actions/prepareMavenRepoForCache/action.yaml
+++ b/.github/actions/prepareMavenRepoForCache/action.yaml
@@ -1,0 +1,11 @@
+name: 'Prepare Maven Repo'
+description: |
+  Prepares ~/.m2/repository/ for caching
+runs:
+  using: "composite"
+  steps:
+    - name: Extract built Kapua artifacts # This splits the built Kapua artifact of this run from the cached repository of external dependencies for caching
+      run: |
+        mkdir --parents ~/.m2/kapua-repository/org/eclipse/
+        mv ~/.m2/repository/org/eclipse/kapua ~/.m2/kapua-repository/org/eclipse/kapua
+      shell: bash

--- a/.github/actions/prepareMavenRepoForCache/action.yaml
+++ b/.github/actions/prepareMavenRepoForCache/action.yaml
@@ -5,6 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Extract built Kapua artifacts # This splits the built Kapua artifact of this run from the cached repository of external dependencies for caching
+      if: ${{ steps.cache-maven-kapua-artifacts.outputs.cache-hit != 'true' }}
       run: |
         mkdir --parents ~/.m2/kapua-repository/org/eclipse/
         mv ~/.m2/repository/org/eclipse/kapua ~/.m2/kapua-repository/org/eclipse/kapua

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -1,4 +1,4 @@
-name: 'Execute tests tagged in a certain way'
+name: 'Execute tests'
 description: 'Execute tests suite for tests tagged as specified'
 inputs:
   tag:

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -36,16 +36,6 @@ runs:
       run: mvn clean install -Pdocker -pl :kapua-assembly-api
       shell: bash
 
-    - name: Dns look-up containers needed for tests - message-broker
-      if: ${{ inputs.needs-docker-images == 'true' }}
-      run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      shell: bash
-
-    - name: Dns look-up containers needed for tests - job-engine
-      if: ${{ inputs.needs-docker-images == 'true' }}
-      run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
-      shell: bash
-
     - name: Cucumber tests execution step
       if: ${{ inputs.run-junit == 'false' }}
       run: mvn -B -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -23,22 +23,8 @@ runs:
     - name: Set up runner
       uses: ./.github/actions/setUpRunner
 
-    - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies built from 'build' job
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2/repository/
-        key: ${{ runner.os }}-maven-develop-dependencies
-
-    - name: Cache Maven repository - Kapua artifacts # Cache of Kapua artifacts built from 'build' job
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2/kapua-repository/org/eclipse/kapua
-        key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts
-        fail-on-cache-miss: true
-
-    - name: Build full cached Maven repository # This adds the built Kapua artifact of this run to the cached repository of external dependencies
-      run: mv ~/.m2/kapua-repository/org/eclipse/kapua ~/.m2/repository/org/eclipse/kapua
-      shell: bash
+    - name: Set up Maven caches
+      uses: ./.github/actions/setUpMavenCaches
 
     - name: Docker images creation
       if: ${{ inputs.needs-docker-images == 'true' }}

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -20,20 +20,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Java 11
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'zulu'
-        java-version: 11
-
-    - name: Setup Node 16
-      uses: actions/setup-node@v4 # Installs Node and NPM
-      with:
-        node-version: 16
-
-    - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
-      run: 'npm install -g @apidevtools/swagger-cli'
-      shell: bash
+    - name: Set up runner
+      uses: ./.github/actions/setUpRunner
 
     - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies built from 'build' job
       uses: actions/cache@v4

--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -20,47 +20,67 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup java
+    - name: Setup Java 11
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: 11
-    - name: Setup Node
+
+    - name: Setup Node 16
       uses: actions/setup-node@v4 # Installs Node and NPM
       with:
         node-version: 16
+
     - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
       run: 'npm install -g @apidevtools/swagger-cli'
       shell: bash
-    - name: Reuse cached maven artifacts dependencies
-      if: ${{ inputs.run-junit == 'false' }}
+
+    - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies built from 'build' job
       uses: actions/cache@v4
       with:
-        path: ~/.m2/repository
-        key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
+        path: ~/.m2/repository/
+        key: ${{ runner.os }}-maven-develop-dependencies
+
+    - name: Cache Maven repository - Kapua artifacts # Cache of Kapua artifacts built from 'build' job
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/kapua-repository/org/eclipse/kapua
+        key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts
+        fail-on-cache-miss: true
+
+    - name: Build full cached Maven repository # This adds the built Kapua artifact of this run to the cached repository of external dependencies
+      run: mv ~/.m2/kapua-repository/org/eclipse/kapua ~/.m2/repository/org/eclipse/kapua
+      shell: bash
+
     - name: Docker images creation
       if: ${{ inputs.needs-docker-images == 'true' }}
       run: mvn clean install -pl ${APP_PROJECTS} && mvn clean install -Pdocker -f assembly/pom.xml -pl '!:kapua-assembly-api' #api container not used in the tests at all se we don't need to build it here
       shell: bash
+
     - name: Docker rest-api image creation
       if: ${{ inputs.needs-api-docker-image == 'true' }}
       run: mvn clean install -Pdocker -pl :kapua-assembly-api
       shell: bash
+
     - name: Dns look-up containers needed for tests - message-broker
       if: ${{ inputs.needs-docker-images == 'true' }}
       run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
       shell: bash
+
     - name: Dns look-up containers needed for tests - job-engine
       if: ${{ inputs.needs-docker-images == 'true' }}
       run: echo "127.0.0.1       job-engine" | sudo tee -a /etc/hosts
       shell: bash
+
     - name: Cucumber tests execution step
       if: ${{ inputs.run-junit == 'false' }}
       run: mvn -B -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="${{ inputs.tag }}" -pl ${TEST_PROJECTS} verify
       shell: bash
+
     - name: Junit tests execution step
       if: ${{ inputs.run-junit == 'true' }}
       run: mvn -B -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
       shell: bash
+
     - name: Code coverage results upload
       uses: codecov/codecov-action@v4

--- a/.github/actions/saveBuiltKapuaArtifacts/action.yaml
+++ b/.github/actions/saveBuiltKapuaArtifacts/action.yaml
@@ -1,12 +1,16 @@
-name: 'Prepare Maven Repo'
+name: 'Save built Kapua Artifacts'
 description: |
-  Prepares ~/.m2/repository/ for caching
+  Saves the built Kapua artifacts for later usage
 runs:
   using: "composite"
   steps:
     - name: Extract built Kapua artifacts # This splits the built Kapua artifact of this run from the cached repository of external dependencies for caching
-      if: ${{ steps.cache-maven-kapua-artifacts.outputs.cache-hit != 'true' }}
       run: |
         mkdir --parents ~/.m2/kapua-repository/org/eclipse/
         mv ~/.m2/repository/org/eclipse/kapua ~/.m2/kapua-repository/org/eclipse/kapua
       shell: bash
+    - name: Save built Kapua artifacts
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.m2/kapua-repository/org/eclipse/kapua
+        key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts

--- a/.github/actions/saveBuiltKapuaArtifacts/action.yaml
+++ b/.github/actions/saveBuiltKapuaArtifacts/action.yaml
@@ -9,6 +9,7 @@ runs:
         mkdir --parents ~/.m2/kapua-repository/org/eclipse/
         mv ~/.m2/repository/org/eclipse/kapua ~/.m2/kapua-repository/org/eclipse/kapua
       shell: bash
+
     - name: Save built Kapua artifacts
       uses: actions/cache/save@v4
       with:

--- a/.github/actions/setUpMavenCaches/action.yaml
+++ b/.github/actions/setUpMavenCaches/action.yaml
@@ -1,0 +1,29 @@
+name: 'Set Up Maven caches'
+description: |
+  Set up maven caches to speedup build time and reuse built artifacts
+inputs:
+  kapua-artifact-cache-enabled:
+    description: Whether to enable Kapua artifacts cache or not. If not enable you'll be required to build Kapua Artifacts on the runner
+    default: 'true'
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
+      id: cache-maven-external-deps
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository/
+        key: ${{ runner.os }}-maven-develop-dependencies
+
+    - name: Cache Maven repository - Kapua artifacts # Cache of built Kapua artifacts be reused in other jobs
+      if: ${{ inputs.kapua-artifact-cache-enabled == 'true' }}
+      id: cache-maven-kapua-artifacts
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/kapua-repository/org/eclipse/kapua
+        key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts
+
+    - name: Build full cached Maven repository # This adds the built Kapua artifact of this run to the cached repository of external dependencies. Used when re-running a job
+      if: ${{ inputs.kapua-artifact-cache-enabled == 'true' && steps.cache-maven-kapua-artifacts.outputs.cache-hit == 'true' }}
+      run: mv ~/.m2/kapua-repository/org/eclipse/kapua ~/.m2/repository/org/eclipse/kapua
+      shell: bash

--- a/.github/actions/setUpMavenCaches/action.yaml
+++ b/.github/actions/setUpMavenCaches/action.yaml
@@ -18,13 +18,14 @@ runs:
     - name: Cache Maven repository - Kapua artifacts # Cache of built Kapua artifacts be reused in other jobs
       if: ${{ inputs.kapua-artifact-cache-enabled == 'true' }}
       id: cache-maven-kapua-artifacts
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ~/.m2/kapua-repository/org/eclipse/kapua
         key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts
+        fail-on-cache-miss: 'true'
 
     - name: Build full cached Maven repository # This adds the built Kapua artifact of this run to the cached repository of external dependencies. Used when re-running a job
-      if: ${{ inputs.kapua-artifact-cache-enabled == 'true' && steps.cache-maven-kapua-artifacts.outputs.cache-hit == 'true' }}
+      if: ${{ inputs.kapua-artifact-cache-enabled == 'true' }}
       run: mv ~/.m2/kapua-repository/org/eclipse/kapua ~/.m2/repository/org/eclipse/kapua
       shell: bash
 

--- a/.github/actions/setUpMavenCaches/action.yaml
+++ b/.github/actions/setUpMavenCaches/action.yaml
@@ -27,3 +27,4 @@ runs:
       if: ${{ inputs.kapua-artifact-cache-enabled == 'true' && steps.cache-maven-kapua-artifacts.outputs.cache-hit == 'true' }}
       run: mv ~/.m2/kapua-repository/org/eclipse/kapua ~/.m2/repository/org/eclipse/kapua
       shell: bash
+

--- a/.github/actions/setUpRunner/action.yaml
+++ b/.github/actions/setUpRunner/action.yaml
@@ -4,6 +4,7 @@ description: |
   - Setup Java 11
   - Setup Node 16
   - Install Swagger CLI
+  - Add entries to /etc/hosts
 runs:
   using: "composite"
   steps:
@@ -20,4 +21,10 @@ runs:
 
     - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
       run: 'npm install -g @apidevtools/swagger-cli'
+      shell: bash
+
+    - name: Dns look-up Docker containers needed for tests
+      run: |
+        echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
+        echo "127.0.0.1       job-engine"     | sudo tee -a /etc/hosts
       shell: bash

--- a/.github/actions/setUpRunner/action.yaml
+++ b/.github/actions/setUpRunner/action.yaml
@@ -4,7 +4,7 @@ description: |
   - Setup Java 11
   - Setup Node 16
   - Install Swagger CLI
-  - Add entries to /etc/hosts
+  - Add entries to /etc/hosts for tests
 runs:
   using: "composite"
   steps:
@@ -15,11 +15,11 @@ runs:
         java-version: 11
 
     - name: Setup Node 16
-      uses: actions/setup-node@v4 # Installs Node and NPM
+      uses: actions/setup-node@v4
       with:
         node-version: 16
 
-    - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
+    - name: Install Swagger CLI # Required to bundle OpenAPI files
       run: 'npm install -g @apidevtools/swagger-cli'
       shell: bash
 

--- a/.github/actions/setUpRunner/action.yaml
+++ b/.github/actions/setUpRunner/action.yaml
@@ -1,0 +1,23 @@
+name: 'Set Up Runner'
+description: |
+  Set up runner with tools required for the build
+  - Setup Java 11
+  - Setup Node 16
+  - Install Swagger CLI
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Java 11
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: 11
+
+    - name: Setup Node 16
+      uses: actions/setup-node@v4 # Installs Node and NPM
+      with:
+        node-version: 16
+
+    - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
+      run: 'npm install -g @apidevtools/swagger-cli'
+      shell: bash

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -13,23 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Checkout repository # Checks out a copy of the repository on the worker
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
 
-      - name: Setup Java 11
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 11
-
-      - name: Setup Node 16 # Installs Node and NPM
-        uses: actions/setup-node@v4
-        with:
-          node-version: 16
-
-      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
-        run: 'npm install -g @apidevtools/swagger-cli'
-        shell: bash
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
 
       - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
         id: cache-maven-external-deps
@@ -69,8 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@brokerAcl'
@@ -80,8 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@tag'
@@ -91,8 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@broker'
@@ -102,8 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@device'
@@ -113,8 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@deviceManagement'
@@ -124,8 +122,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@connection'
@@ -135,8 +135,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@datastore'
@@ -146,8 +148,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@user'
@@ -157,8 +161,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@userIntegrationBase'
@@ -168,8 +174,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@userIntegration'
@@ -179,8 +187,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@security'
@@ -190,8 +200,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '(@job or @scheduler) and not @it'
@@ -201,8 +213,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@job and @it'
@@ -212,8 +226,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobEngine'
@@ -223,8 +239,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@jobsIntegration'
@@ -234,8 +252,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@account or @translator'
@@ -245,8 +265,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@role or @group'
@@ -256,8 +278,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@deviceRegistry'
@@ -267,8 +291,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@endpoint'
@@ -278,8 +304,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@rest_auth'
@@ -290,8 +318,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@rest_cors'
@@ -302,8 +332,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           tag: '@rest_parsing'
@@ -314,8 +346,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
         with:
           needs-docker-images: 'false'
@@ -325,23 +359,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
-
-      - name: Setup Java 11
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 11
-
-      - name: Setup Node 16
-        uses: actions/setup-node@v4 # Installs Node and NPM
-        with:
-          node-version: 16
-
-      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
-        run: 'npm install -g @apidevtools/swagger-cli'
-        shell: bash
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
 
       - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
         id: cache-maven-external-deps

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Set up Maven caches
         uses: ./.github/actions/setUpMavenCaches
+        with:
+          kapua-artifact-cache-enabled: 'false'
 
       - name: Maven version
         run: mvn --version
@@ -28,8 +30,8 @@ jobs:
       - name: Build Kapua project
         run: mvn -B -DskipTests clean install -T 1C
 
-      - name: Prepare Maven repo for caching
-        uses: ./.github/actions/prepareMavenRepoForCache
+      - name: Save built Kapua Artifacts
+        uses: ./.github/actions/saveBuiltKapuaArtifacts
 
   build-javadoc:
     needs: build

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -13,23 +13,57 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4 # Checks out a copy of the repository on the ubuntu-latest machine
-      - uses: actions/setup-java@v4
+      - name: Checkout repository # Checks out a copy of the repository on the worker
+        uses: actions/checkout@v4
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
-      - uses: actions/setup-node@v4 # Installs Node and NPM
+
+      - name: Setup Node 16 # Installs Node and NPM
+        uses: actions/setup-node@v4
         with:
           node-version: 16
+
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
-      - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
+        shell: bash
+
+      - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
+        id: cache-maven-external-deps
+        uses: actions/cache@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-      - run: mvn -v
-      - run: docker images -a  # used as log (should show only GitHub environment standard docker images; if kapua images are present, something is wrong)
-      - run: mvn -B -DskipTests clean install -T 1C
+          path: ~/.m2/repository/
+          key: ${{ runner.os }}-maven-develop-dependencies
+
+      - name: Cache Maven repository - Kapua artifacts # Cache of Kapua artifacts be reused in following jobs
+        id: cache-maven-kapua-artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/kapua-repository/org/eclipse/kapua
+          key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts
+
+      - name: Build full cached Maven repository # This adds the built Kapua artifact of this run to the cached repository of external dependencies. Used when re-running a job
+        if: steps.cache-maven-kapua-artifacts.outputs.cache-hit == 'true'
+        run: mv ~/.m2/kapua-repository/org/eclipse/kapua ~/.m2/repository/org/eclipse/kapua
+
+      - name: Maven version
+        run: mvn --version
+
+      - name: Build Kapua project
+        run: mvn -B -DskipTests clean install -T 1C
+
+      - name: Download all dependencies of the project # Downloading all referenced dependencies to build a complete cache if not present
+        if: steps.cache-maven-external-deps.outputs.cache-hit != 'true'
+        run: mvn dependency:go-offline
+
+      - name: Extract built Kapua artifacts # This splits the built Kapua artifact of this run from the cached repository of external dependencies for caching
+        run: |
+          mkdir --parents ~/.m2/kapua-repository/org/eclipse/
+          mv ~/.m2/repository/org/eclipse/kapua ~/.m2/kapua-repository/org/eclipse/kapua
+
   test-brokerAcl:
     needs: build
     runs-on: ubuntu-latest
@@ -291,18 +325,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v4
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
-      - uses: actions/setup-node@v4 # Installs Node and NPM
+
+      - name: Setup Node 16
+        uses: actions/setup-node@v4 # Installs Node and NPM
         with:
           node-version: 16
+
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
-      - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
+        shell: bash
+
+      - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
+        id: cache-maven-external-deps
+        uses: actions/cache@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ github.run_id }}-${{ github.run_number }}-maven-cache
-      - run: mvn -B -DskipTests install javadoc:jar
+          path: ~/.m2/repository/
+          key: ${{ runner.os }}-maven-develop-dependencies
+
+      - name: Build Kapua Javadoc
+        run: mvn -B -DskipTests install javadoc:jar

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -28,14 +28,43 @@ jobs:
       - name: Build Kapua project
         run: mvn -B -DskipTests clean install -T 1C
 
-      - name: Download all dependencies of the project # Downloading all referenced dependencies to build a complete cache if not present
-        if: steps.cache-maven-external-deps.outputs.cache-hit != 'true'
-        run: mvn dependency:go-offline
+      - name: Prepare Maven repo for caching
+        uses: ./.github/actions/prepareMavenRepoForCache
 
-      - name: Extract built Kapua artifacts # This splits the built Kapua artifact of this run from the cached repository of external dependencies for caching
-        run: |
-          mkdir --parents ~/.m2/kapua-repository/org/eclipse/
-          mv ~/.m2/repository/org/eclipse/kapua ~/.m2/kapua-repository/org/eclipse/kapua
+  build-javadoc:
+    needs: build
+    name: Build Javadoc
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository # Checks out a copy of the repository on the runner
+        uses: actions/checkout@v4
+
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
+
+      - name: Set up Maven caches
+        uses: ./.github/actions/setUpMavenCaches
+        with:
+          kapua-artifact-cache-enabled: 'false'
+
+      - name: Build Kapua Javadoc
+        run: mvn -B -DskipTests install javadoc:jar
+
+  junit-tests:
+    needs: build
+    name: Run jUnit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository # Checks out a copy of the repository on the runner
+        uses: actions/checkout@v4
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
+      - uses: ./.github/actions/runTestsTaggedAs
+        with:
+          needs-docker-images: 'false'
+          run-junit: 'true'
 
   test-brokerAcl:
     needs: build
@@ -326,34 +355,3 @@ jobs:
           tag: '@rest_parsing'
           needs-docker-images: 'true'
           needs-api-docker-image: 'true'
-  junit-tests:
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
-      - name: Set up runner
-        uses: ./.github/actions/setUpRunner
-      - uses: ./.github/actions/runTestsTaggedAs
-        with:
-          needs-docker-images: 'false'
-          run-junit: 'true'
-  build-javadoc:
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
-
-      - name: Set up runner
-        uses: ./.github/actions/setUpRunner
-
-      - name: Set up Maven caches
-        uses: ./.github/actions/setUpMavenCaches
-        with:
-          kapua-artifact-cache-enabled: 'false'
-
-      - name: Build Kapua Javadoc
-        run: mvn -B -DskipTests install javadoc:jar

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -15,21 +15,16 @@ jobs:
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
-
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
-
       - name: Set up Maven caches
         uses: ./.github/actions/setUpMavenCaches
         with:
           kapua-artifact-cache-enabled: 'false'
-
       - name: Maven version
         run: mvn --version
-
       - name: Build Kapua project
         run: mvn -B -DskipTests clean install -T 1C
-
       - name: Save built Kapua Artifacts
         uses: ./.github/actions/saveBuiltKapuaArtifacts
 
@@ -41,15 +36,12 @@ jobs:
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
-
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
-
       - name: Set up Maven caches
         uses: ./.github/actions/setUpMavenCaches
         with:
           kapua-artifact-cache-enabled: 'false'
-
       - name: Build Kapua Javadoc
         run: mvn -B -DskipTests install javadoc:jar
 
@@ -81,6 +73,7 @@ jobs:
         with:
           tag: '@brokerAcl'
           needs-docker-images: 'true'
+
   test-tag:
     needs: build
     runs-on: ubuntu-latest
@@ -94,6 +87,7 @@ jobs:
         with:
           tag: '@tag'
           needs-docker-images: 'false'
+
   test-broker:
     needs: build
     runs-on: ubuntu-latest
@@ -107,6 +101,7 @@ jobs:
         with:
           tag: '@broker'
           needs-docker-images: 'true'
+
   test-device:
     needs: build
     runs-on: ubuntu-latest
@@ -120,6 +115,7 @@ jobs:
         with:
           tag: '@device'
           needs-docker-images: 'true'
+
   test-device-management:
     needs: build
     runs-on: ubuntu-latest
@@ -133,6 +129,7 @@ jobs:
         with:
           tag: '@deviceManagement'
           needs-docker-images: 'true'
+
   test-connection:
     needs: build
     runs-on: ubuntu-latest
@@ -146,6 +143,7 @@ jobs:
         with:
           tag: '@connection'
           needs-docker-images: 'true'
+
   test-datastore:
     needs: build
     runs-on: ubuntu-latest
@@ -159,6 +157,7 @@ jobs:
         with:
           tag: '@datastore'
           needs-docker-images: 'true'
+
   test-user:
     needs: build
     runs-on: ubuntu-latest
@@ -172,6 +171,7 @@ jobs:
         with:
           tag: '@user'
           needs-docker-images: 'false'
+
   test-userIntegrationBase:
     needs: build
     runs-on: ubuntu-latest
@@ -185,6 +185,7 @@ jobs:
         with:
           tag: '@userIntegrationBase'
           needs-docker-images: 'true'
+
   test-userIntegration:
     needs: build
     runs-on: ubuntu-latest
@@ -198,6 +199,7 @@ jobs:
         with:
           tag: '@userIntegration'
           needs-docker-images: 'true'
+
   test-security:
     needs: build
     runs-on: ubuntu-latest
@@ -211,6 +213,7 @@ jobs:
         with:
           tag: '@security'
           needs-docker-images: 'false'
+
   test-jobsAndScheduler:
     needs: build
     runs-on: ubuntu-latest
@@ -224,6 +227,7 @@ jobs:
         with:
           tag: '(@job or @scheduler) and not @it'
           needs-docker-images: 'false'
+
   test-job-IT:
     needs: build
     runs-on: ubuntu-latest
@@ -237,6 +241,7 @@ jobs:
         with:
           tag: '@job and @it'
           needs-docker-images: 'true'
+
   test-jobEngine-IT:
     needs: build
     runs-on: ubuntu-latest
@@ -250,6 +255,7 @@ jobs:
         with:
           tag: '@jobEngine'
           needs-docker-images: 'true'
+
   test-jobsIntegration:
     needs: build
     runs-on: ubuntu-latest
@@ -263,6 +269,7 @@ jobs:
         with:
           tag: '@jobsIntegration'
           needs-docker-images: 'true'
+
   test-accountAndTranslator:
     needs: build
     runs-on: ubuntu-latest
@@ -276,6 +283,7 @@ jobs:
         with:
           tag: '@account or @translator'
           needs-docker-images: 'false'
+
   test-RoleAndGroup:
     needs: build
     runs-on: ubuntu-latest
@@ -289,6 +297,7 @@ jobs:
         with:
           tag: '@role or @group'
           needs-docker-images: 'false'
+
   test-deviceRegistry:
     needs: build
     runs-on: ubuntu-latest
@@ -302,6 +311,7 @@ jobs:
         with:
           tag: '@deviceRegistry'
           needs-docker-images: 'true'
+
   test-endpoint:
     needs: build
     runs-on: ubuntu-latest
@@ -315,6 +325,7 @@ jobs:
         with:
           tag: '@endpoint'
           needs-docker-images: 'true'
+
   test-api-auth:
     needs: build
     runs-on: ubuntu-latest
@@ -329,6 +340,7 @@ jobs:
           tag: '@rest_auth'
           needs-docker-images: 'true'
           needs-api-docker-image: 'true'
+
   test-api-corsfilter:
     needs: test-endpoint # test suite dependent on the endpoint service (if it has failings it's useless to perform these tests)
     runs-on: ubuntu-latest
@@ -343,6 +355,7 @@ jobs:
           tag: '@rest_cors'
           needs-docker-images: 'true'
           needs-api-docker-image: 'true'
+
   test-api-parsing:
     needs: test-api-auth
     runs-on: ubuntu-latest

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -19,23 +19,8 @@ jobs:
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
 
-      - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
-        id: cache-maven-external-deps
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository/
-          key: ${{ runner.os }}-maven-develop-dependencies
-
-      - name: Cache Maven repository - Kapua artifacts # Cache of Kapua artifacts be reused in following jobs
-        id: cache-maven-kapua-artifacts
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/kapua-repository/org/eclipse/kapua
-          key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts
-
-      - name: Build full cached Maven repository # This adds the built Kapua artifact of this run to the cached repository of external dependencies. Used when re-running a job
-        if: steps.cache-maven-kapua-artifacts.outputs.cache-hit == 'true'
-        run: mv ~/.m2/kapua-repository/org/eclipse/kapua ~/.m2/repository/org/eclipse/kapua
+      - name: Set up Maven caches
+        uses: ./.github/actions/setUpMavenCaches
 
       - name: Maven version
         run: mvn --version
@@ -361,15 +346,14 @@ jobs:
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
+
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
 
-      - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
-        id: cache-maven-external-deps
-        uses: actions/cache@v4
+      - name: Set up Maven caches
+        uses: ./.github/actions/setUpMavenCaches
         with:
-          path: ~/.m2/repository/
-          key: ${{ runner.os }}-maven-develop-dependencies
+          kapua-artifact-cache-enabled: 'false'
 
       - name: Build Kapua Javadoc
         run: mvn -B -DskipTests install javadoc:jar

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -23,12 +23,10 @@ jobs:
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
 
-      - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
-        id: cache-maven-external-deps
-        uses: actions/cache@v4
+      - name: Set up Maven caches
+        uses: ./.github/actions/setUpMavenCaches
         with:
-          path: ~/.m2/repository/
-          key: ${{ runner.os }}-maven-develop-dependencies
+          kapua-artifact-cache-enabled: 'false'
 
       - name: Run Owasp Security Scan
         run: mvn -B ${BUILD_OPTS} -DskipTests -Psecurity-scan verify

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'develop'
       - 'release-**'
+      - 'feat-improvedGitHubActionCaching'
 
 env:
   BUILD_OPTS: ""
@@ -14,22 +15,32 @@ jobs:
   owasp-dependency-check:
     name: Owasp Dependency Check
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4 # Checks out a copy of the repository on the ubuntu-latest machine
-      - uses: actions/setup-java@v4
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v4
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
-          cache: 'maven'
-      - uses: actions/setup-node@v4 # Installs Node and NPM
+
+      - name: Setup Node 16
+        uses: actions/setup-node@v4 # Installs Node and NPM
         with:
           node-version: 16
+
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
-      - uses: actions/cache@v4 # Cache local Maven repository to reuse dependencies
+        shell: bash
+
+      - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
+        id: cache-maven-external-deps
+        uses: actions/cache@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - run: mvn -B ${BUILD_OPTS} -DskipTests -Psecurity-scan verify
+          path: ~/.m2/repository/
+          key: ${{ runner.os }}-maven-develop-dependencies
+
+      - name: Run Owasp Security Scan
+        run: mvn -B ${BUILD_OPTS} -DskipTests -Psecurity-scan verify

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - 'develop'
-      - 'release-**'
-      - 'feat-improvedGitHubActionCaching'
 
 env:
   BUILD_OPTS: ""

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -17,23 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
 
-      - name: Setup Java 11
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 11
-
-      - name: Setup Node 16
-        uses: actions/setup-node@v4 # Installs Node and NPM
-        with:
-          node-version: 16
-
-      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
-        run: 'npm install -g @apidevtools/swagger-cli'
-        shell: bash
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
 
       - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
         id: cache-maven-external-deps

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -4,12 +4,9 @@ on:
   push:
     branches:
       - 'develop'
-      - 'release-**'
-      - 'feat-improvedGitHubActionCaching'
   pull_request:
     branches:
       - 'develop'
-      - 'release-**'
 
 jobs:
   build:

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'develop'
       - 'release-**'
+      - 'feat-improvedGitHubActionCaching'
   pull_request:
     branches:
       - 'develop'
@@ -14,33 +15,39 @@ jobs:
   build:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Clones Kapua repo inside the runner
+        uses: actions/checkout@v4
+
+      - name: Setup Java 11
         uses: actions/setup-java@v4
         with:
-          java-version: 11
           distribution: 'zulu'
-      - name: Set up Node 16
-        uses: actions/setup-node@v4
+          java-version: 11
+
+      - name: Setup Node 16
+        uses: actions/setup-node@v4 # Installs Node and NPM
         with:
           node-version: 16
+
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
+        shell: bash
+
+      - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
+        id: cache-maven-external-deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/
+          key: ${{ runner.os }}-maven-develop-dependencies
+
       - name: Cache SonarQube packages
         uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -23,12 +23,10 @@ jobs:
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
 
-      - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
-        id: cache-maven-external-deps
-        uses: actions/cache@v4
+      - name: Set up Maven caches
+        uses: ./.github/actions/setUpMavenCaches
         with:
-          path: ~/.m2/repository/
-          key: ${{ runner.os }}-maven-develop-dependencies
+          kapua-artifact-cache-enabled: 'false'
 
       - name: Cache SonarQube packages
         uses: actions/cache@v4

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -17,23 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Clones Kapua repo inside the runner
+      - name: Checkout repository # Checks out a copy of the repository on the runner
         uses: actions/checkout@v4
 
-      - name: Setup Java 11
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: 11
-
-      - name: Setup Node 16
-        uses: actions/setup-node@v4 # Installs Node and NPM
-        with:
-          node-version: 16
-
-      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
-        run: 'npm install -g @apidevtools/swagger-cli'
-        shell: bash
+      - name: Set up runner
+        uses: ./.github/actions/setUpRunner
 
       - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
         id: cache-maven-external-deps


### PR DESCRIPTION
Improved the way and what gets cached as dependencies and built artifacts in used GitHub Actions workflows

**Related Issue**
_None_

**Description of the solution adopted**
Instead of having a cache per-build, which means that for each run we are downloading all dependencies for a job (unless restarting the same job), we switched to have 2 caches:

_Cache for external dependencies_

Named `Linux-maven-{branchName}-dependencies`, which will cache all `.m2/repository` but the artifacts under `.m2/repository/org/eclipse/kapua`. 

This cache will be per release branch/develop and can be reused by all workflows and for all branches that start from a release branch or develop.

A TODO is to have this cache have a time reference, like `{year}-{month}`, appended to it to make it rebuilt from time to time with updated dependencies.

Since filtering with exclude paths for `action/cache` is not working properly (see https://github.com/actions/toolkit/issues/713), exclusion is made by moving the folder outside of the maven repository.

 _Cache for built artifacts_ 
Named `Linux-maven-{github_action_run_id}-kapua-artifacts`, which will cache Kapua artifacts built during the run. This cache will be reused by all job from the same run test and other tasks

This cache is restored and then moved to `.m2/repository/org/eclipse/kapua` directory so it can be detected and reused by Maven

Benefit of this are:
- External dependencies are not download for every build.
- Cache size for each build is ~500MB for each run for built artifact and one that gets reused by all workflows of 400MB with external dependencies. 
  - Before, cache entry for each build : 
![Screenshot 2025-01-24 at 11 27 43](https://github.com/user-attachments/assets/97de5950-0fcc-410e-a84c-8900ed2bc233)
  - After, cache for each build + common external dependencies cache: 
![Screenshot 2025-01-24 at 11 28 04](https://github.com/user-attachments/assets/b28e759f-1937-45f3-9719-be654ea1bb93)
- All workflow have a unique cache for external depedendencies. Before we each workflow had its own cache key:
  - Sonar: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
  - Owasp: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }} but JDK setup was enabling cache, duplicating it
  - KapuaCI: {{ github.run_id }}-${{ github.run_number }}-maven-cache

**Screenshots**
_None_

**Any side note on the changes made**
Some clean up and optimization of jobs and action has been done to simplify management and avoid duplication of common parts