### PR TITLE
:recycle: [Device Manageemnt] Simplified DeviceCall interface

### DIFF
--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCall.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCall.java
@@ -42,7 +42,9 @@ public interface DeviceCall<RQ extends DeviceRequestMessage<?, ?>, RS extends De
      * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
      * @throws DeviceCallSendException    if sending the request produces any error.
      * @since 1.0.0
+     * @deprecated Since 2.1.0. Just use {@link #send(DeviceRequestMessage, Long)}
      */
+    @Deprecated
     RS read(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
 
     /**
@@ -54,7 +56,9 @@ public interface DeviceCall<RQ extends DeviceRequestMessage<?, ?>, RS extends De
      * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
      * @throws DeviceCallSendException    if sending the request produces any error.
      * @since 1.0.0
+     * @deprecated Since 2.1.0. Just use {@link #send(DeviceRequestMessage, Long)}
      */
+    @Deprecated
     RS create(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
 
     /**
@@ -66,7 +70,9 @@ public interface DeviceCall<RQ extends DeviceRequestMessage<?, ?>, RS extends De
      * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
      * @throws DeviceCallSendException    if sending the request produces any error.
      * @since 1.0.0
+     * @deprecated Since 2.1.0. Just use {@link #send(DeviceRequestMessage, Long)}
      */
+    @Deprecated
     RS write(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
 
     /**
@@ -78,7 +84,9 @@ public interface DeviceCall<RQ extends DeviceRequestMessage<?, ?>, RS extends De
      * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
      * @throws DeviceCallSendException    if sending the request produces any error.
      * @since 1.0.0
+     * @deprecated Since 2.1.0. Just use {@link #send(DeviceRequestMessage, Long)}
      */
+    @Deprecated
     RS delete(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
 
     /**
@@ -90,7 +98,9 @@ public interface DeviceCall<RQ extends DeviceRequestMessage<?, ?>, RS extends De
      * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
      * @throws DeviceCallSendException    if sending the request produces any error.
      * @since 1.0.0
+     * @deprecated Since 2.1.0. Just use {@link #send(DeviceRequestMessage, Long)}
      */
+    @Deprecated
     RS execute(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
 
     /**
@@ -102,7 +112,9 @@ public interface DeviceCall<RQ extends DeviceRequestMessage<?, ?>, RS extends De
      * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
      * @throws DeviceCallSendException    if sending the request produces any error.
      * @since 1.0.0
+     * @deprecated Since 2.1.0. Just use {@link #send(DeviceRequestMessage, Long)}
      */
+    @Deprecated
     RS options(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
 
     /**
@@ -115,7 +127,9 @@ public interface DeviceCall<RQ extends DeviceRequestMessage<?, ?>, RS extends De
      * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
      * @throws DeviceCallSendException    if sending the request produces any error.
      * @since 1.3.0
+     * @deprecated Since 2.1.0. Just use {@link #send(DeviceRequestMessage, Long)}
      */
+    @Deprecated
     RS submit(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
 
     /**
@@ -128,8 +142,22 @@ public interface DeviceCall<RQ extends DeviceRequestMessage<?, ?>, RS extends De
      * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
      * @throws DeviceCallSendException    if sending the request produces any error.
      * @since 1.3.0
+     * @deprecated Since 2.1.0. Just use {@link #send(DeviceRequestMessage, Long)}
      */
+    @Deprecated
     RS cancel(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
+
+    /**
+     * Sends the request message
+     *
+     * @param requestMessage The {@link DeviceRequestMessage} to send.
+     * @param timeout        The timeout of the request.
+     * @throws DeviceCallTimeoutException if waiting of the response goes on timeout.
+     * @throws DeviceCallSendException    if sending the request produces any error.
+     * @throws TransportException
+     * @since 2.1.0
+     */
+    RS send(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;
 
     /**
      * Get the {@link DeviceMessage} type.

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallImpl.java
@@ -124,6 +124,12 @@ public class KuraDeviceCallImpl implements DeviceCall<KuraRequestMessage, KuraRe
     }
 
     @Override
+    public KuraResponseMessage send(KuraRequestMessage requestMessage, @Nullable Long timeout)
+            throws DeviceCallTimeoutException, DeviceCallSendException, TransportException {
+        return sendInternal(requestMessage, timeout);
+    }
+
+    @Override
     public Class<KuraMessage> getBaseMessageClass() {
         return KuraMessage.class;
     }

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallBuilder.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallBuilder.java
@@ -25,7 +25,6 @@ import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestMe
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponseMessage;
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
-import org.eclipse.kapua.service.device.management.exception.DeviceManagementRequestBadMethodException;
 import org.eclipse.kapua.service.device.management.exception.DeviceManagementSendException;
 import org.eclipse.kapua.service.device.management.exception.DeviceManagementTimeoutException;
 import org.eclipse.kapua.service.device.management.exception.DeviceNeverConnectedException;
@@ -147,41 +146,10 @@ public class DeviceCallBuilder<C extends KapuaRequestChannel, P extends KapuaReq
             DeviceCall<DeviceRequestMessage<?, ?>, DeviceResponseMessage<?, ?>> deviceCall = deviceCallFactory.newDeviceCall();
             Translator<RQ, DeviceRequestMessage<?, ?>> tKapuaToClient = translatorHub.getTranslatorFor(requestMessage.getRequestClass(), deviceCall.getBaseMessageClass());
             DeviceRequestMessage<?, ?> deviceRequestMessage = tKapuaToClient.translate(requestMessage);
+
             // Send the request
-            DeviceResponseMessage<?, ?> responseMessage;
-            switch (requestMessage.getChannel().getMethod()) {
-                case CREATE:
-                case POST:
-                    responseMessage = deviceCall.create(deviceRequestMessage, timeout);
-                    break;
-                case READ:
-                case GET:
-                    responseMessage = deviceCall.read(deviceRequestMessage, timeout);
-                    break;
-                case OPTIONS:
-                    responseMessage = deviceCall.options(deviceRequestMessage, timeout);
-                    break;
-                case DELETE:
-                case DEL:
-                    responseMessage = deviceCall.delete(deviceRequestMessage, timeout);
-                    break;
-                case EXECUTE:
-                case EXEC:
-                    responseMessage = deviceCall.execute(deviceRequestMessage, timeout);
-                    break;
-                case WRITE:
-                case PUT:
-                    responseMessage = deviceCall.write(deviceRequestMessage, timeout);
-                    break;
-                case SUBMIT:
-                    responseMessage = deviceCall.submit(deviceRequestMessage, timeout);
-                    break;
-                case CANCEL:
-                    responseMessage = deviceCall.cancel(deviceRequestMessage, timeout);
-                    break;
-                default:
-                    throw new DeviceManagementRequestBadMethodException(requestMessage.getChannel().getMethod());
-            }
+            DeviceResponseMessage<?, ?> responseMessage = deviceCall.send(deviceRequestMessage, timeout);
+
             // Translate the response from Device to Kapua
             Translator<DeviceResponseMessage<?, ?>, RS> tClientToKapua = translatorHub.getTranslatorFor(deviceCall.getBaseMessageClass(), requestMessage.getResponseClass());
             return tClientToKapua.translate(responseMessage);
@@ -213,40 +181,10 @@ public class DeviceCallBuilder<C extends KapuaRequestChannel, P extends KapuaReq
             DeviceCall<DeviceRequestMessage<?, ?>, DeviceResponseMessage<?, ?>> deviceCall = deviceCallFactory.newDeviceCall();
             Translator<RQ, DeviceRequestMessage<?, ?>> tKapuaToClient = translatorHub.getTranslatorFor(requestMessage.getRequestClass(), deviceCall.getBaseMessageClass());
             DeviceRequestMessage<?, ?> deviceRequestMessage = tKapuaToClient.translate(requestMessage);
+
             // Send the request
-            switch (requestMessage.getChannel().getMethod()) {
-                case CREATE:
-                case POST:
-                    deviceCall.create(deviceRequestMessage, null);
-                    break;
-                case READ:
-                case GET:
-                    deviceCall.read(deviceRequestMessage, null);
-                    break;
-                case OPTIONS:
-                    deviceCall.options(deviceRequestMessage, null);
-                    break;
-                case DELETE:
-                case DEL:
-                    deviceCall.delete(deviceRequestMessage, null);
-                    break;
-                case EXECUTE:
-                case EXEC:
-                    deviceCall.execute(deviceRequestMessage, null);
-                    break;
-                case WRITE:
-                case PUT:
-                    deviceCall.write(deviceRequestMessage, null);
-                    break;
-                case SUBMIT:
-                    deviceCall.submit(deviceRequestMessage, null);
-                    break;
-                case CANCEL:
-                    deviceCall.cancel(deviceRequestMessage, null);
-                    break;
-                default:
-                    throw new DeviceManagementRequestBadMethodException(requestMessage.getChannel().getMethod());
-            }
+            deviceCall.send(deviceRequestMessage, null);
+
         } catch (TransportException te) {
             throw te;
         } catch (Exception e) {


### PR DESCRIPTION
This PR simplifies the DeviceCall interface that does not need many entries that in its implementation invoke the same internal method

**Related Issue**
_None_

**Description of the solution adopted**
Added new ` RS send(@NotNull RQ requestMessage, @Nullable Long timeout) throws DeviceCallTimeoutException, DeviceCallSendException, TransportException;` which replaces all other methods

**Screenshots**
_None_

**Any side note on the changes made**
_None_