### PR TITLE
⬆️ Bump`netty` from `4.1.114.Final` to `4.1.118.Final` - CVE-2025-25193 CVE-2025-24970 CVE-2023-44487

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <logback.version>1.5.12</logback.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.114.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <ow2-asm.version>9.4</ow2-asm.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>


### PR DESCRIPTION
This pull request addresses different CVEs by updating the `netty` library to the `4.1.118.Final` version.

This PR solves following CVEs

- io.netty:netty-commons: CVE-2025-25193
- io.netty:netty-handler:  CVE-2025-24970 

Also solves following CVEs for 2.0.0 and 1.6.13 releases:

- io.netty:netty-codec-http2: CVE-2023-44487
