### PR TITLE
🐛 [Sonar] Disabled Sonar Scan for PR/Branches from forks due to missing SONAR_TOKEN not available for forks

### DIFF
--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - 'develop'
 
+env:
+  SONAR_TOKEN_AVAILABLE: ${{ secrets.SONAR_TOKEN != '' }}
+
 jobs:
   build:
     name: Analyze
@@ -32,8 +35,13 @@ jobs:
           key: ${{ runner.os }}-sonar
 
       - name: Build and analyze
+        if: ${{ env.SONAR_TOKEN_AVAILABLE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B compile -PsonarScan
+
+      - name: Skip Build and analyze
+        if: ${{ env.SONAR_TOKEN_AVAILABLE == 'false' }}
+        run: echo "Secret SONAR_TOKEN not available to this workflow run... Skipping analysis!"
 


### PR DESCRIPTION
Brief description of the PR.
Disabled Sonar Scan for PR/branches that are from forks. 
The `SONAR_TOKEN` is a secret of the main `eclipse-kapua/kapua` repo and for security reasons is not available for builds from forks.
Therefore is useless run the Sonar Scan for PR/branches in forks, since the sonar plugin is configured to run with orgname `eclipse`

The error occurring for all PR from forks is the following

```
Error:  Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar (default) on project kapua-assembly-job-engine: Error status returned by url [https://api.sonarcloud.io/analysis/jres?os=linux&arch=x86_64]: 401 -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :kapua-assembly-job-engine
Error: Process completed with exit code 1.
```

**Related Issue**
_None_

**Description of the solution adopted**
Added a condition to the run of the `Sonar Scan` to match only the main `eclipse-kapua/kapua` repository

**Screenshots**
_None_

**Any side note on the changes made**
_None_