### PR TITLE
Add the organization name to the "switch to account" menu

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
@@ -349,8 +349,9 @@ public class NorthView extends LayoutContainer {
                         // Add item menu entry
                         KapuaMenuItem childAccountMenuItem = new KapuaMenuItem();
                         childAccountMenuItem.setIcon(IconSet.USER);
-                        childAccountMenuItem.setText(childAccount.getName());
-                        childAccountMenuItem.setTitle(childAccount.getName());
+                        String childAccountFullName = childAccount.getName() + " (" + childAccount.getGwtOrganization().getName() + ")";
+                        childAccountMenuItem.setText(childAccountFullName);
+                        childAccountMenuItem.setTitle(childAccountFullName);
                         childAccountMenuItem.setId(String.valueOf(childAccount.getId()));
                         menu.add(childAccountMenuItem);
 


### PR DESCRIPTION
This change adds the organization name to the `switch to account` gwt menu

**Related Issue**
This PR fixes #4204
