### PR TITLE
:sparkles: [Account] Addded `findParentId` to `AccountRelativeFinder`

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AccountRelativeFinder.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AccountRelativeFinder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,10 @@ package org.eclipse.kapua.commons.configuration;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountListResult;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +34,7 @@ public interface AccountRelativeFinder extends KapuaService {
      * @param targetScopeId - nullable target scope id
      * @return the list of child accounts
      * @throws KapuaException
+     * @since 2.0.0
      */
     AccountListResult findChildren(KapuaId scopeId, Optional<KapuaId> targetScopeId) throws KapuaException;
 
@@ -39,6 +42,17 @@ public interface AccountRelativeFinder extends KapuaService {
      * @param accountId    The id of the account to lookup
      * @return             The list of parent ids for the target account
      * @throws KapuaException
+     * @since 2.1.0
      */
     List<KapuaId> findParentIds(KapuaId accountId) throws KapuaException;
+
+    /**
+     * Gets the {@link Account#getScopeId()} which is the parent {@link Account} of the given {@link Account#getId()}
+     *
+     * @param accountId The {@link Account#getId()} to search for parent
+     * @return The parent {@link Account#getId()}
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    KapuaId findParentId(@NotNull KapuaId accountId) throws KapuaException;
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountRelativeFinderImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountRelativeFinderImpl.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
@@ -84,5 +85,16 @@ public class AccountRelativeFinderImpl implements AccountRelativeFinder, KapuaSe
         }
 
         return parentAccountIds;
+    }
+
+    @Override
+    public KapuaId findParentId(KapuaId accountId) throws KapuaException {
+        Account account = KapuaSecurityUtils.doPrivileged(() -> accountService.find(accountId));
+
+        if(account == null){
+            throw new KapuaEntityNotFoundException(Account.TYPE, accountId);
+        }
+
+        return account.getScopeId();
     }
 }


### PR DESCRIPTION
Added a new method to resolve direct parent of an Account

**Related Issue**
_None_

**Description of the solution adopted**
Added a new method that resolves the given `Account.id` into its `Account.scopeId`

**Screenshots**
_None_

**Any side note on the changes made**
_None_