### PR TITLE
:sparkles: [Service Config] Exposing the count of allowed entities from service configuration managers

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ResourceLimitedServiceConfigurationManagerImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ResourceLimitedServiceConfigurationManagerImpl.java
@@ -85,6 +85,11 @@ public class ResourceLimitedServiceConfigurationManagerImpl
         }
     }
 
+    @Override
+    public long countAllowedEntities(TxContext txContext, KapuaId scopeId) throws KapuaException {
+        return allowedChildEntities(txContext, scopeId);
+    }
+
     /**
      * Gets the number of remaining allowed entity for the given scope, according to the {@link KapuaConfigurableService#getConfigValues(KapuaId)}
      *

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationManager.java
@@ -40,6 +40,8 @@ public interface ServiceConfigurationManager {
 
     void checkAllowedEntities(TxContext txContext, KapuaId scopeId, String entityType) throws KapuaException;
 
+    long countAllowedEntities(TxContext txContext, KapuaId scopeId) throws KapuaException;
+
     void setConfigValues(KapuaId scopeId, Optional<KapuaId> parentId, Map<String, Object> values) throws KapuaException;
 
     Map<String, Object> getConfigValues(TxContext txContext, KapuaId scopeId, boolean excludeDisabled) throws KapuaException;

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationManagerCachingWrapper.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationManagerCachingWrapper.java
@@ -72,9 +72,13 @@ public class ServiceConfigurationManagerCachingWrapper implements ServiceConfigu
     }
 
     @Override
+    public long countAllowedEntities(TxContext txContext, KapuaId scopeId) throws KapuaException {
+        return wrapped.countAllowedEntities(txContext, scopeId);
+    }
+
+    @Override
     public void setConfigValues(KapuaId scopeId, Optional<KapuaId> parentId, Map<String, Object> values) throws KapuaException {
         wrapped.setConfigValues(scopeId, parentId, values);
-
     }
 
     @Override

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationManagerImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationManagerImpl.java
@@ -123,6 +123,11 @@ public class ServiceConfigurationManagerImpl implements ServiceConfigurationMana
     }
 
     @Override
+    public long countAllowedEntities(TxContext txContext, KapuaId scopeId) throws KapuaException {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
     public void setConfigValues(KapuaId scopeId, Optional<KapuaId> parentId, Map<String, Object> values) throws KapuaException {
         txManager.<Void>execute(tx -> {
             Optional<KapuaTocd> maybeOcd = doGetConfigMetadata(tx, scopeId, false);


### PR DESCRIPTION
With a view of reducing exception-based communication within the app, this pr exposes externally the count of allowed entities for a specific configuration manager. Consuming services can then perform smart decisions without relying on exception handling.