### PR TITLE
:sparkles: [Device Management] Allowed for empty AppId and method

### DIFF
--- a/translator/kura/mqtt/src/main/java/org/eclipse/kapua/translator/kura/mqtt/TranslatorRequestKuraMqtt.java
+++ b/translator/kura/mqtt/src/main/java/org/eclipse/kapua/translator/kura/mqtt/TranslatorRequestKuraMqtt.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.translator.kura.mqtt;
 
+import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestChannel;
@@ -85,8 +86,14 @@ public class TranslatorRequestKuraMqtt extends Translator<KuraRequestMessage, Mq
 
             topicTokens.add(kuraRequestChannel.getScope());
             topicTokens.add(kuraRequestChannel.getClientId());
-            topicTokens.add(kuraRequestChannel.getAppId());
-            topicTokens.add(kuraRequestChannel.getMethod().name());
+
+            if (!Strings.isNullOrEmpty(kuraRequestChannel.getAppId())) {
+                topicTokens.add(kuraRequestChannel.getAppId());
+            }
+
+            if (kuraRequestChannel.getMethod() != null) {
+                topicTokens.add(kuraRequestChannel.getMethod().name());
+            }
 
             Collections.addAll(topicTokens, kuraRequestChannel.getResources());
 


### PR DESCRIPTION
This PR makes optional the app_id and the method with sending a request to a Device

**Related Issue**
_None_

**Description of the solution adopted**
Not adding appId and method to the final topic if not specified

**Screenshots**
_None_

**Any side note on the changes made**
_None_