### PR TITLE
⬆️ [Dependencies] Bump`shiro` from `1.12.0` to `1.13.0` - CVE-2023-46749

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
         <reflections.version>0.10.2</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
-        <shiro.version>1.12.0</shiro.version>
+        <shiro.version>1.13.0</shiro.version>
         <slf4j.version>2.0.16</slf4j.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>


### PR DESCRIPTION
This pull request addresses different CVEs by updating the `shiro` library to the `1.13.0` version.

This PR solves following CVEs:

- CVE-2023-46749