### PR TITLE
🐛 [User] Fixed bugs on duplicate external SSO users creation and update

### DIFF
--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -126,7 +126,7 @@ public class UserServiceImpl extends KapuaConfigurableServiceBase implements Use
 
                 // Check duplicate externalUsername
                 if (userCreator.getExternalUsername() != null) {
-                    Optional<User> userByExternalPreferredUserame = userRepository.findByExternalId(tx, userCreator.getExternalUsername());
+                    Optional<User> userByExternalPreferredUserame = userRepository.findByExternalUsername(tx, userCreator.getExternalUsername());
                     if (userByExternalPreferredUserame.isPresent()) {
                         throw new KapuaDuplicateExternalUsernameException(userCreator.getExternalUsername());
                     }
@@ -209,7 +209,7 @@ public class UserServiceImpl extends KapuaConfigurableServiceBase implements Use
                     if (user.getExternalId() != null) {
                         if (userRepository.findByExternalId(tx, user.getExternalId())
                                 .map(u -> u.getId())
-                                .map(id -> id.equals(user.getId()))
+                                .map(id -> !(id.equals(user.getId())))
                                 .orElse(false)) {
                             throw new KapuaDuplicateExternalIdException(user.getExternalId());
                         }
@@ -217,9 +217,9 @@ public class UserServiceImpl extends KapuaConfigurableServiceBase implements Use
 
                     // User.externalUsername
                     if (user.getExternalUsername() != null) {
-                        if (userRepository.findByExternalId(tx, user.getExternalUsername())
+                        if (userRepository.findByExternalUsername(tx, user.getExternalUsername())
                                 .map(u -> u.getId())
-                                .map(id -> id.equals(user.getId()))
+                                .map(id -> !(id.equals(user.getId())))
                                 .orElse(false)) {
                             throw new KapuaDuplicateExternalUsernameException(user.getExternalUsername());
                         }


### PR DESCRIPTION
There were some problems when trying to create an already existing external user with the same _externalUsername_ parameter: the back-end was allowing the operation. Other than that, It was not possible to update an external username, for example changing its e-mail, because the back-end was complaining about an already present user in the system.

I solved the issue changing the Userservice accordingly: other than fixing a method reference to findByExternalId that needed to be findByExternalUsername, I fixed the logic of searching duplicate users by externalIds and externalUsernames