### PR TITLE
⬆️ [Dependencies] Bump`commons-compress` from `1.24.0` to `1.27.1` - CVE-2024-25710

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-configuration2.version>2.10.1</commons-configuration2.version>
-        <commons-compress.version>1.24.0</commons-compress.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
         <commons-fileupload.versison>1.5</commons-fileupload.versison>
         <commons-imaging.version>1.0-alpha3</commons-imaging.version>
         <commons-io.version>2.11.0</commons-io.version>


### PR DESCRIPTION
This pull request addresses different CVEs by updating the `commons-compress` library to the `1.27.1` version.

CVE solved:

- CVE-2024-25710