### PR TITLE
✨ [Docker] Migrated from rockylinux:8-minimal to rockylinux:9-minimal base image

### DIFF
--- a/assembly/java-base/pom.xml
+++ b/assembly/java-base/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>kapua-assembly-java-base</artifactId>
 
     <properties>
-        <docker.base.image>rockylinux:8-minimal</docker.base.image>
+        <docker.base.image>rockylinux:9-minimal</docker.base.image>
         <jolokia.agent.url>https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.3.4/jolokia-jvm-1.3.4-agent.jar</jolokia.agent.url>
     </properties>
 


### PR DESCRIPTION
This PR changes the base image used to build our `java-base` image for Docker containers

Main scope of this change is to move to a more recent base image and also improve Docker image footprint.

| Container                          | Size Rockylinux 8-minimal | Size Rockylinux 9-minimal |
|------------------------------------|---------------------------|---------------------------|
| kapua/java-base                    | 640MB                     | 610 MB                    |
| kapua/jetty-base                   | 689 MB                    | 659 MB                    |
| kapua/kapua-sql                    | 645 MB                    | 615 MB                    |
| kapua/kapua-events-broker          | 897 MB                    | 867 MB                    |
| kapua/kapua-api                    | 955 MB                    | 925 MB                    |
| kapua/kapua-job-engine             | 922 MB                    | 892 MB                    |
| kapua/kapua-broker-artemis         | 992 MB                    | 962 MB                    |
| kapua/kapua-service-authentication | 766 MB                    | 636 MB                    |
| kapua/kapua-consumer-lifecycle     | 780 MB                    | 750 MB                    |
| kapua/kapua-consumer-telemetry     | 771 MB                    | 741 MB                    |

The `java-base` image shrinks of 30 MB, which are saved for each of the Docker container that are using it (all of them).

Moving to `9-minimal` also decreases the number of vulnerabilities for our Docker images.

![Screenshot 2025-01-27 at 16 16 40](https://github.com/user-attachments/assets/acf3af91-c069-4f21-95a1-c6dd4fbcad55)
![Screenshot 2025-01-27 at 16 16 59](https://github.com/user-attachments/assets/ec323acd-d4af-42b1-a455-46468fb78389)


**Related Issue**
_None_

**Description of the solution adopted**
Updated the base image reference from `8-minimal` to `9-minimal`

**Screenshots**
_None_

**Any side note on the changes made**
_None_