### PR TITLE
:bug: [Broker] Fixed logic for DeviceConnection unbound coupling when reserved user is set

### DIFF
--- a/qa/integration/src/test/resources/features/connection/UserCouplingI9n.feature
+++ b/qa/integration/src/test/resources/features/connection/UserCouplingI9n.feature
@@ -1326,16 +1326,18 @@ Feature: User Coupling
     Given The account name is "test-acc-1" and the client ID is "device-2"
     And The broker URI is "tcp://test-user-1:KeepCalm123.@localhost:1883"
     When I start the simulator
-    And I search for a connection from the device "device-2" in account "test-acc-1" I find 1 connection with status "CONNECTED" and user "test-user-1" within 10 seconds
-    Then I stop the simulator
     And I wait for 2 seconds
+    When I search for a connection from the device "device-2" in account "test-acc-1"
+    Then I find 1 connection
+    And The connection status is "DISCONNECTED"
 
     Given The account name is "test-acc-1" and the client ID is "device-2"
     And The broker URI is "tcp://test-user-3:KeepCalm123.@localhost:1883"
     When I start the simulator
-    And I search for a connection from the device "device-2" in account "test-acc-1" I find 1 connection with status "CONNECTED" and user "test-user-3" within 10 seconds
-    Then I stop the simulator
     And I wait for 2 seconds
+    When I search for a connection from the device "device-2" in account "test-acc-1"
+    Then I find 1 connection
+    And The connection status is "DISCONNECTED"
 
     Given The account name is "test-acc-1" and the client ID is "device-3"
     And The broker URI is "tcp://test-user-2:KeepCalm123.@localhost:1883"

--- a/service/authentication/src/main/java/org/eclipse/kapua/service/authentication/authentication/AuthenticationLogic.java
+++ b/service/authentication/src/main/java/org/eclipse/kapua/service/authentication/authentication/AuthenticationLogic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -44,7 +44,7 @@ import java.util.Map;
 /**
  * Authentication logic definition
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public abstract class AuthenticationLogic {
 
@@ -205,8 +205,13 @@ public abstract class AuthenticationLogic {
                 }
             }
         } else {
-            if (deviceConnection != null && deviceConnection.getReservedUserId() != null && userId.equals(deviceConnection.getReservedUserId())) {
-                checkConnectionCountByReservedUserId(scopeId, userId, 1);
+            if (deviceConnection != null && deviceConnection.getReservedUserId() != null) {
+                if (userId.equals(deviceConnection.getReservedUserId())) {
+                    checkConnectionCountByReservedUserId(scopeId, userId, 1);
+                }
+                else {
+                    throw new SecurityException(USER_NOT_AUTHORIZED + " DeviceConnection cannot use User different from reserved User!");
+                }
             } else {
                 checkConnectionCountByReservedUserId(scopeId, userId, 0);
             }


### PR DESCRIPTION
Currently if the `DeviceConnection.userCoupling` is `LOOSE` but the `DeviceConnection.reservedUser` is set the DeviceConnection is allowed to connect with any username. 

This is incorrect since the `reservedUser` should be always honored

**Related Issue**
_None_

**Description of the solution adopted**
Changed the logic ho always honor the `DeviceConnection.reservedUser` 

**Screenshots**
_None_

**Any side note on the changes made**
_None_