### PR TITLE
🐛 [Job Engine] Job start on precise targets

### DIFF
--- a/job-engine/app/resources/src/main/java/org/eclipse/kapua/job/engine/app/resources/JobEngineResource.java
+++ b/job-engine/app/resources/src/main/java/org/eclipse/kapua/job/engine/app/resources/JobEngineResource.java
@@ -69,7 +69,7 @@ public class JobEngineResource {
 
     @POST
     @Path("start-with-options/{scopeId}/{jobId}")
-    @Consumes({MediaType.APPLICATION_JSON})
+    @Consumes({MediaType.APPLICATION_XML})
     public void startJob(@PathParam("scopeId") KapuaId scopeId, @PathParam("jobId") KapuaId jobId, JobStartOptions jobStartOptions) throws KapuaException {
         jobEngineService.startJob(scopeId, jobId, jobStartOptions);
     }

--- a/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineServiceClient.java
+++ b/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineServiceClient.java
@@ -120,10 +120,10 @@ public class JobEngineServiceClient implements JobEngineService {
     public void startJob(KapuaId scopeId, KapuaId jobId, JobStartOptions jobStartOptions) throws KapuaException {
         try {
             String path = String.format("start-with-options/%s/%s", scopeId.toCompactId(), jobId.toCompactId());
-            String jobStartOptionsJson = xmlUtil.marshalJson(jobStartOptions);
-            LOG.debug("POST {} - Content: {}", path, jobStartOptionsJson);
+            String jobStartOptionsXml = xmlUtil.marshal(jobStartOptions);
+            LOG.debug("POST {} - Content: {}", path, jobStartOptionsXml);
 
-            Response response = getPreparedRequest(path).post(Entity.json(jobStartOptionsJson));
+            Response response = getPreparedRequest(path).post(Entity.xml(jobStartOptionsXml));
 
             checkResponse("POST", path, response);
         } catch (ClientErrorException | JAXBException e) {

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestJAXBContextProvider.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestJAXBContextProvider.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import javax.xml.bind.JAXBContext;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.rest.model.IsJobRunningMultipleResponse;
 import org.eclipse.kapua.commons.rest.model.IsJobRunningResponse;
 import org.eclipse.kapua.commons.rest.model.errors.ExceptionInfo;
 import org.eclipse.kapua.commons.rest.model.errors.JobAlreadyRunningExceptionInfo;
@@ -36,9 +37,6 @@ import org.eclipse.kapua.commons.service.event.store.api.EventStoreXmlRegistry;
 import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.job.engine.JobStartOptions;
-import org.eclipse.kapua.job.engine.client.JobStartOptionsClient;
-import org.eclipse.kapua.job.engine.commons.model.JobStepPropertiesOverrides;
-import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTdesignate;
 import org.eclipse.kapua.model.config.metatype.KapuaTicon;
@@ -97,8 +95,6 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackages
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 import org.eclipse.kapua.service.job.Job;
-import org.eclipse.kapua.service.job.JobListResult;
-import org.eclipse.kapua.service.job.JobXmlRegistry;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
@@ -140,15 +136,11 @@ public class TestJAXBContextProvider implements JAXBContextProvider {
 
                     // Jobs
                     Job.class,
-                    JobListResult.class,
-                    JobXmlRegistry.class,
 
                     // Job Engine
-                    JobStartOptionsClient.class,
                     JobStartOptions.class,
-                    JobTargetSublist.class,
                     IsJobRunningResponse.class,
-                    JobStepPropertiesOverrides.class,
+                    IsJobRunningMultipleResponse.class,
 
                     // Job Engine Client
                     JobAlreadyRunningExceptionInfo.class,

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceOperations.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceOperations.feature
@@ -135,6 +135,29 @@ Feature: Job Engine Service - Operations
     Then I confirm that job has 2 job execution
     And I confirm that job target in job has step index 0 and status "PROCESS_OK"
 
+  Scenario: Start - job started on selected devices
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a device with name "rpione3"
+    And I create a job with the name "TestJob"
+    And I add device targets to job
+      | rpione3 |
+    And I create a device with name "rpione4"
+    And I add device targets to job
+      | rpione4 |
+    And I search for step definition with the name
+      | Bundle Start |
+    And I add job step to job with name "Test Step - Bundle Start" and with selected job step definition and properties
+      | name     | type              | value |
+      | bundleId | java.lang.String  | 34    |
+      | timeout  | java.lang.Long    | 5000  |
+    When I start a job for targets
+      | rpione4 |
+    And I wait job to finish its execution up to 10s
+    Then I confirm that job has 1 job execution
+    And I confirm that device job target "rpione3" in job has step index 0 and status "PROCESS_AWAITING"
+    And I confirm that device job target "rpione4" in job has step index 0 and status "PROCESS_FAILED"
+
   Scenario: Start - JobTarget failed, then "loading status" (process_awaiting), then ok
 
     Given I login as user with name "kapua-sys" and password "kapua-password"

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobEngine.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobEngine.java
@@ -41,7 +41,7 @@ public class JobEngine extends AbstractKapuaResource {
 
     @POST
     @Path("{jobId}/_start")
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public void startJob(
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("jobId") EntityId jobId,

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobEngineSteps.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobEngineSteps.java
@@ -23,21 +23,35 @@ import org.eclipse.kapua.job.engine.JobEngineFactory;
 import org.eclipse.kapua.job.engine.JobEngineService;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.qa.common.StepData;
+import org.eclipse.kapua.service.device.registry.DeviceAttributes;
+import org.eclipse.kapua.service.device.registry.DeviceFactory;
+import org.eclipse.kapua.service.device.registry.DeviceListResult;
+import org.eclipse.kapua.service.device.registry.DeviceQuery;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.targets.JobTarget;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Singleton
 public class JobEngineSteps extends JobServiceTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobEngineSteps.class);
 
+    private DeviceFactory deviceFactory;
+    private DeviceRegistryService deviceRegistryService;
     private JobEngineService jobEngineService;
     private JobEngineFactory jobEngineFactory;
 
@@ -55,6 +69,8 @@ public class JobEngineSteps extends JobServiceTestBase {
     public void setServices() {
         KapuaLocator locator = KapuaLocator.getInstance();
 
+        deviceFactory= locator.getFactory(DeviceFactory.class);
+        deviceRegistryService = locator.getService(DeviceRegistryService.class);
         jobEngineService = locator.getService(JobEngineService.class);
         jobEngineFactory = locator.getFactory(JobEngineFactory.class);
     }
@@ -65,6 +81,38 @@ public class JobEngineSteps extends JobServiceTestBase {
         KapuaId currentJobId = (KapuaId) stepData.get(CURRENT_JOB_ID);
         try {
             JobStartOptions jobStartOptions = jobEngineFactory.newJobStartOptions();
+            jobStartOptions.setEnqueue(true);
+            jobEngineService.startJob(getCurrentScopeId(), currentJobId, jobStartOptions);
+        } catch (KapuaException ke) {
+            verifyException(ke);
+        }
+    }
+
+    @When("I start a job for targets")
+    public void startJobOnPreciseTargets(List<String> clientIds) throws Exception {
+        primeException();
+        KapuaId currentJobId = (KapuaId) stepData.get(CURRENT_JOB_ID);
+        try {
+            DeviceQuery deviceQuery = deviceFactory.newQuery(getCurrentScopeId());
+            deviceQuery.setPredicate(
+                    deviceQuery.attributePredicate(DeviceAttributes.CLIENT_ID, clientIds)
+            );
+            DeviceListResult devices = deviceRegistryService.query(deviceQuery);
+            List<KapuaId> deviceIds = devices.getItems()
+                    .stream()
+                    .map(KapuaEntity::getId)
+                    .collect(Collectors.toList());
+
+            Set<KapuaId> targetIdsSublist = new HashSet<>();
+            List<JobTarget> currentJobTargets = (ArrayList<JobTarget>)stepData.get(JOB_TARGET_LIST);
+            for (JobTarget jobT : currentJobTargets) {
+                if (deviceIds.contains(jobT.getJobTargetId())) {
+                    targetIdsSublist.add(jobT.getId());
+                }
+            }
+
+            JobStartOptions jobStartOptions = jobEngineFactory.newJobStartOptions();
+            jobStartOptions.setTargetIdSublist(targetIdsSublist);
             jobStartOptions.setEnqueue(true);
             jobEngineService.startJob(getCurrentScopeId(), currentJobId, jobStartOptions);
         } catch (KapuaException ke) {

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobTargetServiceSteps.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobTargetServiceSteps.java
@@ -170,11 +170,12 @@ public class JobTargetServiceSteps extends JobServiceTestBase {
         JobTargetCreator jobTargetCreator = jobTargetFactory.newCreator(getCurrentScopeId());
         jobTargetCreator.setJobId(job.getId());
 
-        List<JobTarget> jobTargets = new ArrayList<>();
+        List<JobTarget> jobTargets = (ArrayList<JobTarget>) stepData.get(JOB_TARGET_LIST) == null ? new ArrayList<>() : (ArrayList<JobTarget>) stepData.get(JOB_TARGET_LIST);
         for (KapuaId deviceId : deviceIds) {
             jobTargetCreator.setJobTargetId(deviceId);
             JobTarget jobTarget = jobTargetService.create(jobTargetCreator);
             stepData.put(JOB_TARGET, jobTarget);
+            jobTargets.add(jobTarget);
         }
         stepData.put(JOB_TARGET_LIST, jobTargets);
     }


### PR DESCRIPTION
This PR fixed the capability to start a job on precise targets, for example with the proper rest-API.
Furthermore, a precise scenario to test this has been added 
