### PR TITLE
:bug: [Streams] Added missing resolution of the Device from the given clientId

### DIFF
--- a/service/stream/internal/src/main/java/org/eclipse/kapua/service/stream/internal/StreamServiceImpl.java
+++ b/service/stream/internal/src/main/java/org/eclipse/kapua/service/stream/internal/StreamServiceImpl.java
@@ -18,6 +18,7 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.model.domains.Domains;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.message.Message;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
@@ -168,8 +169,10 @@ public class StreamServiceImpl implements StreamService {
      */
     private Device checkDeviceInfo(KapuaDataMessage dataMessage) throws KapuaException {
         Device device = null;
+
+        // If `dataMessage.deviceId` check that it exists and that the `dataMessage.clientId` matches if specified.
         if (dataMessage.getDeviceId() != null) {
-            device = deviceRegistryService.find(dataMessage.getScopeId(), dataMessage.getDeviceId());
+            device = KapuaSecurityUtils.doPrivileged(() -> deviceRegistryService.find(dataMessage.getScopeId(), dataMessage.getDeviceId()));
 
             if (device == null) {
                 throw new KapuaEntityNotFoundException(Device.TYPE, dataMessage.getDeviceId());
@@ -181,6 +184,12 @@ public class StreamServiceImpl implements StreamService {
                 }
             }
         }
+
+        // If `dataMessage.deviceId` is not present, try resolve Device from the `dataMessage.clientId`
+        if (device == null) {
+            device = KapuaSecurityUtils.doPrivileged(() -> deviceRegistryService.findByClientId(dataMessage.getScopeId(), dataMessage.getClientId()));
+        }
+
         return device;
     }
 


### PR DESCRIPTION
This PR adds the missing resolution of the Device from the `clientId` when a `dataMessage.deviceId` is not provided

**Related Issue**
_None_

**Description of the solution adopted**
Added missing resolution of the Device from the `dataMessage.clientId` field

**Screenshots**
_None_

**Any side note on the changes made**
_None_