### PR TITLE
⬆️ Bump`jetty` from `9.4.53.v20231009` to `9.4.57.v20241219` - CVE-2024-8184 CVE-2024-22201 CVE-2022-2048 CVE-2024-9823

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <jaxb-impl.version>2.3.6</jaxb-impl.version>
         <jbatch.version>1.0.2</jbatch.version>
         <jersey.version>2.38</jersey.version>
-        <jetty.version>9.4.53.v20231009</jetty.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.10</jose4j.version>


### PR DESCRIPTION
This pull request addresses different CVEs by updating the `jetty` library to the `9.4.57.v20241219` version.

This PR solves following CVEs:

- org.eclipse.jetty:jetty-server: CVE-2024-8184
- org.eclipse.jetty.http2:http2-common: CVE-2024-22201
- org.eclipse.jetty.http2:http2-server: CVE-2022-2048
- org.eclipse.jetty:jetty-servlets: CVE-2024-9823