### PR TITLE
:bug: [Job] Fixed JobStepDefinitionProperties description for complex object to state that also JSON is allowed

### DIFF
--- a/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/definition/DeviceAssetWriteJobStepDefinition.java
+++ b/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/definition/DeviceAssetWriteJobStepDefinition.java
@@ -43,7 +43,7 @@ public class DeviceAssetWriteJobStepDefinition extends JobStepDefinitionRecord {
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DeviceAssetWritePropertyKeys.ASSETS,
-                                "XML string that defines the asset, channels and values to be written",
+                                "XML or JSON string that defines the asset, channels and values to be written",
                                 DeviceAssets.class.getName(),
                                 null,
                                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n <deviceAssets>\n     <deviceAsset>\n         <name>assetName</name>\n         <channels>\n             <channel>\n                 <valueType>binary</valueType>\n                 <value>EGVzdCBzdHJpbmcgdmFsdWU=</value>\n                 <name>binaryTest</name>\n             </channel>\n         </channels>\n     </deviceAsset>\n</deviceAssets>",

--- a/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/definition/DeviceCommandExecJobStepDefinition.java
+++ b/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/definition/DeviceCommandExecJobStepDefinition.java
@@ -43,7 +43,7 @@ public class DeviceCommandExecJobStepDefinition extends JobStepDefinitionRecord 
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DeviceCommandExecPropertyKeys.COMMAND_INPUT,
-                                "XML string that defines the system command to be executed",
+                                "XML or JSON string that defines the system command to be executed",
                                 DeviceCommandInput.class.getName(),
                                 null,
                                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<commandInput>\n    <command>ls</command>\n    <timeout>30000</timeout>\n    <runAsynch>false</runAsynch>\n</commandInput>",

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackageDownloadJobStepDefinition.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackageDownloadJobStepDefinition.java
@@ -44,7 +44,7 @@ public class DevicePackageDownloadJobStepDefinition extends JobStepDefinitionRec
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DevicePackageDownloadPropertyKeys.PACKAGE_DOWNLOAD_REQUEST,
-                                "XML string that defines the package download request sent",
+                                "XML or JSON string that defines the package download request sent",
                                 DevicePackageDownloadRequest.class.getName(),
                                 null,
                                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<downloadRequest>\n   <uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri>\n   <name>heater</name>\n   <version>1.0.300</version>\n   <install>true</install>\n</downloadRequest>",

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackageUninstallJobStepDefinition.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackageUninstallJobStepDefinition.java
@@ -44,7 +44,7 @@ public class DevicePackageUninstallJobStepDefinition extends JobStepDefinitionRe
                 Lists.newArrayList(
                         new JobStepPropertyRecord(
                                 DevicePackageUninstallPropertyKeys.PACKAGE_UNINSTALL_REQUEST,
-                                "XML string that defines the package uninstall request sent",
+                                "XML or JSON string that defines the package uninstall request sent",
                                 DevicePackageUninstallRequest.class.getName(),
                                 null,
                                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<uninstallRequest>\n   <name>heater</name>\n   <version>1.0.300</version>\n   <reboot>true</reboot>\n   <rebootDelay>30000</rebootDelay>\n</uninstallRequest>",


### PR DESCRIPTION
This PR fixes JobStepDefinitionProperties description for complex object to state that also JSON is allowed

**Related Issue**
_None_

**Description of the solution adopted**
Fixed descriptions

**Screenshots**
_None_

**Any side note on the changes made**
_None_