### PR TITLE
✨ [Docker] Further Docker images footprints improvements

### DIFF
--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -30,7 +30,8 @@ RUN microdnf install -y \
     openssl \
     tar \
     gzip \
-    shadow-utils
+    shadow-utils && \
+    microdnf clean all
 
 # Install Jolokia agent
 RUN mkdir -p /opt/jolokia && \

--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,7 @@ FROM @docker.base.image@
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-openjdk
 
-# Packages used for:
+# Install packages
 #
 # Java 11: well is Java
 # curl: required to download jetty, H2 and others
@@ -24,16 +24,16 @@ ENV JAVA_HOME=/usr/lib/jvm/jre-openjdk
 # tar: Unpack archives
 # gzip: Unpack archives
 # shadow-utils: To run useradd command
-
 RUN microdnf install -y \
     java-11-openjdk-headless \
     curl \
     openssl \
     tar \
     gzip \
-    shadow-utils \
-    && \
-    mkdir -p /opt/jolokia && \
+    shadow-utils
+
+# Install Jolokia agent
+RUN mkdir -p /opt/jolokia && \
     curl -s @jolokia.agent.url@ -o /opt/jolokia/jolokia-jvm-agent.jar
 
 # Generate X509 certificate and private key

--- a/assembly/jetty-base/docker/Dockerfile
+++ b/assembly/jetty-base/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN useradd -u 1000 -g 0 -d '/var/opt/jetty' -s '/sbin/nologin' jetty && \
     curl -Ls @jetty.url@ -o /tmp/jetty.tar.gz && \
     tar --strip=1 -xzf /tmp/jetty.tar.gz -C /opt/jetty && \
     rm -f /tmp/jetty.tar.gz && \
+    rm -rf /opt/jetty/demo-base && \
     cd /var/opt/jetty && \
     java -jar /opt/jetty/start.jar --approve-all-licenses --create-startd --add-to-start=http,https,jsp,jstl,websocket,deploy,logging-logback,jmx,ssl,stats && \
     chown -R 1000:0 /opt/jetty /var/opt/jetty && \


### PR DESCRIPTION
This PR amis to further improve Docker images optimisation to reduce footprint of the images.

Optimisations have the following results

| Container                          | Before | After  |
|------------------------------------|--------|--------|
| kapua/java-base                    | 591 MB | 545 MB |
| kapua/jetty-base                   | 639 MB | 573 MB |
| kapua/kapua-sql                    | 595 MB | 549 MB |
| kapua/kapua-events-broker          | 848MB  | 802 MB |
| kapua/kapua-api                    | 905MB  | 838 MB |
| kapua/kapua-job-engine             | 873MB  | 806 MB |
| kapua/kapua-broker-artemis         | 943MB  | 897 MB |
| kapua/kapua-service-authentication | 716MB  | 670 MB |
| kapua/kapua-consumer-lifecycle     | 730MB  | 684 MB |
| kapua/kapua-consumer-telemetry     | 721MB  | 675 MB |

The java-base image shrinks of 46 MB, which are saved for each of the Docker container that are using it (all of them).

**Related Issue**
_None_

**Description of the solution adopted**
Optimization performed:

1. run `microdnf clean all` to remove all microdnf packages metadata 
2. removed `/opt/jetty/demo-base` directory, not needed in our `jetty-base` image

**Screenshots**
_None_

**Any side note on the changes made**
_None_