### PR TITLE
:sparkles: [Docker] Migrated from java-11-openjdk to java-11-openjdk-headless JVM package

### DIFF
--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -26,7 +26,7 @@ ENV JAVA_HOME=/usr/lib/jvm/jre-openjdk
 # shadow-utils: To run useradd command
 
 RUN microdnf install -y \
-    java-11-openjdk \
+    java-11-openjdk-headless \
     curl \
     openssl \
     tar \


### PR DESCRIPTION
This PR changes the version of JDK 11 installed on our `java-base` image.

Moving to this JDK we optimize the Docker Image footprint

Comparison with standard version:

| Container                          | java-11-openjdk | java-11-openjdk-headless |
|------------------------------------|-----------------|--------------------------|
| kapua/java-base                    | 610 MB          | 591 MB                   |
| kapua/jetty-base                   | 659 MB          | 639 MB                   |
| kapua/kapua-sql                    | 615 MB          | 595 MB                   |
| kapua/kapua-events-broker          | 867 MB          | 848 MB                   |
| kapua/kapua-api                    | 925 MB          | 905 MB                   |
| kapua/kapua-job-engine             | 892 MB          | 873 MB                   |
| kapua/kapua-broker-artemis         | 962 MB          | 943 MB                   |
| kapua/kapua-service-authentication | 636 MB          | 716 MB                   |
| kapua/kapua-consumer-lifecycle     | 750 MB          | 730 MB                   |
| kapua/kapua-consumer-telemetry     | 741 MB          | 721 MB                   |

The java-base image shrinks of 19 MB, which are saved for each of the Docker container that are using it (all of them).

**Related Issue**
_None_

**Description of the solution adopted**
Replaced JDK 11 package installed from `java-11-openjdk` to `java-11-openjdk-headless`

**Screenshots**
_None_

**Any side note on the changes made**
_None_