### PR TITLE
🐛 [Device Management] - Command execution with env variables with 'POST /{scopeId}/devices/{deviceId}/commands/_execute' API does not work

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand.yaml
@@ -43,8 +43,19 @@ components:
           format: base64
         environment:
           type: array
+          deprecated: true
           items:
             type: string
+        environments:
+          properties:
+            environment:
+              oneOf:
+                - description: An array of strings containing multiple environment variables for the command/script
+                  type: array
+                  items:
+                    type: string
+                - description: A string containing the environment variable for the command/script
+                  type: string
         runAsynch:
           type: boolean
         stdin:

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
@@ -34,6 +34,7 @@ import javax.xml.bind.annotation.XmlType;
         "workingDir",
         "body",
         "environment",
+        "environments",
         "runAsynch",
         "stdin"
 }, factoryClass = DeviceCommandXmlRegistry.class, factoryMethod = "newCommandInput")
@@ -134,16 +135,38 @@ public interface DeviceCommandInput extends DeviceCommand {
      * Get the environment attributes
      *
      * @return
+     * @deprecated Since 2.1.0
      */
+    @Deprecated
     @XmlElement(name = "environment")
     String[] getEnvironment();
+
+    /**
+     * Get the environment attributes
+     *
+     * @return
+     * @since 2.1.0
+     */
+    @XmlElementWrapper(name = "environments")
+    @XmlElement(name = "environment")
+    String[] getEnvironments();
 
     /**
      * Set the environment attributes
      *
      * @param environment
+     * @deprecated Since 2.1.0
      */
+    @Deprecated
     void setEnvironment(String[] environment);
+
+    /**
+     * Set the environment attributes
+     *
+     * @param environment
+     * @since 2.1.0
+     */
+    void setEnvironments(String[] environment);
 
     /**
      * Get the asynchronous run flag

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandInputImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandInputImpl.java
@@ -99,7 +99,17 @@ public class DeviceCommandInputImpl implements DeviceCommandInput {
     }
 
     @Override
+    public void setEnvironments(String[] environment) {
+        this.envVars = environment;
+    }
+
+    @Override
     public String[] getEnvironment() {
+        return envVars;
+    }
+
+    @Override
+    public String[] getEnvironments() {
         return envVars;
     }
 

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
@@ -86,7 +86,7 @@ public class DeviceCommandManagementServiceImpl extends AbstractDeviceManagement
         commandRequestPayload.setStdin(commandInput.getStdin());
         commandRequestPayload.setTimeout(commandInput.getTimeout());
         commandRequestPayload.setWorkingDir(commandInput.getWorkingDir());
-        commandRequestPayload.setEnvironmentPairs(commandInput.getEnvironment());
+        commandRequestPayload.setEnvironmentPairs(commandInput.getEnvironments());
         commandRequestPayload.setRunAsync(commandInput.isRunAsynch());
         commandRequestPayload.setPassword(commandInput.getPassword());
         commandRequestPayload.setBody(commandInput.getBody());

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppCommandKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppCommandKapuaKura.java
@@ -68,15 +68,21 @@ public class TranslatorAppCommandKapuaKura extends AbstractTranslatorKapuaKura<C
             // Payload translation
             Map<String, Object> metrics = kuraRequestPayload.getMetrics();
             metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_CMD).getName(), kapuaPayload.getCommand());
-            metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_ENVP).getName(), kapuaPayload.getEnvironmentPairs());
             metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_DIR).getName(), kapuaPayload.getWorkingDir());
             metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_STDIN).getName(), kapuaPayload.getStdin());
             metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_TOUT).getName(), kapuaPayload.getTimeout());
             metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_ASYNC).getName(), kapuaPayload.isRunAsync());
             metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_PASSWORD).getName(), kapuaPayload.getPassword());
 
-            // argument translation
+            // environment variables translation
             int i = 0;
+            String[] envs = kapuaPayload.getEnvironmentPairs();
+            for (String env : envs) {
+                metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_ENVP).getName() + i++, env);
+            }
+
+            // argument translation
+            i = 0;
             String[] arguments = kapuaPayload.getArguments();
             for (String argument : arguments) {
                 metrics.put(PROPERTIES_DICTIONARY.get(CommandAppProperties.APP_PROPERTY_ARG).getName() + i++, argument);


### PR DESCRIPTION
Before this PR, you could reproduce this bug:

Execute POST /{scopeId}/devices/{deviceId}/commands/_execute with the following body

{
  "command": "env",
  "arguments": {
    "argument": ""
  },
  "timeout": 60000,
  "environment": ["MY_VAR_01=01","MY_VAR_02=02"]
}

Environment variables are not set device side during command execution.

Expected result:

Environment variables should be set.


With this PR, the env. variables are restored and can be set correctly for a command, for example in the case of a script that reads some env. variables and that is sent to the device for execution