### PR TITLE
:bug: [Console GWT] Fixed not efficient User.id to User.name resolution

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -45,6 +45,7 @@ import org.eclipse.kapua.app.console.module.account.shared.util.KapuaGwtAccountM
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
+import org.eclipse.kapua.app.console.module.api.server.util.UserCreatedByModifiedByUtils;
 import org.eclipse.kapua.app.console.module.api.setting.ConsoleSetting;
 import org.eclipse.kapua.app.console.module.api.setting.ConsoleSettingKeys;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtConfigComponent;
@@ -84,10 +85,6 @@ import org.eclipse.kapua.service.endpoint.EndpointInfo;
 import org.eclipse.kapua.service.endpoint.EndpointInfoFactory;
 import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
 import org.eclipse.kapua.service.endpoint.EndpointInfoService;
-import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.service.user.UserFactory;
-import org.eclipse.kapua.service.user.UserListResult;
-import org.eclipse.kapua.service.user.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,6 +102,10 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
 
     private static final long serialVersionUID = 3314502846487119577L;
 
+    private static final String ENTITY_INFO = "entityInfo";
+
+    private static final String ORGANIZATION_INFO = "organizationInfo";
+
     private static final Logger LOG = LoggerFactory.getLogger(GwtAccountServiceImpl.class);
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
@@ -121,8 +122,6 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
     private static final RoleService ROLE_SERVICE = LOCATOR.getService(RoleService.class);
     private static final RoleFactory ROLE_FACTORY = LOCATOR.getFactory(RoleFactory.class);
 
-    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
-    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
 
     @Override
     public GwtAccount create(GwtXSRFToken xsrfToken, GwtAccountCreator gwtAccountCreator)
@@ -202,35 +201,19 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
     @Override
     public ListLoadResult<GwtGroupedNVPair> getAccountInfo(String scopeIdString, String accountIdString)
             throws GwtKapuaException {
-        final KapuaId scopeId = KapuaEid.parseCompactId(scopeIdString);
-        KapuaId accountId = KapuaEid.parseCompactId(accountIdString);
 
-        List<GwtGroupedNVPair> accountPropertiesPairs = new ArrayList<GwtGroupedNVPair>();
         try {
+            final KapuaId scopeId = KapuaEid.parseCompactId(scopeIdString);
+            KapuaId accountId = KapuaEid.parseCompactId(accountIdString);
+
             final Account account = ACCOUNT_SERVICE.find(scopeId, accountId);
 
-            //TODO: #LAYER_VIOLATION - user lookup should not be done here
-            UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
-
-                @Override
-                public UserListResult call() throws Exception {
-                    return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                }
-            });
-
-            Map<String, String> usernameMap = new HashMap<String, String>();
-            for (User user : userListResult.getItems()) {
-                usernameMap.put(user.getId().toCompactId(), user.getName());
-            }
-
-            final String entityInfo = "entityInfo";
-            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "expirationDate", account.getExpirationDate()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountCreatedOn", account.getCreatedOn()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountCreatedBy",
-                    account.getCreatedBy() != null ? usernameMap.get(account.getCreatedBy().toCompactId()) : null));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountModifiedOn", account.getModifiedOn()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountModifiedBy",
-                    account.getModifiedBy() != null ? usernameMap.get(account.getModifiedBy().toCompactId()) : null));
+            List<GwtGroupedNVPair> accountPropertiesPairs = new ArrayList<GwtGroupedNVPair>();
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ENTITY_INFO, "expirationDate", account.getExpirationDate()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ENTITY_INFO, "accountCreatedOn", account.getCreatedOn()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ENTITY_INFO, "accountCreatedBy", UserCreatedByModifiedByUtils.resolveFromId(account.getCreatedBy())));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ENTITY_INFO, "accountModifiedOn", account.getModifiedOn()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ENTITY_INFO, "accountModifiedBy", UserCreatedByModifiedByUtils.resolveFromId(account.getModifiedBy())));
 
             if (account.getScopeId() != null) {
                 Account parentAccount = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
@@ -246,7 +229,6 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
 
             if (AUTHORIZATION_SERVICE.isPermitted(PERMISSION_FACTORY.newPermission(Domains.ENDPOINT_INFO, Actions.read, scopeId))) {
                 //TODO: #LAYER_VIOLATION - related entities lookup should not be done here
-
                 EndpointInfoListResult endpointInfos = KapuaSecurityUtils.doPrivileged(new Callable<EndpointInfoListResult>() {
 
                     @Override
@@ -259,23 +241,23 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
                     accountPropertiesPairs.add(new GwtGroupedNVPair("deploymentInfo", ei.getSecure() ? "deploymentNodeUriSecure" : "deploymentNodeUri", ei.toStringURI()));
                 }
             }
-            final String organizationInfo = "organizationInfo";
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationName", account.getOrganization().getName()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationContactName", account.getOrganization().getPersonName()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationEmail", account.getOrganization().getEmail()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationPhoneNumber", account.getOrganization().getPhoneNumber()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationAddress1", account.getOrganization().getAddressLine1()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationAddress2", account.getOrganization().getAddressLine2()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationAddress3", account.getOrganization().getAddressLine3()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationZip", account.getOrganization().getZipPostCode()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationCity", account.getOrganization().getCity()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationState", account.getOrganization().getStateProvinceCounty()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationCountry", account.getOrganization().getCountry()));
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
-        }
 
-        return new BaseListLoadResult<GwtGroupedNVPair>(accountPropertiesPairs);
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationName", account.getOrganization().getName()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationContactName", account.getOrganization().getPersonName()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationEmail", account.getOrganization().getEmail()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationPhoneNumber", account.getOrganization().getPhoneNumber()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationAddress1", account.getOrganization().getAddressLine1()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationAddress2", account.getOrganization().getAddressLine2()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationAddress3", account.getOrganization().getAddressLine3()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationZip", account.getOrganization().getZipPostCode()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationCity", account.getOrganization().getCity()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationState", account.getOrganization().getStateProvinceCounty()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(ORGANIZATION_INFO, "organizationCountry", account.getOrganization().getCountry()));
+
+            return new BaseListLoadResult<GwtGroupedNVPair>(accountPropertiesPairs);
+        } catch (Throwable t) {
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
+        }
     }
 
     @Override
@@ -665,40 +647,28 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
     @Override
     public PagingLoadResult<GwtAccount> query(PagingLoadConfig loadConfig, GwtAccountQuery gwtAccountQuery) throws GwtKapuaException {
 
-        int totalLength = 0;
-        List<GwtAccount> gwtAccounts = new ArrayList<GwtAccount>();
         try {
             AccountQuery query = GwtKapuaAccountModelConverter.convertAccountQuery(loadConfig, gwtAccountQuery);
-
             KapuaListResult<Account> accounts = ACCOUNT_SERVICE.query(query);
-            totalLength = accounts.getTotalCount().intValue();
 
+            List<GwtAccount> gwtAccounts = new ArrayList<GwtAccount>();
             if (!accounts.isEmpty()) {
-                UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                    }
-                });
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResult(accounts);
 
-                Map<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : usernames.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
+                for (Account account : accounts.getItems()) {
+                    GwtAccount gwtAccount = KapuaGwtAccountModelConverter.convertAccount(account);
 
-                for (Account a : accounts.getItems()) {
-                    GwtAccount gwtAccount = KapuaGwtAccountModelConverter.convertAccount(a);
-                    gwtAccount.setCreatedByName(usernameMap.get(gwtAccount.getCreatedBy()));
-                    gwtAccount.setModifiedByName(usernameMap.get(gwtAccount.getModifiedBy()));
+                    gwtAccount.setCreatedByName(idUsernameMap.get(account.getCreatedBy()));
+                    gwtAccount.setModifiedByName(idUsernameMap.get(account.getModifiedBy()));
+
                     gwtAccounts.add(gwtAccount);
                 }
             }
+
+            return new BasePagingLoadResult<GwtAccount>(gwtAccounts, loadConfig.getOffset(), accounts.getTotalCount().intValue());
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+           throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
-
-        return new BasePagingLoadResult<GwtAccount>(gwtAccounts, loadConfig.getOffset(), totalLength);
     }
-
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/util/UserCreatedByModifiedByUtils.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/util/UserCreatedByModifiedByUtils.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.api.server.util;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserAttributes;
+import org.eclipse.kapua.service.user.UserFactory;
+import org.eclipse.kapua.service.user.UserListResult;
+import org.eclipse.kapua.service.user.UserQuery;
+import org.eclipse.kapua.service.user.UserService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ * Utils to resolve {@link KapuaEntity#getCreatedBy()} and {@link KapuaUpdatableEntity#getModifiedBy()} into respective {@link User#getName()}.
+ *
+ * @since 2.1.0
+ */
+public class UserCreatedByModifiedByUtils {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
+    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
+
+    /**
+     * Constructor
+     *
+     * @since 2.1.0
+     */
+    private UserCreatedByModifiedByUtils() {
+    }
+
+    /**
+     * Creates a map of {@link User#getId()} and {@link User#getName()} starting from a {@link KapuaListResult} of {@link KapuaEntity}/{@link KapuaUpdatableEntity}
+     * <p>
+     * Retrieves all {@link KapuaEntity#getCreatedBy()} and {@link KapuaUpdatableEntity#getModifiedBy()}.
+     * Then queries the {@link UserService} with the list of {@link User#getId()}.
+     * </p>
+     *
+     * @param entities The {@link KapuaListResult} from which to extract data
+     * @return A {@link Map} of {@link User#getId()} associated with the {@link User#getName()}.
+     * @param <E> The {@link KapuaEntity} type
+     * @throws KapuaException
+     *
+     * @since 2.1.0
+     */
+    public static <E extends KapuaEntity> Map<KapuaId, String> resolveFromListResult(KapuaListResult<E> entities) throws Exception {
+        return resolveFromListResultAndFields(entities, new Callable<Set<KapuaId>>() {
+            @Override
+            public Set<KapuaId> call() {
+                return Collections.emptySet();
+            }
+        });
+    }
+
+    /**
+     * Creates a map of {@link User#getId()} and {@link User#getName()} starting from a {@link KapuaListResult} of {@link KapuaEntity}/{@link KapuaUpdatableEntity}
+     * <p>
+     * Retrieves all {@link KapuaEntity#getCreatedBy()} and {@link KapuaUpdatableEntity#getModifiedBy()} and additionally can extract more {@link User#getId()} from the {@link KapuaEntity} in the {@link KapuaListResult}.
+     * Then queries the {@link UserService} with the list of {@link User#getId()}.
+     * </p>
+     *
+     * @param entities The {@link KapuaListResult} from which to extract data
+     * @return A {@link Map} of {@link User#getId()} associated with the {@link User#getName()}.
+     * @param <E> The {@link KapuaEntity} type
+     * @throws KapuaException
+     *
+     * @since 2.1.0
+     */
+    public static <E extends KapuaEntity> Map<KapuaId, String> resolveFromListResultAndFields(KapuaListResult<E> entities, Callable<Set<KapuaId>> additionalFieldsToResolve) throws Exception {
+
+        // Build list of ids
+        final Set<KapuaId> userIds = new HashSet<KapuaId>();
+
+        for (KapuaEntity entity : entities.getItems()) {
+            if (entity.getCreatedBy() != null) {
+                userIds.add(entity.getCreatedBy());
+            }
+
+            // This handles `KapuaUpdatableEntity.modifiedBy`
+            if (entity instanceof KapuaUpdatableEntity) {
+                KapuaUpdatableEntity updatableEntity = (KapuaUpdatableEntity) entity;
+
+                if (updatableEntity.getModifiedBy() != null) {
+                    userIds.add(updatableEntity.getModifiedBy());
+                }
+            }
+        }
+
+        // Handles additional ids to resolve;
+        userIds.addAll(additionalFieldsToResolve.call());
+
+        // Resolve from ids
+        return resolveFromIds(userIds);
+    }
+
+    /**
+     * Resolves the given {@link User#getId()} to its {@link User#getName()}/
+     *
+     * @param userId The {@link User#getId()} to resolve
+     * @return The {@link User#getName()} if found or {@code null}
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    public static String resolveFromId(final KapuaId userId) throws KapuaException {
+        User resolvedUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+            @Override
+            public User call() throws Exception {
+                return USER_SERVICE.find(userId);
+            }
+        });
+
+        return resolvedUser != null ?
+                resolvedUser.getName() :
+                null;
+    }
+
+    /**
+     * Creates a map of {@link User#getId()} and {@link User#getName()} starting from a {@link Set} of {@link User#getId()}
+     *
+     * @param userIds The {@link Set} of {@link User#getId()}s to resolve
+     * @return A {@link Map} of {@link User#getId()} associated with the {@link User#getName()}.
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    public static HashMap<KapuaId, String> resolveFromIds(final Set<KapuaId> userIds) throws KapuaException {
+        // Query Users to find matching ids
+        UserListResult users = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
+
+            @Override
+            public UserListResult call() throws Exception {
+                UserQuery userQuery = USER_FACTORY.newQuery(KapuaId.ANY);
+
+                userQuery.setPredicate(
+                        userQuery.attributePredicate(UserAttributes.ENTITY_ID, userIds)
+                );
+
+                return USER_SERVICE.query(userQuery);
+            }
+        });
+
+        // Produce map with id and username association
+        HashMap<KapuaId, String> idAndUsernameMap = new HashMap<KapuaId, String>();
+        for (User user : users.getItems()) {
+            idAndUsernameMap.put(user.getId(), user.getName());
+        }
+
+        // Return the map
+        return idAndUsernameMap;
+    }
+}

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
+import org.eclipse.kapua.app.console.module.api.server.util.UserCreatedByModifiedByUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredential;
@@ -41,20 +42,19 @@ import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
 import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
 import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
 import org.eclipse.kapua.service.authentication.credential.CredentialService;
-import org.eclipse.kapua.service.authentication.shiro.utils.AuthenticationUtils;
 import org.eclipse.kapua.service.authentication.user.PasswordChangeRequest;
 import org.eclipse.kapua.service.authentication.user.PasswordResetRequest;
 import org.eclipse.kapua.service.authentication.user.UserCredentialsFactory;
 import org.eclipse.kapua.service.authentication.user.UserCredentialsService;
 import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.service.user.UserFactory;
-import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserService;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implements GwtCredentialService {
@@ -71,60 +71,55 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
     private static final CredentialsFactory CREDENTIALS_FACTORY = LOCATOR.getFactory(CredentialsFactory.class);
 
     private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
-    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
 
     private static final UserCredentialsService USER_CREDENTIALS_SERVICE = LOCATOR.getService(UserCredentialsService.class);
     private static final UserCredentialsFactory USER_CREDENTIALS_FACTORY = LOCATOR.getFactory(UserCredentialsFactory.class);
-    private static final AuthenticationUtils AUTHENTICATION_UTILS = LOCATOR.getComponent(AuthenticationUtils.class);
-
-    // this should be removed due to the refactoring in fixPasswordValidationBypass method
-    private static final int SYSTEM_MAXIMUM_PASSWORD_LENGTH = 255;
 
     @Override
     public PagingLoadResult<GwtCredential> query(PagingLoadConfig loadConfig, final GwtCredentialQuery gwtCredentialQuery) throws GwtKapuaException {
-        int totalLength = 0;
-        List<GwtCredential> gwtCredentials = new ArrayList<GwtCredential>();
         try {
 
             // Convert from GWT entity
             CredentialQuery credentialQuery = GwtKapuaAuthenticationModelConverter.convertCredentialQuery(loadConfig, gwtCredentialQuery);
 
             // query
-            CredentialListResult credentials = CREDENTIAL_SERVICE.query(credentialQuery);
+            final CredentialListResult credentials = CREDENTIAL_SERVICE.query(credentialQuery);
             credentials.sort(credentialComparator);
-            totalLength = credentials.getTotalCount().intValue();
 
             // If there are results
+            List<GwtCredential> gwtCredentials = new ArrayList<GwtCredential>();
             if (!credentials.isEmpty()) {
-                //TODO: #LAYER_VIOLATION - user lookup should not be done here
-                UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtCredentialQuery.getScopeId())));
-                    }
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResultAndFields(
+                        credentials,
+                        new Callable<Set<KapuaId>>() {
+                            @Override
+                            public Set<KapuaId> call() {
+                                Set<KapuaId> additionalKapuaIds = new HashSet<KapuaId>();
+                                for (Credential credential : credentials.getItems()) {
+                                    additionalKapuaIds.add(credential.getUserId());
+                                }
+
+                                return additionalKapuaIds;
+                            }
                 });
-
-                HashMap<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : userListResult.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
 
                 // Convert to GWT entity
                 for (Credential credential : credentials.getItems()) {
                     GwtCredential gwtCredential = KapuaGwtAuthenticationModelConverter.convertCredential(credential);
-                    gwtCredential.setUsername(usernameMap.get(credential.getUserId().toCompactId()));
-                    gwtCredential.setCreatedByName(usernameMap.get(credential.getCreatedBy().toCompactId()));
-                    gwtCredential.setModifiedByName(usernameMap.get(credential.getModifiedBy().toCompactId()));
+
+                    gwtCredential.setUsername(idUsernameMap.get(credential.getUserId()));
+                    gwtCredential.setCreatedByName(idUsernameMap.get(credential.getCreatedBy()));
+                    gwtCredential.setModifiedByName(idUsernameMap.get(credential.getModifiedBy()));
+
                     gwtCredentials.add(gwtCredential);
                 }
             }
 
+            return new BasePagingLoadResult<GwtCredential>(gwtCredentials, loadConfig.getOffset(), credentials.getTotalCount().intValue());
         } catch (Throwable t) {
             throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
-
-        return new BasePagingLoadResult<GwtCredential>(gwtCredentials, loadConfig.getOffset(), totalLength);
     }
 
     @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
+import org.eclipse.kapua.app.console.module.api.server.util.UserCreatedByModifiedByUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
@@ -30,7 +31,6 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGrou
 import org.eclipse.kapua.app.console.module.authorization.shared.util.GwtKapuaAuthorizationModelConverter;
 import org.eclipse.kapua.app.console.module.authorization.shared.util.KapuaGwtAuthorizationModelConverter;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.group.Group;
@@ -39,16 +39,10 @@ import org.eclipse.kapua.service.authorization.group.GroupFactory;
 import org.eclipse.kapua.service.authorization.group.GroupListResult;
 import org.eclipse.kapua.service.authorization.group.GroupQuery;
 import org.eclipse.kapua.service.authorization.group.GroupService;
-import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.service.user.UserFactory;
-import org.eclipse.kapua.service.user.UserListResult;
-import org.eclipse.kapua.service.user.UserService;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements GwtGroupService {
 
@@ -58,9 +52,6 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
 
     private static final GroupService GROUP_SERVICE = LOCATOR.getService(GroupService.class);
     private static final GroupFactory GROUP_FACTORY = LOCATOR.getFactory(GroupFactory.class);
-
-    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
-    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
 
     private static final String ENTITY_INFO = "entityInfo";
 
@@ -122,40 +113,31 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
     }
 
     @Override
-    public PagingLoadResult<GwtGroup> query(PagingLoadConfig loadConfig,
-                                            final GwtGroupQuery gwtGroupQuery) throws GwtKapuaException {
-        int totalLength = 0;
-        List<GwtGroup> gwtGroupList = new ArrayList<GwtGroup>();
+    public PagingLoadResult<GwtGroup> query(PagingLoadConfig loadConfig, GwtGroupQuery gwtGroupQuery) throws GwtKapuaException {
         try {
             GroupQuery groupQuery = GwtKapuaAuthorizationModelConverter.convertGroupQuery(loadConfig, gwtGroupQuery);
+
             GroupListResult groups = GROUP_SERVICE.query(groupQuery);
-            totalLength = groups.getTotalCount().intValue();
 
+            List<GwtGroup> gwtGroupList = new ArrayList<GwtGroup>();
             if (!groups.isEmpty()) {
-                UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                    }
-                });
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResult(groups);
 
-                Map<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : usernames.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
+                for (Group group : groups.getItems()) {
+                    GwtGroup gwtGroup = KapuaGwtAuthorizationModelConverter.convertGroup(group);
 
-                for (Group g : groups.getItems()) {
-                    GwtGroup gwtGroup = KapuaGwtAuthorizationModelConverter.convertGroup(g);
-                    gwtGroup.setCreatedByName(usernameMap.get(g.getCreatedBy().toCompactId()));
+                    gwtGroup.setCreatedByName(idUsernameMap.get(group.getCreatedBy()));
+                    gwtGroup.setModifiedByName(idUsernameMap.get(group.getModifiedBy()));
+
                     gwtGroupList.add(gwtGroup);
                 }
             }
-        } catch (Exception e) {
-            KapuaExceptionHandler.handle(e);
-        }
 
-        return new BasePagingLoadResult<GwtGroup>(gwtGroupList, loadConfig.getOffset(), totalLength);
+            return new BasePagingLoadResult<GwtGroup>(gwtGroupList, loadConfig.getOffset(), groups.getTotalCount().intValue());
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
+        }
     }
 
     @Override
@@ -173,44 +155,30 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
     }
 
     @Override
-    public ListLoadResult<GwtGroupedNVPair> getGroupDescription(String scopeShortId,
-                                                                String groupShortId) throws GwtKapuaException {
-        List<GwtGroupedNVPair> gwtGroupDescription = new ArrayList<GwtGroupedNVPair>();
+    public ListLoadResult<GwtGroupedNVPair> getGroupDescription(String scopeShortId, String groupShortId) throws GwtKapuaException {
         try {
-            final KapuaId scopeId = KapuaEid.parseCompactId(scopeShortId);
+            KapuaId scopeId = KapuaEid.parseCompactId(scopeShortId);
             KapuaId groupId = KapuaEid.parseCompactId(groupShortId);
 
-            final Group group = GROUP_SERVICE.find(scopeId, groupId);
+            Group group = GROUP_SERVICE.find(scopeId, groupId);
 
-            //TODO: #LAYER_VIOLATION - user lookup should not be done here (horribly inefficient)
-            UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
-
-                @Override
-                public UserListResult call() throws Exception {
-                    return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                }
-            });
-
-            Map<String, String> usernameMap = new HashMap<String, String>();
-            for (User user : userListResult.getItems()) {
-                usernameMap.put(user.getId().toCompactId(), user.getName());
-            }
-
+            List<GwtGroupedNVPair> gwtGroupDescription = new ArrayList<GwtGroupedNVPair>();
             if (group != null) {
                 // gwtGroupDescription.add(new GwtGroupedNVPair("Entity", "Scope
                 // Id", KapuaGwtAuthenticationModelConverter.convertKapuaId(group.getScopeId())));
                 gwtGroupDescription.add(new GwtGroupedNVPair("accessGroupInfo", "accessGroupName", group.getName()));
                 gwtGroupDescription.add(new GwtGroupedNVPair("accessGroupInfo", "accessGroupDescription", group.getDescription()));
-                gwtGroupDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "accessGroupModifiedOn", group.getModifiedOn()));
-                gwtGroupDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "accessGroupModifiedBy", group.getModifiedBy() != null ? usernameMap.get(group.getModifiedBy().toCompactId()) : null));
                 gwtGroupDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "accessGroupCreatedOn", group.getCreatedOn()));
-                gwtGroupDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "accessGroupCreatedBy", group.getCreatedBy() != null ? usernameMap.get(group.getCreatedBy().toCompactId()) : null));
+                gwtGroupDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "accessGroupCreatedBy", UserCreatedByModifiedByUtils.resolveFromId(group.getCreatedBy())));
+                gwtGroupDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "accessGroupModifiedOn", group.getModifiedOn()));
+                gwtGroupDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "accessGroupModifiedBy", UserCreatedByModifiedByUtils.resolveFromId(group.getModifiedBy())));
 
             }
+
+            return new BaseListLoadResult<GwtGroupedNVPair>(gwtGroupDescription);
         } catch (Exception e) {
-            KapuaExceptionHandler.handle(e);
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
-        return new BaseListLoadResult<GwtGroupedNVPair>(gwtGroupDescription);
     }
 
     @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
+import org.eclipse.kapua.app.console.module.api.server.util.UserCreatedByModifiedByUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
@@ -58,13 +59,8 @@ import org.eclipse.kapua.service.authorization.role.RolePermissionQuery;
 import org.eclipse.kapua.service.authorization.role.RolePermissionService;
 import org.eclipse.kapua.service.authorization.role.RoleQuery;
 import org.eclipse.kapua.service.authorization.role.RoleService;
-import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.service.user.UserFactory;
-import org.eclipse.kapua.service.user.UserListResult;
-import org.eclipse.kapua.service.user.UserService;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -82,9 +78,6 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
     private static final RolePermissionService ROLE_PERMISSION_SERVICE = LOCATOR.getService(RolePermissionService.class);
     private static final RolePermissionFactory ROLE_PERMISSION_FACTORY = LOCATOR.getFactory(RolePermissionFactory.class);
-
-    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
-    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
 
     private static final GroupService GROUP_SERVICE = LOCATOR.getService(GroupService.class);
 
@@ -157,53 +150,38 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
     @Override
     public PagingLoadResult<GwtRole> query(PagingLoadConfig loadConfig, final GwtRoleQuery gwtRoleQuery) throws GwtKapuaException {
-        // Do query
-        int totalLength = 0;
-        List<GwtRole> gwtRoles = new ArrayList<GwtRole>();
 
         try {
             // Convert from GWT entity
             RoleQuery roleQuery = GwtKapuaAuthorizationModelConverter.convertRoleQuery(loadConfig, gwtRoleQuery);
 
-            // query
+            // Query
             RoleListResult roles = ROLE_SERVICE.query(roleQuery);
-            totalLength = roles.getTotalCount().intValue();
 
+            // Convert results
+            List<GwtRole> gwtRoles = new ArrayList<GwtRole>();
             if (!roles.isEmpty()) {
-                //TODO: #LAYER_VIOLATION - user lookup should not be done here (horribly inefficient)
-                UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
-
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                    }
-                });
-
-                Map<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : usernames.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResult(roles);
 
                 // Converto to GWT entity
-                for (Role r : roles.getItems()) {
-                    GwtRole gwtRole = KapuaGwtAuthorizationModelConverter.convertRole(r);
-                    gwtRole.setCreatedByName(usernameMap.get(r.getCreatedBy().toCompactId()));
-                    gwtRole.setModifiedByName(usernameMap.get(r.getModifiedBy().toCompactId()));
+                for (Role role : roles.getItems()) {
+                    GwtRole gwtRole = KapuaGwtAuthorizationModelConverter.convertRole(role);
+
+                    gwtRole.setCreatedByName(idUsernameMap.get(role.getCreatedBy()));
+                    gwtRole.setModifiedByName(idUsernameMap.get(role.getModifiedBy()));
+
                     gwtRoles.add(gwtRole);
                 }
             }
 
+            return new BasePagingLoadResult<GwtRole>(gwtRoles, loadConfig.getOffset(), roles.getTotalCount().intValue());
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
-
-        return new BasePagingLoadResult<GwtRole>(gwtRoles, loadConfig.getOffset(), totalLength);
     }
 
     @Override
     public ListLoadResult<GwtGroupedNVPair> getRoleDescription(String scopeShortId, String roleShortId) throws GwtKapuaException {
-        // Do get
-        List<GwtGroupedNVPair> gwtRoleDescription = new ArrayList<GwtGroupedNVPair>();
         try {
             // Convert from GWT Entity
             final KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(scopeShortId);
@@ -211,41 +189,26 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
             // Find
             final Role role = ROLE_SERVICE.find(scopeId, roleId);
-            UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
-
-                @Override
-                public UserListResult call() throws Exception {
-                    return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                }
-            });
-
-            Map<String, String> usernameMap = new HashMap<String, String>();
-            for (User user : userListResult.getItems()) {
-                usernameMap.put(user.getId().toCompactId(), user.getName());
-            }
 
             // If there are results
+            List<GwtGroupedNVPair> gwtRoleDescription = new ArrayList<GwtGroupedNVPair>();
             if (role != null) {
                 gwtRoleDescription.add(new GwtGroupedNVPair("roleInfo", "roleName", role.getName()));
                 gwtRoleDescription.add(new GwtGroupedNVPair("roleInfo", "roleDescription", role.getDescription()));
-                gwtRoleDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "roleModifiedOn", role.getModifiedOn()));
-                gwtRoleDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "roleModifiedBy", role.getModifiedBy() != null ? usernameMap.get(role.getModifiedBy().toCompactId()) : null));
                 gwtRoleDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "roleCreatedOn", role.getCreatedOn()));
-                gwtRoleDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "roleCreatedBy", role.getCreatedBy() != null ? usernameMap.get(role.getCreatedBy().toCompactId()) : null));
+                gwtRoleDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "roleCreatedBy", UserCreatedByModifiedByUtils.resolveFromId(role.getCreatedBy())));
+                gwtRoleDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "roleModifiedOn", role.getModifiedOn()));
+                gwtRoleDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "roleModifiedBy", UserCreatedByModifiedByUtils.resolveFromId(role.getModifiedBy())));
             }
 
+            return new BaseListLoadResult<GwtGroupedNVPair>(gwtRoleDescription);
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
-
-        return new BaseListLoadResult<GwtGroupedNVPair>(gwtRoleDescription);
     }
 
     @Override
     public PagingLoadResult<GwtRolePermission> getRolePermissions(PagingLoadConfig loadConfig, String scopeShortId, String roleShortId) throws GwtKapuaException {
-        // Do get
-        int totalLength = 0;
-        List<GwtRolePermission> gwtRolePermissions = new ArrayList<GwtRolePermission>();
         try {
             // Convert from GWT Entity
             KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(scopeShortId);
@@ -267,51 +230,41 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
             query.setSortCriteria(sortCriteria);
             query.setAskTotalCount(true);
 
-            RolePermissionListResult list = ROLE_PERMISSION_SERVICE.query(query);
-            totalLength = list.getTotalCount().intValue();
+            RolePermissionListResult rolePermissions = ROLE_PERMISSION_SERVICE.query(query);
 
-            if (list != null) {
-                for (final RolePermission rolePermission : list.getItems()) {
-                    User createdByUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+            List<GwtRolePermission> gwtRolePermissions = new ArrayList<GwtRolePermission>();
+            for (final RolePermission rolePermission : rolePermissions.getItems()) {
+                Account targetScopeIdAccount = null;
+                if (rolePermission.getPermission().getTargetScopeId() != null) {
+                    targetScopeIdAccount = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
 
                         @Override
-                        public User call() throws Exception {
-                            return USER_SERVICE.find(rolePermission.getScopeId(), rolePermission.getCreatedBy());
+                        public Account call() throws Exception {
+                            return ACCOUNT_SERVICE.find(rolePermission.getScopeId(), rolePermission.getPermission().getTargetScopeId());
                         }
                     });
-
-                    Account targetScopeIdAccount = null;
-                    if (rolePermission.getPermission().getTargetScopeId() != null) {
-                        targetScopeIdAccount = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
-
-                            @Override
-                            public Account call() throws Exception {
-                                return ACCOUNT_SERVICE.find(rolePermission.getScopeId(), rolePermission.getPermission().getTargetScopeId());
-                            }
-                        });
-                    }
-
-                    GwtRolePermission gwtRolePermission = KapuaGwtAuthorizationModelConverter.convertRolePermission(rolePermission);
-                    if (rolePermission.getPermission().getGroupId() != null) {
-                        Group group = GROUP_SERVICE.find(rolePermission.getScopeId(), rolePermission.getPermission().getGroupId());
-                        if (group != null) {
-                            gwtRolePermission.setGroupName(group.getName());
-                        }
-                    } else {
-                        gwtRolePermission.setGroupName("ALL");
-                    }
-
-                    gwtRolePermission.setCreatedByName(createdByUser != null ? createdByUser.getName() : null);
-                    gwtRolePermission.setTargetScopeIdByName(targetScopeIdAccount != null ? targetScopeIdAccount.getName() : null);
-
-                    gwtRolePermissions.add(gwtRolePermission);
                 }
-            }
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
-        }
 
-        return new BasePagingLoadResult<GwtRolePermission>(gwtRolePermissions, loadConfig.getOffset(), totalLength);
+                GwtRolePermission gwtRolePermission = KapuaGwtAuthorizationModelConverter.convertRolePermission(rolePermission);
+                if (rolePermission.getPermission().getGroupId() != null) {
+                    Group group = GROUP_SERVICE.find(rolePermission.getScopeId(), rolePermission.getPermission().getGroupId());
+                    if (group != null) {
+                        gwtRolePermission.setGroupName(group.getName());
+                    }
+                } else {
+                    gwtRolePermission.setGroupName("ALL");
+                }
+
+                gwtRolePermission.setCreatedByName(UserCreatedByModifiedByUtils.resolveFromId(rolePermission.getCreatedBy()));
+                gwtRolePermission.setTargetScopeIdByName(targetScopeIdAccount != null ? targetScopeIdAccount.getName() : null);
+
+                gwtRolePermissions.add(gwtRolePermission);
+            }
+
+            return new BasePagingLoadResult<GwtRolePermission>(gwtRolePermissions, loadConfig.getOffset(), rolePermissions.getTotalCount().intValue());
+        } catch (Throwable t) {
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
+        }
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.client.connection;
 
-import com.extjs.gxt.ui.client.data.ListLoadResult;
-import com.extjs.gxt.ui.client.event.BaseEvent;
-import com.extjs.gxt.ui.client.event.Events;
-import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.data.BasePagingLoader;
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.extjs.gxt.ui.client.data.RpcProxy;
 import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.form.CheckBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
@@ -40,6 +40,7 @@ import org.eclipse.kapua.app.console.module.device.shared.model.connection.GwtDe
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceConnectionOptionService;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceConnectionOptionServiceAsync;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
+import org.eclipse.kapua.app.console.module.user.shared.model.GwtUserQuery;
 import org.eclipse.kapua.app.console.module.user.shared.model.permission.UserSessionPermission;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserService;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserServiceAsync;
@@ -84,14 +85,7 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         FormLayout layoutSecurityOptions = new FormLayout();
         layoutSecurityOptions.setLabelWidth(Constants.LABEL_WIDTH_DEVICE_FORM);
 
-        Listener<BaseEvent> comboBoxListener = new Listener<BaseEvent>() {
-
-            @Override
-            public void handleEvent(BaseEvent be) {
-                formPanel.fireEvent(Events.OnClick);
-            }
-        };
-
+        // Last User
         lastUserField = new LabelField();
         lastUserField.setName("connectionUserLastUserField");
         lastUserField.setLabelSeparator(":");
@@ -118,61 +112,55 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         couplingModeCombo.setSimpleValue(GwtConnectionUserCouplingMode.INHERITED.getLabel());
         groupFormPanel.add(couplingModeCombo);
 
-        reservedUserCombo = new ComboBox<GwtUser>();
-        reservedUserCombo.setName("connectionUserReservedUserCombo");
-        reservedUserCombo.setEditable(false);
-        reservedUserCombo.setTypeAhead(false);
-        reservedUserCombo.setAllowBlank(false);
-        reservedUserCombo.setFieldLabel(MSGS.connectionFormReservedUser());
-        reservedUserCombo.setToolTip(MSGS.connectionFormReservedUserTooltip());
-        reservedUserCombo.setTriggerAction(TriggerAction.ALL);
-        reservedUserCombo.setStore(new ListStore<GwtUser>());
-        reservedUserCombo.setDisplayField("username");
-        reservedUserCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={username}>{username}</div></tpl>");
-        reservedUserCombo.setValueField("id");
-        reservedUserCombo.addListener(Events.Select, comboBoxListener);
+        //
+        // Reserved User
+        if (currentSession.hasPermission(UserSessionPermission.read())) {
 
+            reservedUserCombo = new ComboBox<GwtUser>();
+            reservedUserCombo.setName("connectionUserReservedUserCombo");
+            reservedUserCombo.setEditable(true);
+            reservedUserCombo.setTypeAhead(false);
+            reservedUserCombo.setAllowBlank(true);
+            reservedUserCombo.setEmptyText("No user");
+            reservedUserCombo.setFieldLabel(MSGS.connectionFormReservedUser());
+            reservedUserCombo.setToolTip(MSGS.connectionFormReservedUserTooltip());
+            reservedUserCombo.setTriggerAction(TriggerAction.QUERY);
+            reservedUserCombo.setDisplayField("username");
+            reservedUserCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={username}>{username}</div></tpl>");
+            reservedUserCombo.setValueField("id");
+            groupFormPanel.add(reservedUserCombo);
+
+            reservedUserCombo.setPageSize(100);
+        }
+
+        RpcProxy<PagingLoadResult<GwtUser>> userDataProxy = new RpcProxy<PagingLoadResult<GwtUser>>() {
+
+            @Override
+            protected void load(Object loadConfig, AsyncCallback<PagingLoadResult<GwtUser>> callback) {
+
+                GwtUserQuery query = new GwtUserQuery();
+                query.setScopeId(selectedDeviceConnection.getScopeId());
+                query.setName(reservedUserCombo.getRawValue()); // This filters results with the user keyword used
+
+                GWT_USER_SERVICE.query((PagingLoadConfig) loadConfig,
+                        query,
+                        callback);
+            }
+        };
+
+        BasePagingLoader<PagingLoadResult<GwtUser>> userPagingLoader = new BasePagingLoader<PagingLoadResult<GwtUser>>(userDataProxy);
+        ListStore<GwtUser> userListStore = new ListStore<GwtUser>(userPagingLoader);
+
+        reservedUserCombo.setStore(userListStore);
+
+        //
         // Allow credential change
         allowUserChangeCheckbox = new CheckBox();
         allowUserChangeCheckbox.setName("connectionUserAllowUserChangeCheckbox");
         allowUserChangeCheckbox.setFieldLabel(MSGS.connectionFormAllowUserChange());
         allowUserChangeCheckbox.setToolTip(MSGS.connectionFormAllowUserChangeTooltip());
         allowUserChangeCheckbox.setBoxLabel("");
-
-        if (currentSession.hasPermission(UserSessionPermission.read())) {
-            // Device User
-            GWT_USER_SERVICE.findAll(currentSession.getSelectedAccountId(), new AsyncCallback<ListLoadResult<GwtUser>>() {
-
-                @Override
-                public void onFailure(Throwable caught) {
-                    exitStatus = false;
-                    if (!isPermissionErrorMessage(caught)) {
-                        FailureHandler.handle(caught);
-                        hide();
-                    }
-                }
-
-                @Override
-                public void onSuccess(ListLoadResult<GwtUser> result) {
-                    reservedUserCombo.getStore().removeAll();
-                    reservedUserCombo.getStore().add(NO_USER);
-                    for (GwtUser gwtUser : result.getData()) {
-                        reservedUserCombo.getStore().add(gwtUser);
-                    }
-                    setReservedUser();
-                }
-
-            });
-
-            groupFormPanel.add(reservedUserCombo);
-            groupFormPanel.add(allowUserChangeCheckbox);
-
-        } else {
-            GwtUser selectedUser = new GwtUser();
-            selectedUser.setId(selectedDeviceConnection.getReservedUserId());
-            reservedUserCombo.getStore().add(selectedUser);
-            reservedUserCombo.setValue(selectedUser);
-        }
+        groupFormPanel.add(allowUserChangeCheckbox);
 
         // Authentication type
         authenticationTypeCombo = new SimpleComboBox<String>();
@@ -226,8 +214,11 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         GwtDeviceConnectionOption selectedDeviceConnectionOption = new GwtDeviceConnectionOption(selectedDeviceConnection);
         selectedDeviceConnectionOption.setAllowUserChange(allowUserChangeCheckbox.getValue());
         selectedDeviceConnectionOption.setConnectionUserCouplingMode(couplingModeCombo.getValue() != null ? couplingModeCombo.getValue().getValue() : null);
-        selectedDeviceConnectionOption.setReservedUserId(reservedUserCombo.getValue() != null ? reservedUserCombo.getValue().getId() : null);
         selectedDeviceConnectionOption.setAuthenticationType(authenticationTypeCombo.getSimpleValue());
+
+        if (currentSession.hasPermission(UserSessionPermission.read())) {
+            selectedDeviceConnectionOption.setReservedUserId(reservedUserCombo.getValue() != null ? reservedUserCombo.getValue().getId() : null);
+        }
 
         GWT_CONNECTION_OPTION_SERVICE.update(xsrfToken, selectedDeviceConnectionOption, new AsyncCallback<GwtDeviceConnectionOption>() {
 
@@ -293,11 +284,13 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         } else {
             lastUserField.setValue("N/A");
         }
+
         GwtConnectionUserCouplingMode gwtConnectionUserCouplingMode = null;
         if (gwtDeviceConnection.getConnectionUserCouplingMode() != null) {
             gwtConnectionUserCouplingMode = GwtConnectionUserCouplingMode.getEnumFromLabel(gwtDeviceConnection.getConnectionUserCouplingMode());
         }
         couplingModeCombo.setSimpleValue(gwtConnectionUserCouplingMode != null ? gwtConnectionUserCouplingMode.getLabel() : "N/A");
+        setReservedUser();
         allowUserChangeCheckbox.setValue(gwtDeviceConnection.getAllowUserChange());
         authenticationTypeCombo.setSimpleValue(gwtDeviceConnection.getAuthenticationType());
         lastAuthenticationTypeLabel.setValue(gwtDeviceConnection.getLastAuthenticationType() != null ? gwtDeviceConnection.getLastAuthenticationType() : "N/A");
@@ -312,19 +305,39 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
     }
 
     private void setReservedUser() {
-        for (GwtUser gwtUser : reservedUserCombo.getStore().getModels()) {
-            if (gwtUser.getId() == null) {
-                if (selectedDeviceConnection.getReservedUserId() == null) {
-                    reservedUserCombo.setValue(gwtUser);
+        String reservedUserId = selectedDeviceConnection.getReservedUserId();
+
+        if (reservedUserId != null) {
+            for (GwtUser listStoreUser : reservedUserCombo.getStore().getModels()) {
+                if (listStoreUser.getId().equals(reservedUserId)) {
+                    reservedUserCombo.setValue(listStoreUser);
+
+                    return;
                 }
-            } else if (gwtUser.getId().equals(selectedDeviceConnection.getReservedUserId())) {
-                reservedUserCombo.setValue(gwtUser);
-                break;
-            } else {
-                reservedUserCombo.setValue(NO_USER);
             }
+
+            // If not found in the current page of the list store...
+            GWT_USER_SERVICE.find(currentSession.getSelectedAccountId(), selectedDeviceConnection.getReservedUserId(), new AsyncCallback<GwtUser>() {
+
+                @Override
+                public void onFailure(Throwable caught) {
+                    exitStatus = false;
+                    if (!isPermissionErrorMessage(caught)) {
+                        FailureHandler.handle(caught);
+                        hide();
+                    }
+                }
+
+                @Override
+                public void onSuccess(GwtUser reservedUser) {
+                    if (reservedUser != null) {
+                        reservedUserCombo.setValue(reservedUser);
+                    } else {
+                        // ??
+                    }
+                }
+            });
         }
-        formPanel.clearDirtyFields();
     }
 
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceConnectionServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceConnectionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,9 +20,9 @@ import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
+import org.eclipse.kapua.app.console.module.api.server.util.UserCreatedByModifiedByUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
-import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
 import org.eclipse.kapua.app.console.module.device.shared.model.connection.GwtDeviceConnection;
 import org.eclipse.kapua.app.console.module.device.shared.model.connection.GwtDeviceConnection.GwtConnectionUserCouplingMode;
 import org.eclipse.kapua.app.console.module.device.shared.model.connection.GwtDeviceConnectionQuery;
@@ -31,7 +31,6 @@ import org.eclipse.kapua.app.console.module.device.shared.util.GwtKapuaDeviceMod
 import org.eclipse.kapua.app.console.module.device.shared.util.KapuaGwtDeviceModelConverter;
 import org.eclipse.kapua.commons.model.domains.Domains;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -41,16 +40,12 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionQuery;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
-import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.service.user.UserFactory;
-import org.eclipse.kapua.service.user.UserListResult;
-import org.eclipse.kapua.service.user.UserQuery;
-import org.eclipse.kapua.service.user.UserService;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 /**
@@ -65,57 +60,60 @@ public class GwtDeviceConnectionServiceImpl extends KapuaRemoteServiceServlet im
     private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
 
     private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
-    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
-    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
-
     private static final String CONNECTION_INFO = "connectionInfo";
     private static final String CONNECTION_USER_COUPLING_MODE_INFO = "connectionUserCouplingModeInfo";
 
     @Override
     public PagingLoadResult<GwtDeviceConnection> query(PagingLoadConfig loadConfig, GwtDeviceConnectionQuery gwtDeviceConnectionQuery) throws GwtKapuaException {
-
-        int totalLength = 0;
-        List<GwtDeviceConnection> gwtDeviceConnections = new ArrayList<GwtDeviceConnection>();
         try {
             DeviceConnectionQuery query = GwtKapuaDeviceModelConverter.convertConnectionQuery(loadConfig, gwtDeviceConnectionQuery);
 
-            KapuaListResult<DeviceConnection> deviceConnections = DEVICE_CONNECTION_SERVICE.query(query);
-            totalLength = deviceConnections.getTotalCount().intValue();
+            final KapuaListResult<DeviceConnection> deviceConnections = DEVICE_CONNECTION_SERVICE.query(query);
 
+            List<GwtDeviceConnection> gwtDeviceConnections = new ArrayList<GwtDeviceConnection>();
             if (!deviceConnections.isEmpty()) {
-                Map<String, String> users = new HashMap<String, String>();
-                final UserQuery userQuery = USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtDeviceConnectionQuery.getScopeId()));
 
-//TODO: #LAYER_VIOLATION - user lookup logic should not be done here (fetching all users is incredibly inefficient anyway)
-                UserListResult userList = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResultAndFields(
+                        deviceConnections,
+                        new Callable<Set<KapuaId>>() {
+                            @Override
+                            public Set<KapuaId> call() {
+                                Set<KapuaId> additionalKapuaIds = new HashSet<KapuaId>();
+                                for (DeviceConnection deviceConnection : deviceConnections.getItems()) {
+                                    if (deviceConnection.getUserId() != null) {
+                                        additionalKapuaIds.add(deviceConnection.getUserId());
+                                    }
+                                    if (deviceConnection.getReservedUserId() != null) {
+                                        additionalKapuaIds.add(deviceConnection.getReservedUserId());
+                                    }
+                                }
 
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(userQuery);
+                                return additionalKapuaIds;
+                            }
+                        });
+
+                for (DeviceConnection deviceConnection : deviceConnections.getItems()) {
+                    GwtDeviceConnection gwtDeviceConnection = KapuaGwtDeviceModelConverter.convertDeviceConnection(deviceConnection);
+
+                    gwtDeviceConnection.setCreatedByName(idUsernameMap.get(deviceConnection.getCreatedBy()));
+                    gwtDeviceConnection.setModifiedBy(idUsernameMap.get(deviceConnection.getModifiedBy()));
+
+                    if (deviceConnection.getUserId() != null) {
+                        gwtDeviceConnection.setUserName(idUsernameMap.get(deviceConnection.getUserId()));
                     }
-                });
-                for (User user : userList.getItems()) {
-                    users.put(user.getId().toCompactId(), user.getName());
-                }
 
-                for (DeviceConnection dc : deviceConnections.getItems()) {
-                    GwtDeviceConnection gwtDeviceConnection = KapuaGwtDeviceModelConverter.convertDeviceConnection(dc);
-                    if (dc.getUserId() != null) {
-                        gwtDeviceConnection.setUserName(users.get(dc.getUserId().toCompactId()));
-                    }
-
-                    if (dc.getReservedUserId() != null) {
-                        gwtDeviceConnection.setReservedUserName(users.get(dc.getReservedUserId().toCompactId()));
+                    if (deviceConnection.getReservedUserId() != null) {
+                        gwtDeviceConnection.setReservedUserName(idUsernameMap.get(deviceConnection.getReservedUserId()));
                     }
 
                     gwtDeviceConnections.add(gwtDeviceConnection);
                 }
             }
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
-        }
 
-        return new BasePagingLoadResult<GwtDeviceConnection>(gwtDeviceConnections, loadConfig.getOffset(), totalLength);
+            return new BasePagingLoadResult<GwtDeviceConnection>(gwtDeviceConnections, loadConfig.getOffset(), deviceConnections.getTotalCount().intValue());
+        } catch (Throwable t) {
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
+        }
     }
 
     @Override
@@ -135,77 +133,43 @@ public class GwtDeviceConnectionServiceImpl extends KapuaRemoteServiceServlet im
     }
 
     @Override
-    public ListLoadResult<GwtGroupedNVPair> getConnectionInfo(String scopeIdString, String gwtDeviceConnectionId) throws GwtKapuaException {
-        KapuaId deviceConnectionId = KapuaEid.parseCompactId(gwtDeviceConnectionId);
-        final KapuaId scopeId = KapuaEid.parseCompactId(scopeIdString);
-
-        List<GwtGroupedNVPair> deviceConnectionPropertiesPairs = new ArrayList<GwtGroupedNVPair>();
+    public ListLoadResult<GwtGroupedNVPair> getConnectionInfo(String scopeIdString, String gwtDeviceConnectionId)
+            throws GwtKapuaException {
         try {
-            final DeviceConnection deviceConnection = DEVICE_CONNECTION_SERVICE.find(scopeId, deviceConnectionId);
-//TODO: #LAYER_VIOLATION - user lookup logic should not be done here
-            User connectionUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+            KapuaId scopeId = KapuaEid.parseCompactId(scopeIdString);
+            KapuaId deviceConnectionId = KapuaEid.parseCompactId(gwtDeviceConnectionId);
 
-                @Override
-                public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, deviceConnection.getUserId());
-                }
-            });
-            User createdUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+            DeviceConnection deviceConnection = DEVICE_CONNECTION_SERVICE.find(scopeId, deviceConnectionId);
 
-                @Override
-                public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, deviceConnection.getCreatedBy());
-                }
-            });
-            User modifiedUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
-
-                @Override
-                public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, deviceConnection.getModifiedBy());
-                }
-            });
-
-            User reservedUser;
-            if (deviceConnection.getReservedUserId() != null) {
-                reservedUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
-
-                    @Override
-                    public User call() throws Exception {
-                        return USER_SERVICE.find(scopeId, deviceConnection.getReservedUserId());
-                    }
-                });
-            } else {
-                reservedUser = null;
-            }
-
+            List<GwtGroupedNVPair> deviceConnectionPropertiesPairs = new ArrayList<GwtGroupedNVPair>();
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionStatus", deviceConnection.getStatus().toString()));
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionModifiedOn", deviceConnection.getModifiedOn()));
-            deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionModifiedBy", modifiedUser != null ? modifiedUser.getName() : null));
+            deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionModifiedBy", UserCreatedByModifiedByUtils.resolveFromId(deviceConnection.getModifiedBy())));
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionProtocol", deviceConnection.getProtocol()));
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionClientId", deviceConnection.getClientId()));
-            deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionUser", connectionUser != null ? connectionUser.getName() : null));
+            deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionUser", UserCreatedByModifiedByUtils.resolveFromId(deviceConnection.getUserId())));
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionClientIp", deviceConnection.getClientIp()));
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionServerIp", deviceConnection.getServerIp()));
             GwtConnectionUserCouplingMode gwtConnectionUserCouplingMode = null;
             if (deviceConnection.getUserCouplingMode() != null) {
                 gwtConnectionUserCouplingMode = GwtConnectionUserCouplingMode.valueOf(deviceConnection.getUserCouplingMode().name());
             }
-            deviceConnectionPropertiesPairs
-                    .add(new GwtGroupedNVPair(CONNECTION_USER_COUPLING_MODE_INFO, "connectionUserCouplingMode", gwtConnectionUserCouplingMode != null ? gwtConnectionUserCouplingMode.getLabel() : null));
+            deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_USER_COUPLING_MODE_INFO, "connectionUserCouplingMode", gwtConnectionUserCouplingMode != null ? gwtConnectionUserCouplingMode.getLabel() : null));
+
             if (AUTHORIZATION_SERVICE.isPermitted(PERMISSION_FACTORY.newPermission(Domains.USER, Actions.read, scopeId))) {
-                deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_USER_COUPLING_MODE_INFO, "connectionReservedUser", reservedUser != null ? reservedUser.getName() : null));
+                deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_USER_COUPLING_MODE_INFO, "connectionReservedUser", deviceConnection.getReservedUserId() != null ? UserCreatedByModifiedByUtils.resolveFromId(deviceConnection.getReservedUserId()) : null));
                 deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_USER_COUPLING_MODE_INFO, "allowUserChange", deviceConnection.getAllowUserChange()));
             }
+
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionAuthenticationType", deviceConnection.getAuthenticationType()));
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionLastAuthenticationType", deviceConnection.getLastAuthenticationType()));
             deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionFirstEstablishedOn", deviceConnection.getCreatedOn()));
-            deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionFirstEstablishedBy", createdUser != null ? createdUser.getName() : null));
+            deviceConnectionPropertiesPairs.add(new GwtGroupedNVPair(CONNECTION_INFO, "connectionFirstEstablishedBy", UserCreatedByModifiedByUtils.resolveFromId(deviceConnection.getCreatedBy())));
 
+            return new BaseListLoadResult<GwtGroupedNVPair>(deviceConnectionPropertiesPairs);
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
-
-        return new BaseListLoadResult<GwtGroupedNVPair>(deviceConnectionPropertiesPairs);
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/connection/GwtDeviceConnectionOption.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/connection/GwtDeviceConnectionOption.java
@@ -30,6 +30,11 @@ public class GwtDeviceConnectionOption extends GwtUpdatableEntityModel implement
     public GwtDeviceConnectionOption(GwtDeviceConnection gwtDeviceConnection) {
         setId(gwtDeviceConnection.getId());
         setScopeId(gwtDeviceConnection.getScopeId());
+        setConnectionUserCouplingMode(gwtDeviceConnection.getConnectionUserCouplingMode());
+        setUserId(gwtDeviceConnection.getUserId());
+        setReservedUserId(gwtDeviceConnection.getUserId());
+        setAllowUserChange(gwtDeviceConnection.getAllowUserChange());
+        setAuthenticationType(gwtDeviceConnection.getAuthenticationType());
     }
 
     @Override

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
+import org.eclipse.kapua.app.console.module.api.server.util.UserCreatedByModifiedByUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
@@ -32,7 +33,6 @@ import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointS
 import org.eclipse.kapua.app.console.module.endpoint.shared.util.GwtKapuaEndpointModelConverter;
 import org.eclipse.kapua.app.console.module.endpoint.shared.util.KapuaGwtEndpointModelConverter;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.endpoint.EndpointInfo;
@@ -42,18 +42,12 @@ import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
 import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
 import org.eclipse.kapua.service.endpoint.EndpointInfoService;
 import org.eclipse.kapua.service.endpoint.EndpointUsage;
-import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.service.user.UserFactory;
-import org.eclipse.kapua.service.user.UserListResult;
-import org.eclipse.kapua.service.user.UserService;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements GwtEndpointService {
 
@@ -63,9 +57,6 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
 
     private static final EndpointInfoService ENDPOINT_INFO_SERVICE = LOCATOR.getService(EndpointInfoService.class);
     private static final EndpointInfoFactory ENDPOINT_INFO_FACTORY = LOCATOR.getFactory(EndpointInfoFactory.class);
-
-    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
-    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
 
     private static final String ENDPOINT_INFO = "endpointInfo";
     private static final String ENTITY_INFO = "entityInfo";
@@ -139,41 +130,35 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
 
     @Override
     public PagingLoadResult<GwtEndpoint> query(PagingLoadConfig loadConfig, final GwtEndpointQuery gwtEndpointQuery, String section) throws GwtKapuaException {
-        int totalLength = 0;
-        List<GwtEndpoint> gwtEndpointList = new ArrayList<GwtEndpoint>();
         try {
             EndpointInfoQuery endpointQuery = GwtKapuaEndpointModelConverter.convertEndpointQuery(loadConfig, gwtEndpointQuery);
 
             EndpointInfoListResult endpoints = ENDPOINT_INFO_SERVICE.query(endpointQuery, section);
-            totalLength = endpoints.getTotalCount().intValue();
 
+            List<GwtEndpoint> gwtEndpointList = new ArrayList<GwtEndpoint>();
             if (!endpoints.isEmpty()) {
-                //TODO: #LAYER_VIOLATION - user lookup should not be done here
-                UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResult(endpoints);
+
+                for (EndpointInfo endpointInfo : endpoints.getItems()) {
+                    GwtEndpoint gwtEndpoint = KapuaGwtEndpointModelConverter.convertEndpoint(endpointInfo);
+
+                    if (endpointInfo.getCreatedBy() != null) {
+                        gwtEndpoint.setCreatedByName(idUsernameMap.get(endpointInfo.getCreatedBy()));
                     }
-                });
 
-                Map<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : userListResult.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
+                    if (endpointInfo.getModifiedBy() != null) {
+                        gwtEndpoint.setModifiedByName(idUsernameMap.get(endpointInfo.getModifiedBy()));
+                    }
 
-                for (EndpointInfo ei : endpoints.getItems()) {
-                    GwtEndpoint gwtEndpoint = KapuaGwtEndpointModelConverter.convertEndpoint(ei);
-                    gwtEndpoint.setCreatedByName(ei.getCreatedBy() != null ? usernameMap.get(ei.getCreatedBy().toCompactId()) : null);
-                    gwtEndpoint.setModifiedByName(ei.getModifiedBy() != null ? usernameMap.get(ei.getModifiedBy().toCompactId()) : null);
                     gwtEndpointList.add(gwtEndpoint);
                 }
             }
+
+            return new BasePagingLoadResult<GwtEndpoint>(gwtEndpointList, loadConfig.getOffset(), endpoints.getTotalCount().intValue());
         } catch (Exception e) {
-            KapuaExceptionHandler.handle(e);
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
-        return new BasePagingLoadResult<GwtEndpoint>(gwtEndpointList, loadConfig.getOffset(),
-                totalLength);
     }
 
     @Override
@@ -193,27 +178,14 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
 
     @Override
     public ListLoadResult<GwtGroupedNVPair> getEndpointDescription(String scopeShortId, String endpointShortId) throws GwtKapuaException {
-        List<GwtGroupedNVPair> gwtEndpointDescription = new ArrayList<GwtGroupedNVPair>();
         try {
-            final KapuaId scopeId = KapuaEid.parseCompactId(scopeShortId);
+            KapuaId scopeId = KapuaEid.parseCompactId(scopeShortId);
             KapuaId endpointId = KapuaEid.parseCompactId(endpointShortId);
 
-            final EndpointInfo endpointInfo = ENDPOINT_INFO_SERVICE.find(scopeId, endpointId);
+            EndpointInfo endpointInfo = ENDPOINT_INFO_SERVICE.find(scopeId, endpointId);
 
+            List<GwtGroupedNVPair> gwtEndpointDescription = new ArrayList<GwtGroupedNVPair>();
             if (endpointInfo != null) {
-                UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
-
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                    }
-                });
-
-                Map<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : userListResult.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
-
                 gwtEndpointDescription.add(new GwtGroupedNVPair(ENDPOINT_INFO, "endpointSchema", endpointInfo.getSchema()));
                 gwtEndpointDescription.add(new GwtGroupedNVPair(ENDPOINT_INFO, "endpointDns", endpointInfo.getDns()));
                 gwtEndpointDescription.add(new GwtGroupedNVPair(ENDPOINT_INFO, "endpointPort", endpointInfo.getPort()));
@@ -225,18 +197,16 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
                 }
                 gwtEndpointDescription.add(new GwtGroupedNVPair(ENDPOINT_INFO, "endpointUsages", usages));
 
-                gwtEndpointDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "endpointModifiedOn", endpointInfo.getModifiedOn()));
-                gwtEndpointDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "endpointModifiedBy",
-                        endpointInfo.getModifiedBy() != null ? usernameMap.get(endpointInfo.getModifiedBy().toCompactId()) : null));
                 gwtEndpointDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "endpointCreatedOn", endpointInfo.getCreatedOn()));
-                gwtEndpointDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "endpointCreatedBy",
-                        endpointInfo.getCreatedBy() != null ? usernameMap.get(endpointInfo.getCreatedBy().toCompactId()) : null));
-
+                gwtEndpointDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "endpointCreatedBy", UserCreatedByModifiedByUtils.resolveFromId(endpointInfo.getCreatedBy())));
+                gwtEndpointDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "endpointModifiedOn", endpointInfo.getModifiedOn()));
+                gwtEndpointDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "endpointModifiedBy", UserCreatedByModifiedByUtils.resolveFromId(endpointInfo.getModifiedBy())));
             }
+
+            return new BaseListLoadResult<GwtGroupedNVPair>(gwtEndpointDescription);
         } catch (Exception e) {
-            KapuaExceptionHandler.handle(e);
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
-        return new BaseListLoadResult<GwtGroupedNVPair>(gwtEndpointDescription);
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
+import org.eclipse.kapua.app.console.module.api.server.util.UserCreatedByModifiedByUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
@@ -30,7 +31,6 @@ import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobService;
 import org.eclipse.kapua.app.console.module.job.shared.util.GwtKapuaJobModelConverter;
 import org.eclipse.kapua.app.console.module.job.shared.util.KapuaGwtJobModelConverter;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.Job;
@@ -39,16 +39,10 @@ import org.eclipse.kapua.service.job.JobFactory;
 import org.eclipse.kapua.service.job.JobListResult;
 import org.eclipse.kapua.service.job.JobQuery;
 import org.eclipse.kapua.service.job.JobService;
-import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.service.user.UserFactory;
-import org.eclipse.kapua.service.user.UserListResult;
-import org.eclipse.kapua.service.user.UserService;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJobService {
 
@@ -57,54 +51,38 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
     private static final JobService JOB_SERVICE = LOCATOR.getService(JobService.class);
     private static final JobFactory JOB_FACTORY = LOCATOR.getFactory(JobFactory.class);
 
-    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
-    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
-
     private static final String ENTITY_INFO = "entityInfo";
 
     @Override
     public PagingLoadResult<GwtJob> query(PagingLoadConfig loadConfig, GwtJobQuery gwtJobQuery) throws GwtKapuaException {
-        // Do query
-        int totalLength = 0;
-        List<GwtJob> gwtJobs = new ArrayList<GwtJob>();
         try {
-
             // Convert from GWT entity
             JobQuery jobQuery = GwtKapuaJobModelConverter.convertJobQuery(gwtJobQuery, loadConfig);
 
-            // query
+            // Query
             JobListResult jobs = JOB_SERVICE.query(jobQuery);
-            totalLength = jobs.getTotalCount().intValue();
 
             // If there are results
+            List<GwtJob> gwtJobs = new ArrayList<GwtJob>();
             if (!jobs.isEmpty()) {
-                //TODO: #LAYER_VIOLATION - user lookup should not be done here (horribly inefficient)
-                UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                    }
-                });
-
-                Map<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : usernames.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResult(jobs);
 
                 // Converto to GWT entity
-                for (Job j : jobs.getItems()) {
-                    GwtJob gwtJob = KapuaGwtJobModelConverter.convertJob(j);
-                    gwtJob.setCreatedByName(usernameMap.get(j.getCreatedBy().toCompactId()));
+                for (Job job : jobs.getItems()) {
+                    GwtJob gwtJob = KapuaGwtJobModelConverter.convertJob(job);
+
+                    gwtJob.setCreatedByName(idUsernameMap.get(job.getCreatedBy()));
+                    gwtJob.setModifiedByName(idUsernameMap.get(job.getModifiedBy()));
+
                     gwtJobs.add(gwtJob);
                 }
             }
 
+            return new BasePagingLoadResult<GwtJob>(gwtJobs, loadConfig.getOffset(), jobs.getTotalCount().intValue());
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
-
-        return new BasePagingLoadResult<GwtJob>(gwtJobs, loadConfig.getOffset(), totalLength);
     }
 
     @Override
@@ -206,40 +184,26 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
     }
 
     @Override
-    public ListLoadResult<GwtGroupedNVPair> findJobDescription(String gwtScopeId,
-                                                               String gwtJobId) throws GwtKapuaException {
-        List<GwtGroupedNVPair> gwtJobDescription = new ArrayList<GwtGroupedNVPair>();
+    public ListLoadResult<GwtGroupedNVPair> findJobDescription(String gwtScopeId, String gwtJobId) throws GwtKapuaException {
         try {
             KapuaId scopeId = KapuaEid.parseCompactId(gwtScopeId);
             KapuaId jobId = KapuaEid.parseCompactId(gwtJobId);
 
             Job job = JOB_SERVICE.find(scopeId, jobId);
 
-            UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
-
-                @Override
-                public UserListResult call() throws Exception {
-                    return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                }
-            });
-
-            Map<String, String> usernameMap = new HashMap<String, String>();
-            for (User user : userListResult.getItems()) {
-                usernameMap.put(user.getId().toCompactId(), user.getName());
-            }
-
+            List<GwtGroupedNVPair> gwtJobDescription = new ArrayList<GwtGroupedNVPair>();
             if (job != null) {
                 gwtJobDescription.add(new GwtGroupedNVPair("jobInfo", "jobName", job.getName()));
                 gwtJobDescription.add(new GwtGroupedNVPair("jobInfo", "jobDescription", job.getDescription()));
                 gwtJobDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "jobCreatedOn", job.getCreatedOn()));
-                gwtJobDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "jobCreatedBy", job.getCreatedBy() != null ? usernameMap.get(job.getCreatedBy().toCompactId()) : null));
+                gwtJobDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "jobCreatedBy", UserCreatedByModifiedByUtils.resolveFromId(job.getCreatedBy())));
                 gwtJobDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "jobModifiedOn", job.getModifiedOn()));
-                gwtJobDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "jobModifiedBy", job.getModifiedBy() != null ? usernameMap.get(job.getModifiedBy().toCompactId()) : null));
+                gwtJobDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "jobModifiedBy", UserCreatedByModifiedByUtils.resolveFromId(job.getModifiedBy())));
             }
-        } catch (Exception e) {
-            KapuaExceptionHandler.handle(e);
-        }
 
-        return new BaseListLoadResult<GwtGroupedNVPair>(gwtJobDescription);
+            return new BaseListLoadResult<GwtGroupedNVPair>(gwtJobDescription);
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
+        }
     }
 }

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
+import org.eclipse.kapua.app.console.module.api.server.util.UserCreatedByModifiedByUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
@@ -33,7 +34,6 @@ import org.eclipse.kapua.app.console.module.user.shared.util.GwtKapuaUserModelCo
 import org.eclipse.kapua.app.console.module.user.shared.util.KapuaGwtUserModelConverter;
 import org.eclipse.kapua.commons.model.domains.Domains;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -60,10 +60,8 @@ import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.service.user.UserType;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 /**
  * The server side implementation of the RPC service.
@@ -225,85 +223,47 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
     @Override
     public PagingLoadResult<GwtUser> query(PagingLoadConfig loadConfig, GwtUserQuery gwtUserQuery) throws GwtKapuaException {
-        // Do query
-        int totalLength = 0;
-        List<GwtUser> gwtUsers = new ArrayList<GwtUser>();
         try {
             // Convert from GWT entity
             UserQuery userQuery = GwtKapuaUserModelConverter.convertUserQuery(loadConfig, gwtUserQuery);
 
-            // query
+            // Query
             UserListResult users = USER_SERVICE.query(userQuery);
-            totalLength = users.getTotalCount().intValue();
 
             // If there are results
+            List<GwtUser> gwtUsers = new ArrayList<GwtUser>();
             if (!users.isEmpty()) {
-                //TODO: #LAYER_VIOLATION - missed opportunity to perform paging at the database layer
 
-                UserListResult allUsers = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
-
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                    }
-                });
-
-                HashMap<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : allUsers.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResult(users);
 
                 // Convert to GWT entity
                 for (User u : users.getItems()) {
                     GwtUser gwtUser = KapuaGwtUserModelConverter.convertUser(u);
-                    gwtUser.setCreatedByName(usernameMap.get(u.getCreatedBy().toCompactId()));
-                    gwtUser.setModifiedByName(usernameMap.get(u.getModifiedBy().toCompactId()));
+
+                    gwtUser.setCreatedByName(idUsernameMap.get(u.getCreatedBy()));
+                    gwtUser.setModifiedByName(idUsernameMap.get(u.getModifiedBy()));
+
                     gwtUsers.add(gwtUser);
                 }
             }
 
+            return new BasePagingLoadResult<GwtUser>(gwtUsers, loadConfig.getOffset(), users.getTotalCount().intValue());
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
-
-        return new BasePagingLoadResult<GwtUser>(gwtUsers, loadConfig.getOffset(), totalLength);
     }
 
     @Override
-    public ListLoadResult<GwtGroupedNVPair> getUserDescription(boolean isSsoEnabled, String shortScopeId,
-                                                               String shortUserId) throws GwtKapuaException {
-        List<GwtGroupedNVPair> gwtUserDescription = new ArrayList<GwtGroupedNVPair>();
+    public ListLoadResult<GwtGroupedNVPair> getUserDescription(boolean isSsoEnabled, String shortScopeId, String shortUserId) throws GwtKapuaException {
         try {
             final KapuaId scopeId = KapuaEid.parseCompactId(shortScopeId);
             final KapuaId userId = KapuaEid.parseCompactId(shortUserId);
 
             final User user = USER_SERVICE.find(scopeId, userId);
 
+            List<GwtGroupedNVPair> gwtUserDescription = new ArrayList<GwtGroupedNVPair>();
             if (user != null) {
-                //TODO: #LAYER_VIOLATION - user lookup should not be done here (horribly inefficient)
 
-                UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
-
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
-                    }
-                });
-
-                Map<String, String> usernameMap = new HashMap<String, String>();
-                for (User userItem : userListResult.getItems()) {
-                    usernameMap.put(userItem.getId().toCompactId(), userItem.getName());
-                }
-
-                DeviceConnection deviceConnection = null;
-                if (deviceListQuery(scopeId) != null && AUTHORIZATION_SERVICE.isPermitted(PERMISSION_FACTORY.newPermission(Domains.DEVICE_CONNECTION, Actions.read, scopeId))) {
-                    for (Device device : deviceListQuery(scopeId).getItems()) {
-                        if (device.getConnectionId() != null) {
-                            deviceConnection = DEVICE_CONNECTION_SERVICE.find(scopeId, device.getConnectionId());
-                            break;
-                        }
-                    }
-                }
                 gwtUserDescription.add(new GwtGroupedNVPair(USER_INFO, "userStatus", user.getStatus().toString()));
                 gwtUserDescription.add(new GwtGroupedNVPair(USER_INFO, "userName", user.getName()));
                 gwtUserDescription.add(new GwtGroupedNVPair(USER_INFO, "userDisplayName", user.getDisplayName()));
@@ -320,19 +280,32 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
                 }
 
                 gwtUserDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "userCreatedOn", user.getCreatedOn()));
-                gwtUserDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "userCreatedBy", user.getCreatedBy() != null ? usernameMap.get(user.getCreatedBy().toCompactId()) : null));
+                gwtUserDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "userCreatedBy", UserCreatedByModifiedByUtils.resolveFromId(user.getCreatedBy())));
                 gwtUserDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "userModifiedOn", user.getModifiedOn()));
-                gwtUserDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "userModifiedBy", user.getModifiedBy() != null ? usernameMap.get(user.getModifiedBy().toCompactId()) : null));
+                gwtUserDescription.add(new GwtGroupedNVPair(ENTITY_INFO, "userModifiedBy", UserCreatedByModifiedByUtils.resolveFromId(user.getModifiedBy())));
 
-                if (deviceConnection != null && deviceConnection.getReservedUserId() != null && deviceConnection.getReservedUserId().equals(user.getId())) {
+                DeviceConnection deviceConnection = null;
+                if (deviceListQuery(scopeId) != null && AUTHORIZATION_SERVICE.isPermitted(PERMISSION_FACTORY.newPermission(Domains.DEVICE_CONNECTION, Actions.read, scopeId))) {
+                    for (Device device : deviceListQuery(scopeId).getItems()) {
+                        if (device.getConnectionId() != null) {
+                            deviceConnection = DEVICE_CONNECTION_SERVICE.find(scopeId, device.getConnectionId());
+                            break;
+                        }
+                    }
+                }
+
+                if (deviceConnection != null &&
+                        deviceConnection.getReservedUserId() != null &&
+                        deviceConnection.getReservedUserId().equals(user.getId())
+                ) {
                     gwtUserDescription.add(new GwtGroupedNVPair(USER_INFO, "userReservedConnection", "Yes"));
                 }
             }
-        } catch (Exception e) {
-            KapuaExceptionHandler.handle(e);
-        }
 
-        return new BaseListLoadResult<GwtGroupedNVPair>(gwtUserDescription);
+            return new BaseListLoadResult<GwtGroupedNVPair>(gwtUserDescription);
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
+        }
     }
 
     @Override
@@ -360,45 +333,31 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
     }
 
     @Override
-    public PagingLoadResult<GwtUser> getUsersForAccount(PagingLoadConfig loadConfig, GwtUserQuery gwtUserQuery,
-                                                        String accountId) throws GwtKapuaException {
-
-        int totalLength = 0;
-        List<GwtUser> gwtUsers = new ArrayList<GwtUser>();
+    public PagingLoadResult<GwtUser> getUsersForAccount(PagingLoadConfig loadConfig, GwtUserQuery gwtUserQuery, String accountId)
+            throws GwtKapuaException {
         try {
             UserQuery userQuery = GwtKapuaUserModelConverter.convertUserQuery(loadConfig, gwtUserQuery);
             UserListResult users = USER_SERVICE.query(userQuery);
-            totalLength = users.getTotalCount().intValue();
 
+            List<GwtUser> gwtUsers = new ArrayList<GwtUser>();
             if (!users.isEmpty()) {
-                //TODO: #LAYER_VIOLATION - user lookup should not be done here (horribly inefficient)
 
-                final UserQuery allUsersQuery = USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(accountId));
-                UserListResult allUsers = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
+                Map<KapuaId, String> idUsernameMap = UserCreatedByModifiedByUtils.resolveFromListResult(users);
 
-                    @Override
-                    public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(allUsersQuery);
-                    }
-                });
-
-                HashMap<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : allUsers.getItems()) {
-                    usernameMap.put(user.getId().toCompactId(), user.getName());
-                }
                 for (User u : users.getItems()) {
                     GwtUser gwtUser = KapuaGwtUserModelConverter.convertUser(u);
-                    gwtUser.setCreatedByName(usernameMap.get(u.getCreatedBy().toCompactId()));
-                    gwtUser.setModifiedByName(usernameMap.get(u.getModifiedBy().toCompactId()));
+
+                    gwtUser.setCreatedByName(idUsernameMap.get(u.getCreatedBy()));
+                    gwtUser.setModifiedByName(idUsernameMap.get(u.getModifiedBy()));
+
                     gwtUsers.add(gwtUser);
                 }
             }
 
+            return new BasePagingLoadResult<GwtUser>(gwtUsers, loadConfig.getOffset(), users.getTotalCount().intValue());
         } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            throw KapuaExceptionHandler.buildExceptionFromError(t);
         }
-
-        return new BasePagingLoadResult<GwtUser>(gwtUsers, loadConfig.getOffset(), totalLength);
     }
 
     /**

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserRepository.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user;
 
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.storage.KapuaNamedEntityRepository;
 import org.eclipse.kapua.storage.TxContext;
 
@@ -19,6 +20,8 @@ import java.util.Optional;
 
 public interface UserRepository extends
         KapuaNamedEntityRepository<User, UserListResult> {
+
+    Optional<User> find(TxContext txContext, KapuaId userId);
 
     Optional<User> findByExternalId(TxContext txContext, final String externalId);
 

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -77,6 +77,16 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      */
     @Override
     User find(KapuaId accountId, KapuaId userId) throws KapuaException;
+
+    /**
+     * Finds a {@link User} by its {@link User#getId()}
+     *
+     * @param userId The {@link User#getId()} to look for
+     * @return The {@link User} found or {@code null}
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    User find(KapuaId userId) throws KapuaException;
 
     /**
      * Returns the User with the specified username; returns null if the user is not found.

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCachedRepository.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCachedRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.user.internal;
 
 import org.eclipse.kapua.commons.service.internal.cache.NamedEntityCache;
 import org.eclipse.kapua.commons.storage.KapuaNamedEntityRepositoryCachingWrapper;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserRepository;
@@ -29,6 +30,13 @@ public class UserCachedRepository
     public UserCachedRepository(UserRepository wrapped, NamedEntityCache entityCache) {
         super(wrapped, entityCache);
         this.wrapped = wrapped;
+    }
+
+    @Override
+    public Optional<User> find(TxContext txContext, KapuaId userId) {
+        final Optional<User> found = wrapped.find(txContext, userId);
+        found.ifPresent(entityCache::put);
+        return found;
     }
 
     @Override

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserImplJpaRepository.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserImplJpaRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,11 @@ public class UserImplJpaRepository
         implements UserRepository {
     public UserImplJpaRepository(KapuaJpaRepositoryConfiguration jpaRepoConfig) {
         super(UserImpl.class, User.TYPE, () -> new UserListResultImpl(), jpaRepoConfig);
+    }
+
+    @Override
+    public Optional<User> find(TxContext txContext, KapuaId userId) {
+        return find(txContext, KapuaId.ANY, userId);
     }
 
     @Override

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -278,6 +278,27 @@ public class UserServiceImpl extends KapuaConfigurableServiceBase implements Use
         // Do the find
         return txManager.execute(tx -> userRepository.find(tx, scopeId, userId))
                 .orElse(null);
+    }
+
+    @Override
+    public User find(KapuaId userId)
+            throws KapuaException {
+        //
+        // Validation of the fields
+        ArgumentValidator.notNull(userId, "userId");
+
+        //
+        // Do find
+        Optional<User> user = txManager.execute(tx -> userRepository.find(tx, userId));
+
+        // Check Access
+        if (user.isPresent()) {
+            authorizationService.checkPermission(permissionFactory.newPermission(Domains.USER, Actions.read, user.get().getScopeId()));
+        }
+
+        //
+        // Return result
+        return user.get();
     }
 
     @Override


### PR DESCRIPTION
This PR fixes the ugly and not efficient `User.id` to `User.name` resolution in Console GWT for `createdBy` and `modifiedBy` properties.

The current way of doing it was to retrieve all user from the DB which can cause problems when there is a large User base

**Related Issue**
_None_

**Description of the solution adopted**
Switched from getting all Users, to get only the ones in the result set that needs to be displayed for the current page.

Most of the Views required resolution of `createdBy` and `modifiedBy`. 
Some entities had few more fields. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_