### PR TITLE
:fix: [Test] Fixed datastore test after backport #4238

### DIFF
--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -1819,7 +1819,7 @@ public class DatastoreSteps extends TestBase {
         checkListOrder(metLst, getNamedMetricOrdering());
     }
 
-    @Given("^Dataservice config enabled (.*), dataTTL (\\d+), rxByteLimit (\\d+), dataIndexBy \"(.*)\", messageUniquenessCheck \"(.*)\"$")
+    @Given("^Dataservice config enabled \"(.*)\", dataTTL (\\d+), rxByteLimit (\\d+), dataIndexBy \"(.*)\", messageUniquenessCheck \"(.*)\"$")
     public void configureDatastoreService(String enabled, int dataTTL, int rxByteLimit, String dataIndexBy, String messageUniquenessCheck) throws Exception {
         Map<String, Object> settings = new HashMap<>();
         settings.put("enabled", enabled.equalsIgnoreCase("TRUE"));


### PR DESCRIPTION
This PR fixes test for Datastore. 

This was a bug that always existed but due to #4238, it never shown.

**Related Issue**
_None_

**Description of the solution adopted**
Fixed reference to parameter with double quotes.

**Screenshots**
_None_

**Any side note on the changes made**
_None_