### PR TITLE
:sparkles: [Docker] Migrated from rockylinux:8 to rockylinux:8-minimal base image

### DIFF
--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -16,9 +16,23 @@ FROM @docker.base.image@
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-openjdk
 
-RUN yum install -y java-11-openjdk && \
-    yum install -y curl && \
-    yum install -y openssl && \
+# Packages used for:
+#
+# Java 11: well is Java
+# curl: required to download jetty, H2 and others
+# openssl: SSL support
+# tar: Unpack archives
+# gzip: Unpack archives
+# shadow-utils: To run useradd command
+
+RUN microdnf install -y \
+    java-11-openjdk \
+    curl \
+    openssl \
+    tar \
+    gzip \
+    shadow-utils \
+    && \
     mkdir -p /opt/jolokia && \
     curl -s @jolokia.agent.url@ -o /opt/jolokia/jolokia-jvm-agent.jar
 

--- a/assembly/java-base/pom.xml
+++ b/assembly/java-base/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>kapua-assembly-java-base</artifactId>
 
     <properties>
-        <docker.base.image>rockylinux:8</docker.base.image>
+        <docker.base.image>rockylinux:8-minimal</docker.base.image>
         <jolokia.agent.url>https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.3.4/jolokia-jvm-1.3.4-agent.jar</jolokia.agent.url>
     </properties>
 


### PR DESCRIPTION
This PR changes the base image used to build our `java-base` image for Docker containers

Main scope of this change is to shrink our image footprint 

| Container                          | Size Rockylinux 8 | Size Rockylinux 8-minimal |
|------------------------------------|-------------------|---------------------------|
| kapua/java-base                    | 850 MB            | 640MB                     |
| kapua/jetty-base                   | 899 MB            | 689 MB                    |
| kapua/kapua-sql                    | 855 MB            | 645 MB                    |
| kapua/kapua-events-broker          | 1.11 GB           | 897 MB                    |
| kapua/kapua-api                    | 1.17 GB           | 955 MB                    |
| kapua/kapua-job-engine             | 1.13 GB           | 922 MB                    |
| kapua/kapua-broker-artemis         | 1.2 GB            | 992 MB                    |
| kapua/kapua-service-authentication | 976 MB            | 766 MB                    |
| kapua/kapua-consumer-lifecycle     | 990 MB            | 780 MB                    |
| kapua/kapua-consumer-telemetry     | 981 MB            | 771 MB                    |

The `java-base` image shrinks of 210 MB, which are saved for each of the Docker container that are using it (all of them).

Moving to `8-minimal` also decreases the number of vulnerabilities for our Docker images.

![Screenshot 2025-01-27 at 15 12 43](https://github.com/user-attachments/assets/f2a2c95b-ec3f-4684-8be1-da1ec900b23e)

**Related Issue**
_None_

**Description of the solution adopted**
- Changed the base image from `rockylinux:8` to `rockylinux:8-minimal`
- Updated `yum` commands to `microdnf`
- Installed required packages no longer in the base image
  - tar
  - gzip
  - shadow-utils

**Screenshots**
_None_

**Any side note on the changes made**
_None_