### PR TITLE
:bug: [Job Engine] Added missing XmlRootElement annotations on JobEngine Client model classes

### DIFF
--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/IsJobRunningMultipleResponse.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/IsJobRunningMultipleResponse.java
@@ -15,10 +15,12 @@ package org.eclipse.kapua.commons.rest.model;
 import org.eclipse.kapua.model.id.KapuaId;
 
 import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+@XmlRootElement(name = "isJobRunningMultipleResponse")
 public class IsJobRunningMultipleResponse {
 
     private List<IsJobRunningResponse> list = new ArrayList<>();

--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/IsJobRunningResponse.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/IsJobRunningResponse.java
@@ -16,8 +16,10 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+@XmlRootElement(name = "isJobRunningResponse")
 public class IsJobRunningResponse {
 
     private KapuaId jobId;

--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/MultipleJobIdRequest.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/MultipleJobIdRequest.java
@@ -17,10 +17,12 @@ import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.HashSet;
 import java.util.Set;
 
+@XmlRootElement(name = "multipleJobIdRequest")
 public class MultipleJobIdRequest {
 
     private Set<KapuaId> jobIds = new HashSet<>();


### PR DESCRIPTION
This PR adds missing `@XmlRootElement` annotations on JobEngine Client model classes.

This was causing a communication error between the JobEngine Client and the JobEngine Resource when asking for multiple is running request

In `develop` branch this was already fixed in another PR https://github.com/eclipse-kapua/kapua/pull/4048

**Related Issue**
_None_

**Description of the solution adopted**
Added missing `@XmlRootElement` annotations

**Screenshots**
_None_

**Any side note on the changes made**
_None_