### PR TITLE
:bug: [Assembly] Fixed warning on assembly projects build

### DIFF
--- a/assembly/api/descriptors/kapua-api-jetty.xml
+++ b/assembly/api/descriptors/kapua-api-jetty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2022 Red Hat Inc and others
+    Copyright (c) 2017, 2025 Red Hat Inc and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/assembly/api/entrypoint/run-api
+++ b/assembly/api/entrypoint/run-api
@@ -1,6 +1,6 @@
 #!/bin/sh
 ################################################################################
-#    Copyright (c) 2024, 2022 Red Hat Inc and others
+#    Copyright (c) 2024, 2025 Red Hat Inc and others
 #
 #    This program and the accompanying materials are made
 #    available under the terms of the Eclipse Public License 2.0

--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -22,8 +22,8 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-api</artifactId>
+    <packaging>pom</packaging>
 
     <properties>
         <swagger-cli.executable>swagger-cli</swagger-cli.executable>
@@ -301,7 +301,6 @@
                                 <descriptor>${project.basedir}/descriptors/kapua-api-jetty.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
-                            <finalName>kapua-api-${project.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>

--- a/assembly/broker-artemis/descriptors/kapua-broker-artemis.xml
+++ b/assembly/broker-artemis/descriptors/kapua-broker-artemis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/assembly/broker-artemis/descriptors/kapua-broker-artemis.xml
+++ b/assembly/broker-artemis/descriptors/kapua-broker-artemis.xml
@@ -25,7 +25,7 @@
     <files>
         <file>
             <source>${project.basedir}/entrypoint/run-broker</source>
-            <outputDirectory>/opt/artemis</outputDirectory>
+            <outputDirectory>opt/artemis</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
     </files>
@@ -33,7 +33,7 @@
     <fileSets>
         <!-- Expanded ActiveMQ Runtime -->
         <fileSet>
-            <outputDirectory>/opt/artemis</outputDirectory>
+            <outputDirectory>opt/artemis</outputDirectory>
             <directory>${project.build.directory}/dependencies/artemis/apache-artemis-${artemis.version}</directory>
             <fileMode>0644</fileMode>
             <excludes>
@@ -109,7 +109,6 @@
                 <include>com.google.guava:failureaccess</include>
                 <include>com.google.guava:guava</include>
                 <include>com.google.guava:listenablefuture</include>
-                <include>com.google.inject.extensions:guice-multibindings</include>
                 <include>com.google.inject:guice</include>
                 <include>com.warrenstrange:googleauth</include>
                 <include>javax.cache:cache-api</include>

--- a/assembly/broker-artemis/docker/Dockerfile
+++ b/assembly/broker-artemis/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2021 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker-artemis/entrypoint/run-broker
+++ b/assembly/broker-artemis/entrypoint/run-broker
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ################################################################################
-#    Copyright (c) 2017, 2018 Eurotech
+#    Copyright (c) 2017, 2025 Eurotech
 #
 #    All rights reserved. This program and the accompanying materials
 #    are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker-artemis/pom.xml
+++ b/assembly/broker-artemis/pom.xml
@@ -222,7 +222,6 @@
                                 <descriptor>descriptors/kapua-broker-artemis.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
-                            <finalName>kapua-broker-artemis-${project.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>

--- a/assembly/broker-artemis/pom.xml
+++ b/assembly/broker-artemis/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -21,8 +21,8 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-broker-artemis</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/assembly/console/descriptors/kapua-console-jetty.xml
+++ b/assembly/console/descriptors/kapua-console-jetty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2022 Red Hat Inc and others
+    Copyright (c) 2017, 2025 Red Hat Inc and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/assembly/console/docker/Dockerfile
+++ b/assembly/console/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/assembly/console/entrypoint/run-console
+++ b/assembly/console/entrypoint/run-console
@@ -1,6 +1,6 @@
 #!/bin/sh
 ################################################################################
-#    Copyright (c) 2017, 2022 Red Hat Inc and others
+#    Copyright (c) 2017, 2025 Red Hat Inc and others
 #
 #    This program and the accompanying materials are made
 #    available under the terms of the Eclipse Public License 2.0

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2022 Red Hat Inc and others
+    Copyright (c) 2017, 2025 Red Hat Inc and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -22,8 +22,8 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-console</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
@@ -223,7 +223,6 @@
                                 <descriptor>${project.basedir}/descriptors/kapua-console-jetty.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
-                            <finalName>kapua-console-${project.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>

--- a/assembly/consumer/lifecycle/pom.xml
+++ b/assembly/consumer/lifecycle/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -14,14 +14,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-assembly-consumer</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-assembly-consumer-lifecycle</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/assembly/consumer/pom.xml
+++ b/assembly/consumer/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -21,16 +21,16 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-consumer</artifactId>
+    <packaging>pom</packaging>
 
     <properties>
         <docker.account>kapua</docker.account>
     </properties>
 
     <modules>
-        <module>telemetry</module>
         <module>lifecycle</module>
+        <module>telemetry</module>
     </modules>
 
     <dependencyManagement>

--- a/assembly/consumer/telemetry/pom.xml
+++ b/assembly/consumer/telemetry/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -15,14 +15,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-assembly-consumer</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-assembly-consumer-telemetry</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/assembly/events-broker/docker/Dockerfile
+++ b/assembly/events-broker/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2021 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/pom.xml
+++ b/assembly/events-broker/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2022 Red Hat Inc and others
+    Copyright (c) 2017, 2025 Red Hat Inc and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
         Eurotech
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,8 +23,8 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-events-broker</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
@@ -56,7 +57,6 @@
                                 <descriptor>descriptors/kapua-events-broker.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
-                            <finalName>kapua-events-broker-${project.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>

--- a/assembly/job-engine/descriptors/kapua-job-engine-jetty.xml
+++ b/assembly/job-engine/descriptors/kapua-job-engine-jetty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2022 Red Hat Inc and others
+    Copyright (c) 2017, 2025 Red Hat Inc and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/assembly/job-engine/docker/Dockerfile
+++ b/assembly/job-engine/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/assembly/job-engine/pom.xml
+++ b/assembly/job-engine/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-assembly-job-engine</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <!-- Kapua dependencies -->
@@ -61,7 +62,6 @@
                                 <descriptor>${project.basedir}/descriptors/kapua-job-engine-jetty.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
-                            <finalName>kapua-job-engine-${project.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>

--- a/assembly/service/authentication/descriptors/kapua-service-authentication.xml
+++ b/assembly/service/authentication/descriptors/kapua-service-authentication.xml
@@ -35,7 +35,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/configurations</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <fileMode>0644</fileMode>
         </fileSet>
     </fileSets>

--- a/assembly/service/authentication/docker/Dockerfile
+++ b/assembly/service/authentication/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/service/authentication/entrypoint/run-service-authentication
+++ b/assembly/service/authentication/entrypoint/run-service-authentication
@@ -1,6 +1,6 @@
 #!/bin/sh
 ################################################################################
-#    Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+#    Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
 #
 #    All rights reserved. This program and the accompanying materials
 #    are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/service/authentication/pom.xml
+++ b/assembly/service/authentication/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -14,14 +14,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-assembly-service</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-assembly-service-authentication</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -482,12 +482,14 @@
                         <configLocation>checkstyle/kapua.xml</configLocation>
                         <suppressionsLocation>checkstyle/kapua.suppressions.xml</suppressionsLocation>
 
-                        <includeResources>false</includeResources>
-                        <includeTestResources>false</includeTestResources>
+                        <sourceDirectories>
+                            <sourceDirectory>${project.basedir}</sourceDirectory>
+                        </sourceDirectories>
 
-                        <sourceDirectory>${project.basedir}</sourceDirectory>
                         <includes>**/*.java, **/*.xml</includes>
                         <excludes>**/target/**/*, **/.settings/**/*, maven/**/*, .maven/**/*, .idea/**/*, **/node/**/*</excludes>
+                        <includeResources>false</includeResources>
+                        <includeTestResources>false</includeTestResources>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Fixed ew warnings reported by maven and maven plugins when building `kapua-assembly-*` projects

**Related Issue**
_None_

**Description of the solution adopted**
Fixed following warnings:
- `sourceDirectory' is deprecated: instead use 'sourceDirectories'` reported by checkstyle plugin
- `The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible`
- `The following patterns were never triggered in this artifact inclusion filter`
- `NoEmptyContinuation: Empty continuation line`

**Screenshots**
_None_

**Any side note on the changes made**
_None_