### PR TITLE
🐛 [REST API] Fixed XML mapping for `ServiceConfiguration*ExceptionInfo` `scopeId` property

### DIFF
--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/ServiceConfigurationLimitExceededExceptionInfo.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/ServiceConfigurationLimitExceededExceptionInfo.java
@@ -14,12 +14,14 @@ package org.eclipse.kapua.commons.rest.model.errors;
 
 import org.eclipse.kapua.commons.configuration.exception.ServiceConfigurationLimitExceededException;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @XmlRootElement(name = "serviceConfigurationLimitExceededExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -30,6 +32,7 @@ public class ServiceConfigurationLimitExceededExceptionInfo extends ExceptionInf
     private String servicePid;
 
     @XmlElement(name = "scopeId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     private KapuaId scopeId;
 
     @XmlElement(name = "limitExceededBy")

--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/ServiceConfigurationParentLimitExceededExceptionInfo.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/ServiceConfigurationParentLimitExceededExceptionInfo.java
@@ -14,12 +14,14 @@ package org.eclipse.kapua.commons.rest.model.errors;
 
 import org.eclipse.kapua.commons.configuration.exception.ServiceConfigurationParentLimitExceededException;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @XmlRootElement(name = "serviceConfigurationParentLimitExceededExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -30,7 +32,7 @@ public class ServiceConfigurationParentLimitExceededExceptionInfo extends Except
     private String servicePid;
 
     @XmlElement(name = "parentScopeId")
-
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     private KapuaId parentScopeId;
 
     @XmlElement(name = "limitExceededBy")

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -718,50 +718,6 @@ components:
         message: "An illegal value was provided for the argument user.email: null"
         kapuaErrorCode: "ILLEGAL_NULL_ARGUMENT"
         argumentName: "user.email"
-    ServiceConfigurationLimitExceededExceptionInfo:
-      description: The update of the configuration for the service exceeds available resources of the current scope
-      allOf:
-        - $ref: '#/components/schemas/exceptionInfo'
-        - properties:
-            scopeId:
-              description: The scope for which limit has been exceeded
-              $ref: '#/components/schemas/kapuaId'
-            servicePid:
-              type: string
-              description: The Pid of the service
-            limitExceededBy:
-              type: string
-              description: The amount of excess
-      example:
-        type: "ServiceConfigurationLimitExceededExceptionInfo"
-        httpErrorCode: 400
-        message: "The maximum of resources for the org.eclipse.kapua.service.account.AccountService service for the account 2 has been exceeded. The resource limit is exceeded by 3."
-        kapuaErrorCode: "LIMIT_EXCEEDED"
-        scopeId: 2
-        servicePid: "org.eclipse.kapua.service.account.AccountService"
-        limitExceededBy: 3
-    ServiceConfigurationParentLimitExceededExceptionInfo:
-      description: The update of the configuration for the service exceeds available resources of the parent scope
-      allOf:
-        - $ref: '#/components/schemas/exceptionInfo'
-        - properties:
-            parentScopeId:
-              description: The parent scope for which limit has been exceeded
-              $ref: '#/components/schemas/kapuaId'
-            servicePid:
-              type: string
-              description: The Pid of the service
-            limitExceededBy:
-              type: string
-              description: The amount of excess
-      example:
-        type: "ServiceConfigurationLimitExceededExceptionInfo"
-        httpErrorCode: 400
-        message: "The maximum of resources for the org.eclipse.kapua.service.account.AccountService service for the parent account 2 has been exceeded."
-        kapuaErrorCode: "PARENT_LIMIT_EXCEEDED"
-        scopeId: 2
-        servicePid: "org.eclipse.kapua.service.account.AccountService"
-        limitExceededBy: 3
     entityUniquenessExceptionInfo:
       description: The object to represent the fact that an Entity with the same unique fields is already present in the system
       allOf:
@@ -1200,6 +1156,10 @@ components:
       $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/option'
     serviceAttributeDefinition:
       $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/attributeDefinition'
+    serviceConfigurationLimitExceededExceptionInfo:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/serviceConfigurationLimitExceededExceptionInfo'
+    serviceConfigurationParentLimitExceededExceptionInfo:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/serviceConfigurationParentLimitExceededExceptionInfo'
     serviceConfigurationUpdateForbiddenExceptionInfo:
       $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/serviceConfigurationUpdateForbiddenExceptionInfo'
     ### System Info Entities ###

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml
@@ -65,19 +65,19 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationLimitExceededExceptionInfo'
-                  - $ref: '../openapi.yaml#/components/responses/illegalArgument/content/application~1json/schema'
-                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationParentLimitExceededExceptionInfo'
-                  - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/illegalArgumentExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/illegalNullArgumentExceptionInfo'
+                  - $ref: './serviceConfiguration.yaml#/components/schemas/serviceConfigurationLimitExceededExceptionInfo'
+                  - $ref: './serviceConfiguration.yaml#/components/schemas/serviceConfigurationParentLimitExceededExceptionInfo'
             application/xml:
               schema:
                 oneOf:
-                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationLimitExceededExceptionInfo'
-                  - $ref: '../openapi.yaml#/components/responses/illegalArgument/content/application~1xml/schema'
-                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationParentLimitExceededExceptionInfo'
-                  - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/illegalArgumentExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/illegalNullArgumentExceptionInfo'
+                  - $ref: './serviceConfiguration.yaml#/components/schemas/serviceConfigurationLimitExceededExceptionInfo'
+                  - $ref: './serviceConfiguration.yaml#/components/schemas/serviceConfigurationParentLimitExceededExceptionInfo'
                 xml:
-                  name: 'ServiceConfigurationLimitExceededExceptionInfo'
+                  name: 'serviceConfigurationLimitExceededExceptionInfo'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId.yaml
@@ -59,19 +59,19 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationLimitExceededExceptionInfo'
-                  - $ref: '../openapi.yaml#/components/responses/illegalArgument/content/application~1json/schema'
-                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationParentLimitExceededExceptionInfo'
-                  - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/illegalArgumentExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/illegalNullArgumentExceptionInfo'
+                  - $ref: './serviceConfiguration.yaml#/components/schemas/serviceConfigurationLimitExceededExceptionInfo'
+                  - $ref: './serviceConfiguration.yaml#/components/schemas/serviceConfigurationParentLimitExceededExceptionInfo'
             application/xml:
               schema:
                 oneOf:
-                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationLimitExceededExceptionInfo'
-                  - $ref: '../openapi.yaml#/components/responses/illegalArgument/content/application~1xml/schema'
-                  - $ref: '../openapi.yaml#/components/schemas/ServiceConfigurationParentLimitExceededExceptionInfo'
-                  - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/illegalArgumentExceptionInfo'
+                  - $ref: '../openapi.yaml#/components/schemas/illegalNullArgumentExceptionInfo'
+                  - $ref: './serviceConfiguration.yaml#/components/schemas/serviceConfigurationParentLimitExceededExceptionInfo'
+                  - $ref: './serviceConfiguration.yaml#/components/schemas/serviceConfigurationLimitExceededExceptionInfo'
                 xml:
-                  name: 'ServiceConfigurationLimitExceededExceptionInfo'
+                  name: 'serviceConfigurationLimitExceededExceptionInfo'
         401:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration.yaml
@@ -379,6 +379,50 @@ components:
           type: integer
 
     ### Exception Info
+    serviceConfigurationLimitExceededExceptionInfo:
+      description: The update of the configuration for the service exceeds available resources of the current scope
+      allOf:
+        - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+        - properties:
+            scopeId:
+              description: The scope for which limit has been exceeded
+              $ref: '../openapi.yaml#/components/schemas/kapuaId'
+            servicePid:
+              type: string
+              description: The Pid of the service
+            limitExceededBy:
+              type: string
+              description: The amount of excess
+      example:
+        type: "ServiceConfigurationLimitExceededExceptionInfo"
+        httpErrorCode: 400
+        message: "The maximum of resources for the org.eclipse.kapua.service.account.AccountService service for the account 2 has been exceeded. The resource limit is exceeded by 3."
+        kapuaErrorCode: "LIMIT_EXCEEDED"
+        scopeId: 2
+        servicePid: "org.eclipse.kapua.service.account.AccountService"
+        limitExceededBy: 3
+    serviceConfigurationParentLimitExceededExceptionInfo:
+      description: The update of the configuration for the service exceeds available resources of the parent scope
+      allOf:
+        - $ref: '../openapi.yaml#/components/schemas/exceptionInfo'
+        - properties:
+            parentScopeId:
+              description: The parent scope for which limit has been exceeded
+              $ref: '../openapi.yaml#/components/schemas/kapuaId'
+            servicePid:
+              type: string
+              description: The Pid of the service
+            limitExceededBy:
+              type: string
+              description: The amount of excess
+      example:
+        type: "ServiceConfigurationLimitExceededExceptionInfo"
+        httpErrorCode: 400
+        message: "The maximum of resources for the org.eclipse.kapua.service.account.AccountService service for the parent account 2 has been exceeded."
+        kapuaErrorCode: "PARENT_LIMIT_EXCEEDED"
+        scopeId: 2
+        servicePid: "org.eclipse.kapua.service.account.AccountService"
+        limitExceededBy: 3
     serviceConfigurationUpdateForbiddenExceptionInfo:
       description: The update of the configuration for the service contains an update to a property than cannot be updated
       allOf:


### PR DESCRIPTION
This PR fixes the Xml mapping for `KapuaId` property `scopeId` of `ServiceConfigurationLimitExceededExceptionInfo` and `ServiceConfigurationParentLimitExceededExceptionInfo`.

Also fixes the documentation of response codes of `/{scopeId}/serviceConfigurations/*` endpoints

**Related Issue**
_None_

**Description of the solution adopted**
Added missing `@XmlJavaTypeAdapter(KapuaIdAdapter.class)` 

**Screenshots**
_None_

**Any side note on the changes made**
_None_