### PR TITLE
:bug: [Datastore] Fixed parsing of MessageStore ServiceConfig

### DIFF
--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
@@ -44,7 +44,7 @@ public class MessageStoreConfiguration {
      * Data storage enabled key.<br>
      * <b>The key must be aligned with the key used in org.eclipse.kapua.service.datastore.MessageStoreService.xml meta data configuration file).</b>
      */
-    public static final String CONFIGURATION_DATA_STORAGE_ENABLED_KEY = "messageStore.enabled";
+    public static final String CONFIGURATION_DATA_STORAGE_ENABLED_KEY = "enabled";
 
     /**
      * Data time to live key.<br>
@@ -114,7 +114,7 @@ public class MessageStoreConfiguration {
                 }
             }
             if (this.values.get(CONFIGURATION_DATA_STORAGE_ENABLED_KEY) != null) {
-                setDataStorageEnabled(Boolean.parseBoolean((String) this.values.get(CONFIGURATION_DATA_STORAGE_ENABLED_KEY)));
+                setDataStorageEnabled((Boolean) this.values.get(CONFIGURATION_DATA_STORAGE_ENABLED_KEY));
             }
             if (this.values.get(CONFIGURATION_DATA_TTL_KEY) != null) {
                 setDataTimeToLive((Integer) this.values.get(CONFIGURATION_DATA_TTL_KEY));


### PR DESCRIPTION
Fixed parsing of MessageStore ServiceConfig which was looking for the wrong key for 'enabled' config

`messageStore.enabled` was used to retrieve the value instead of `enabled`. `messageStore.enabled` was not existing so the value was always `null` from configs and it was making the MessageStore always enabled

**Related Issue**
_None_

**Description of the solution adopted**
Fixed the name of the key used to look into the MessageStore ServiceCofig values for `enabled` property

**Screenshots**
_None_

**Any side note on the changes made**
_None_