### PR TITLE
:bug: [Datastore] Fixed the logic checking message uniqueness when a insert is retried

### DIFF
--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
@@ -156,7 +156,7 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
         if (!newInsert && !MessageUniquenessCheck.NONE.equals(accountServicePlan.getMessageUniquenessCheck())) {
             DatastoreMessage datastoreMessage = MessageUniquenessCheck.FULL.equals(accountServicePlan.getMessageUniquenessCheck()) ?
                     messageRepository.find(message.getScopeId(), storableIdFactory.newStorableId(messageId)) :
-                    messageRepository.find(message.getScopeId(), storableIdFactory.newStorableId(messageId), message.getCapturedOn().getTime());
+                    messageRepository.find(message.getScopeId(), storableIdFactory.newStorableId(messageId), indexedOnDate.getTime());
             if (datastoreMessage != null) {
                 LOG.debug("Message with datastore id '{}' already found", messageId);
                 metrics.getAlreadyInTheDatastore().inc();


### PR DESCRIPTION
This PR fixes the check performed to honor the message uniqueness check strategy.

**Related Issue**
_None_

**Description of the solution adopted**
The `capturedOn` field can be `null` and it would produce an error when the selected strategy is BOUND.
We switched to the indexed date which is always not null 

**Screenshots**
_None_

**Any side note on the changes made**
_None_