### PR TITLE
:bug: [CI] Fixed permissions assigned to 'License Checking' workflow

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -11,6 +11,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  pull-requests: write
+
 jobs:
   # Documentation: https://github.com/eclipse-dash/dash-licenses#reusable-github-workflow-for-automatic-license-check-and-ip-team-review-requests
   eclipse-dash-license-tool-run:


### PR DESCRIPTION
This PR fixed the permission given to the GITHUB_ACTION token for "License Check" workflow.

SInce 22nd January 2025 "License Check" workflow was failing with the following error

> [Invalid workflow file: .github/workflows/license-check.yaml#L16](https://github.com/eclipse-kapua/kapua/actions/runs/12888749175/workflow)
>The workflow is not valid. .github/workflows/license-check.yaml (Line: 16, Col: 3): Error calling workflow 'eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master'. The nested job 'check-licenses' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

**Related Issue**
_None_

**Description of the solution adopted**
Added missing permission to workflow

**Screenshots**
_None_

**Any side note on the changes made**
_None_