### PR TITLE
🐛 [GWT Console] Fix "Fill with example values" Button Visibility for Batch Job Steps

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -12,26 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.steps;
 
-import com.extjs.gxt.ui.client.data.BaseListLoader;
-import com.extjs.gxt.ui.client.data.ListLoadResult;
-import com.extjs.gxt.ui.client.data.RpcProxy;
-import com.extjs.gxt.ui.client.event.ButtonEvent;
-import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
-import com.extjs.gxt.ui.client.event.SelectionChangedListener;
-import com.extjs.gxt.ui.client.event.SelectionListener;
-import com.extjs.gxt.ui.client.store.ListStore;
-import com.extjs.gxt.ui.client.widget.Component;
-import com.extjs.gxt.ui.client.widget.HorizontalPanel;
-import com.extjs.gxt.ui.client.widget.Label;
-import com.extjs.gxt.ui.client.widget.form.CheckBox;
-import com.extjs.gxt.ui.client.widget.form.ComboBox;
-import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
-import com.extjs.gxt.ui.client.widget.form.Field;
-import com.extjs.gxt.ui.client.widget.form.FieldSet;
-import com.extjs.gxt.ui.client.widget.form.LabelField;
-import com.extjs.gxt.ui.client.widget.form.TextField;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
@@ -59,9 +42,26 @@ import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobStepDefinit
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobStepDefinitionServiceAsync;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobStepService;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobStepServiceAsync;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.extjs.gxt.ui.client.data.BaseListLoader;
+import com.extjs.gxt.ui.client.data.ListLoadResult;
+import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
+import com.extjs.gxt.ui.client.event.SelectionChangedListener;
+import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.Component;
+import com.extjs.gxt.ui.client.widget.HorizontalPanel;
+import com.extjs.gxt.ui.client.widget.Label;
+import com.extjs.gxt.ui.client.widget.form.CheckBox;
+import com.extjs.gxt.ui.client.widget.form.ComboBox;
+import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
+import com.extjs.gxt.ui.client.widget.form.Field;
+import com.extjs.gxt.ui.client.widget.form.FieldSet;
+import com.extjs.gxt.ui.client.widget.form.LabelField;
+import com.extjs.gxt.ui.client.widget.form.TextField;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public class JobStepAddDialog extends EntityAddEditDialog {
 
@@ -422,7 +422,25 @@ public class JobStepAddDialog extends EntityAddEditDialog {
         jobStepPropertiesPanel.add(propertiesButtonPanel);
 
         jobStepPropertiesPanel.layout(true);
+
+        hideExampleButtonIfNoExampleValue(gwtJobStepDefinition);
+
     }
+
+
+    private void hideExampleButtonIfNoExampleValue(GwtJobStepDefinition gwtJobStepDefinition) {
+        boolean hideExampleButton = true;
+        for (GwtJobStepProperty property : gwtJobStepDefinition.getStepProperties()) {
+            if (property.getExampleValue() != null) {
+                hideExampleButton = false;
+                break;
+            }
+        }
+        if (hideExampleButton) {
+            exampleButton.hide();
+        }
+    }
+
 
     private void applyFieldLimits(GwtJobStepProperty property, TextField<?> textField) {
         String fieldLabel = camelCaseToNormalCase(property.getPropertyName());

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
@@ -12,13 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.steps;
 
-import com.extjs.gxt.ui.client.data.LoadEvent;
-import com.extjs.gxt.ui.client.event.LoadListener;
-import com.extjs.gxt.ui.client.widget.Component;
-import com.extjs.gxt.ui.client.widget.form.Field;
-import com.extjs.gxt.ui.client.widget.form.LabelField;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
@@ -31,9 +27,13 @@ import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobStepDefinit
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobStepDefinitionServiceAsync;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobStepService;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobStepServiceAsync;
-
-import java.util.HashMap;
-import java.util.Map;
+import com.extjs.gxt.ui.client.data.LoadEvent;
+import com.extjs.gxt.ui.client.event.LoadListener;
+import com.extjs.gxt.ui.client.widget.Component;
+import com.extjs.gxt.ui.client.widget.form.Field;
+import com.extjs.gxt.ui.client.widget.form.LabelField;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public class JobStepEditDialog extends JobStepAddDialog {
 
@@ -53,14 +53,6 @@ public class JobStepEditDialog extends JobStepAddDialog {
         jobStepIndex.setAllowBlank(false);
 
         loadJobStep();
-    }
-
-    @Override
-    protected void refreshJobStepDefinition(GwtJobStepDefinition gwtJobStepDefinition) {
-        super.refreshJobStepDefinition(gwtJobStepDefinition);
-        if (exampleButton != null) {
-            exampleButton.hide();
-        }
     }
 
     private void loadJobStep() {


### PR DESCRIPTION
### Description
This PR addresses an issue with the "Fill with example values" button in the batch job steps of the GWT Console. Currently, the button is always displayed on the step add interface, even when no example values are available, leading to confusion as clicking it does not yield any results. Conversely, the button is not shown on the step edit interface, even when example values are available.

### Changes Made
- **Button Visibility on Step Add:** The "Fill with example values" button will now only be displayed when there are example values available for the batch job step being added.
- **Button Visibility on Step Edit:** The button will be shown on the step edit interface if example values are available, ensuring consistency and usability across both interfaces.

### Motivation
This fix enhances the user experience by ensuring that the button's visibility accurately reflects the availability of example values, preventing user confusion and improving the overall functionality of the batch job steps.