### PR TITLE
:bug: [Broker] Fix retry when datastore is disabled

### DIFF
--- a/consumer/telemetry-app/src/main/java/org/eclipse/kapua/consumer/telemetry/SpringBridge.java
+++ b/consumer/telemetry-app/src/main/java/org/eclipse/kapua/consumer/telemetry/SpringBridge.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,14 +12,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.consumer.telemetry;
 
+import java.util.Map;
+
+import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.liquibase.DatabaseCheckUpdate;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.camel.application.MetricsCamel;
 import org.eclipse.kapua.service.client.protocol.ProtocolDescriptorProvider;
+import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.internal.ConfigurationProvider;
 import org.eclipse.kapua.service.datastore.internal.MetricsDatastore;
 import org.eclipse.kapua.translator.TranslatorHub;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.google.inject.TypeLiteral;
 
 @Configuration
 public class SpringBridge {
@@ -54,4 +62,21 @@ public class SpringBridge {
         return KapuaLocator.getInstance().getComponent(ProtocolDescriptorProvider.class);
     }
 
+    @Bean
+    ConfigurationProvider configurationProvider() {
+        return KapuaLocator.getInstance().getComponent(ConfigurationProvider.class);
+    }
+
+    @Bean
+    AccountService accountService() {
+        return KapuaLocator.getInstance().getComponent(AccountService.class);
+    }
+
+    @Bean
+    ServiceConfigurationManager serviceConfigurationManager() {
+        final TypeLiteral<Map<Class<?>, ServiceConfigurationManager>> typeLiteral = new TypeLiteral<Map<Class<?>, ServiceConfigurationManager>>() {
+        };
+        final Map<Class<?>, ServiceConfigurationManager> component = KapuaLocator.getInstance().getComponent(typeLiteral.getType());
+        return component.get(MessageStoreService.class);
+    }
 }

--- a/consumer/telemetry-app/src/main/resources/camel/camel.xml
+++ b/consumer/telemetry-app/src/main/resources/camel/camel.xml
@@ -20,7 +20,12 @@
             <!-- keep here the bind/unbind of the kapua session so we can avoid the null check in bind method of KapuaCamelFilter because the Artemis internal messages have no KapuaSession in their header -->
             <bean ref="kapuaCamelFilter" method="bindSession"/>
             <bean ref="kapuaDataConverter" method="convertToData"/>
-            <to uri="bean:dataStorageMessageProcessor?method=processMessage"/>
+            <choice id="checkDatastoreEnabled">
+                <when id="datstoreEnabled">
+                    <simple>${bean:telemetryService?method=isDatastoreServiceEnabled} == 'true'</simple>
+                    <to uri="bean:dataStorageMessageProcessor?method=processMessage"/>
+                </when>
+            </choice>
             <to uri="bean:dataStorageMessageProcessor?method=updateAssets"/>
             <bean ref="kapuaCamelFilter" method="unbindSession"/>
         </pipeline>

--- a/consumer/telemetry/src/main/java/org/eclipse/kapua/consumer/telemetry/TelemetryService.java
+++ b/consumer/telemetry/src/main/java/org/eclipse/kapua/consumer/telemetry/TelemetryService.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.consumer.telemetry;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.camel.Exchange;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.client.message.MessageConstants;
+import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component("telemetryService")
+public class TelemetryService {
+
+    protected static final Logger logger = LoggerFactory.getLogger(TelemetryService.class);
+    private final ServiceConfigurationManager serviceConfigurationManager;
+    private final AccountService accountService;
+
+    @Inject
+    public TelemetryService(AccountService accountService, ServiceConfigurationManager serviceConfigurationManager) {
+        this.accountService = accountService;
+        this.serviceConfigurationManager = serviceConfigurationManager;
+    }
+
+    public boolean isDatastoreServiceEnabled(Exchange exchange) throws Exception {
+        Account account = extractAccount(exchange);
+        Map<String, Object> config = serviceConfigurationManager.getConfigValues(account.getId(), false);
+        Boolean enabled = (Boolean)config.get("enabled");
+        Integer ttl = (Integer)config.get("dataTTL");
+        return Boolean.TRUE.equals(enabled) && (ttl!=null && ttl.intValue()!=MessageStoreConfiguration.DISABLED);
+    }
+
+    private Account extractAccount(Exchange exchange) throws KapuaException {
+        String topic = exchange.getMessage().getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class);
+        String accountName = extractAccountNameFromTopic(topic);
+        Account account = accountService.findByName(accountName);
+        if (account == null) {
+            logger.warn("Cannot find account for account name {}", accountName);
+            throw new KapuaIllegalArgumentException("account", "nill");
+        }
+        else {
+            return account;
+        }
+    }
+
+    private String extractAccountNameFromTopic(String topic) throws KapuaIllegalArgumentException {
+        int index = topic.indexOf('/');
+        if (index>0) {
+            return topic.substring(0, index);
+        }
+        else {
+            logger.warn("Cannot extract account name for topic {}", topic);
+            throw new KapuaIllegalArgumentException("account_name", "N/A");
+        }
+    }
+}


### PR DESCRIPTION
Brief description of the PR.
If datastore is disabled for an account, the messge store service throws an exception and the Camel route handle it as a recoverable error retrying the store call. This is not correct so intruduce a check before calling the message store service.

**Related Issue**
none

**Description of the solution adopted**
Cahnged Camel route to do a pre check before invoking the message store service.

**Screenshots**
none

**Any side note on the changes made**
none