### PR TITLE
:sparkles: [REST API] Added parameter to API search for terminated and running executions

### DIFF
--- a/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
@@ -60,7 +60,7 @@ Feature: Job Execution service CRUD tests
       | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular job execution item
-    When I update the end time of the execution item
+    When I update the end time of the execution item as if the job finished now
     Then No exception was thrown
     When I search for the last job execution in the database
     Then The job execution items match
@@ -154,6 +154,24 @@ Feature: Job Execution service CRUD tests
   Scenario: Job execution factory sanity checks
 
     And I test the sanity of the job execution factory
+
+  Scenario: Update the end time of an existing execution item and see if status is computed correctly
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A regular job execution item
+    When I update the end time of the execution item as if the job finished now
+    Then No exception was thrown
+    When I search for the last job execution in the database
+    Then The job execution status is "TERMINATED"
+    When I update the end time of the execution item as if the job never finished
+    Then No exception was thrown
+    When I search for the last job execution in the database
+    Then The job execution status is "RUNNING"
 
   @teardown
   Scenario: Tear down test resources

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
@@ -113,15 +113,7 @@ public class JobExecutions extends AbstractKapuaResource {
         query.setOffset(offset);
         query.setLimit(limit);
 
-        JobExecutionListResult result = query(scopeId, jobId, query);
-        for (JobExecution je : result.getItems()) {
-            if (je.getEndedOn() != null) {
-                je.setStatus(JobStatus.TERMINATED);
-            } else {
-                je.setStatus(JobStatus.RUNNING);
-            }
-        }
-        return result;
+        return query(scopeId, jobId, query);
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
@@ -42,7 +42,7 @@ import org.eclipse.kapua.service.job.execution.JobExecutionFactory;
 import org.eclipse.kapua.service.job.execution.JobExecutionListResult;
 import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
 import org.eclipse.kapua.service.job.execution.JobExecutionService;
-import org.eclipse.kapua.service.job.execution.JobStatus;
+import org.eclipse.kapua.service.job.execution.JobExecutionStatus;
 import org.eclipse.kapua.service.job.targets.JobTargetFactory;
 import org.eclipse.kapua.service.job.targets.JobTargetListResult;
 import org.eclipse.kapua.service.job.targets.JobTargetQuery;
@@ -86,7 +86,7 @@ public class JobExecutions extends AbstractKapuaResource {
             @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit,
-            @QueryParam("status") JobStatus statusParam) throws KapuaException {
+            @QueryParam("status") JobExecutionStatus statusParam) throws KapuaException {
         JobExecutionQuery query = jobExecutionFactory.newQuery(scopeId);
 
         AndPredicate andPredicate = query.andPredicate(query.attributePredicate(JobExecutionAttributes.JOB_ID, jobId));
@@ -97,9 +97,9 @@ public class JobExecutions extends AbstractKapuaResource {
         if (endDateParam != null) {
             andPredicate.and(query.attributePredicate(JobExecutionAttributes.ENDED_ON, endDateParam.getDate(), AttributePredicate.Operator.LESS_THAN_OR_EQUAL));
         }
-        if (statusParam != null && statusParam.equals(JobStatus.RUNNING)) {
+        if (statusParam != null && statusParam.equals(JobExecutionStatus.RUNNING)) {
             andPredicate.and(query.attributePredicate(JobExecutionAttributes.ENDED_ON, null, AttributePredicate.Operator.IS_NULL));
-        } else if (statusParam != null && statusParam.equals(JobStatus.TERMINATED)) {
+        } else if (statusParam != null && statusParam.equals(JobExecutionStatus.TERMINATED)) {
             andPredicate.and(query.attributePredicate(JobExecutionAttributes.ENDED_ON, null, AttributePredicate.Operator.NOT_NULL));
         }
 

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions.yaml
@@ -35,6 +35,14 @@ paths:
             format: 'date-time'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
+        - name: status
+          in: query
+          description: status of job execution
+          schema:
+            type: string
+            enum:
+              - RUNNING
+              - TERMINATED
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/jobExecution.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/jobExecution.yaml
@@ -48,6 +48,12 @@ components:
               items:
                 allOf:
                 - $ref: '../openapi.yaml#/components/schemas/kapuaId'
+            status:
+                description: status of job execution
+                type: string
+                enum:
+                  - RUNNING
+                  - TERMINATED
           example:
             type: jobExecution
             id: GTh9xBWezHY

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -112,11 +112,11 @@ public interface JobExecution extends KapuaUpdatableEntity {
      * @return
      * @since 2.1.0
      */
-    JobStatus getStatus();
+    JobExecutionStatus getStatus();
 
     /**
      * @param status
      * @since 2.1.0
      */
-    void setStatus(JobStatus status);
+    void setStatus(JobExecutionStatus status);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -107,4 +107,16 @@ public interface JobExecution extends KapuaUpdatableEntity {
      * @since 1.1.0
      */
     void setLog(String log);
+
+    /**
+     * @return
+     * @since 2.1.0
+     */
+    JobStatus getStatus();
+
+    /**
+     * @param status
+     * @since 2.1.0
+     */
+    void setStatus(JobStatus status);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionStatus.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionStatus.java
@@ -15,7 +15,7 @@ package org.eclipse.kapua.service.job.execution;
 /**
  * @since 2.1.0
  */
-public enum JobStatus {
+public enum JobExecutionStatus {
 
     /**
      * @since 2.1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobStatus.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobStatus.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.execution;
+
+/**
+ * @since 2.1.0
+ */
+public enum JobStatus {
+
+    /**
+     * @since 2.1.0
+     */
+    RUNNING,
+
+    /**
+     * @since 2.1.0
+     */
+    TERMINATED
+}

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -176,7 +176,11 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
 
     @Override
     public JobStatus getStatus() {
-        return status;
+        if (this.getEndedOn() != null) {
+            return JobStatus.TERMINATED;
+        } else {
+            return JobStatus.RUNNING;
+        }
     }
 
     @Override

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.execution.JobExecution;
+import org.eclipse.kapua.service.job.execution.JobStatus;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
@@ -29,6 +30,7 @@ import javax.persistence.Lob;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.Transient;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -68,6 +70,10 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     @Lob
     @Column(name = "log", nullable = true, updatable = true)
     private String log;
+
+    @Transient
+    private JobStatus status;
+
 
     /**
      * Constructor.
@@ -166,5 +172,15 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     @Override
     public void setLog(String log) {
         this.log = log;
+    }
+
+    @Override
+    public JobStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public void setStatus(JobStatus status) {
+        this.status = status;
     }
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -16,7 +16,7 @@ import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.execution.JobExecution;
-import org.eclipse.kapua.service.job.execution.JobStatus;
+import org.eclipse.kapua.service.job.execution.JobExecutionStatus;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
@@ -72,7 +72,7 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     private String log;
 
     @Transient
-    private JobStatus status;
+    private JobExecutionStatus status;
 
 
     /**
@@ -175,16 +175,16 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     }
 
     @Override
-    public JobStatus getStatus() {
+    public JobExecutionStatus getStatus() {
         if (this.getEndedOn() != null) {
-            return JobStatus.TERMINATED;
+            return JobExecutionStatus.TERMINATED;
         } else {
-            return JobStatus.RUNNING;
+            return JobExecutionStatus.RUNNING;
         }
     }
 
     @Override
-    public void setStatus(JobStatus status) {
+    public void setStatus(JobExecutionStatus status) {
         this.status = status;
     }
 }


### PR DESCRIPTION
A user may want to search for Terminated and/or Running executions without knowing the implementation detail that:

A jobExecution is running if endDate is undefined

A jobExecution is terminated if endDate is defined

Moreover the GET /{scopeId}/jobs/{jobId}/executions API does not have the capability to express a condition like ‘endDate is undefined’. Even with the trick of the endDate a user should first retrieve all the executions and then scan them one by one to decide the status based on the endDate.

To overcome this limitations, I wanted to introduce a new parameter in the REST API:

**status**

that can take the value of TERMINATED or RUNNING

The status should be represented in the returned model object otherwise the UI or the user is still unable to determine the status without knowing the implementation detail. At this stage there’s no need to persist the status in the DB, it can be a transient field.