### PR TITLE
:bug: [SSO] Fixed handling of external username claim not present in userInfo

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -243,7 +243,10 @@ public class JwtAuthenticatingRealm extends KapuaAuthenticatingRealm implements 
     private String extractExternalUsername(JsonObject userInfo) {
         final String externalUsername;
         try {
-            externalUsername = userInfo.getString(jwtProcessor.getExternalUsernameClaimName());
+            // Using JsonObject.getString(String, null) to return 'null' when field is not present in the UserInfo JsonObject.
+            // JsonObject.getString(String) throws NPE when element is not present.
+            // See JsonObject.getString(String) javadoc.
+            externalUsername = userInfo.getString(jwtProcessor.getExternalUsernameClaimName(), null);
         } catch (Exception e) {
             throw new ShiroException("Failed to parse JWT", e);
         }
@@ -261,7 +264,7 @@ public class JwtAuthenticatingRealm extends KapuaAuthenticatingRealm implements 
      */
     private User resolveExternalUsernameWithOpenIdProvider(JwtCredentials jwtCredentials) throws KapuaException {
 
-        // Ask to the OpenId Provider the user's info
+        // Ask the OpenID Provider the user's info
         JsonObject userInfo = openIDService.getUserInfo(jwtCredentials.getAccessToken());
         String externalUsername = extractExternalUsername(userInfo);
 


### PR DESCRIPTION
This PR fixes a NPE on the externalUsername resolution when invoking the `/userInfo` endpoint and the returned entity does not contain the configured claim

**Related Issue**
_None_

**Description of the solution adopted**
Changed the `getString` override to use the one that handles `null` and returned the `null` value for the property

**Screenshots**
_None_

**Any side note on the changes made**
_None_