### PR TITLE
⬆️ [Dependencies] Bump `xstream` from `1.4.20` to `1.4.21` - CVE-2024-47072

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2094,6 +2094,11 @@
 
             <!-- Active MQ-->
             <dependency>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>1.4.21</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
                 <version>${activemq.version}</version>


### PR DESCRIPTION
This pull request addresses different CVEs by updating the `xstream` library to the `1.4.21` version.

This PR solves following CVEs:
- CVE-2024-47072