### PR TITLE
🐛  [Datastore] Improved mechanism of query conversion to ElasticSearch

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/QueryConverterTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/QueryConverterTest.java
@@ -22,7 +22,6 @@ import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory;
 import org.eclipse.kapua.service.elasticsearch.client.QueryConverter;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
-import org.eclipse.kapua.service.elasticsearch.client.exception.QueryMappingException;
 import org.eclipse.kapua.service.elasticsearch.client.rest.QueryConverterImpl;
 import org.eclipse.kapua.service.storable.model.query.SortField;
 import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
@@ -51,14 +50,14 @@ public class QueryConverterTest {
 
     @Test
     public void queryConversionTest1() throws Exception {
-        JsonNode esQuery = qc.convertQuery("COUNT", mq);
+        JsonNode esQuery = qc.convertCountQuery(mq);
         Assert.assertEquals("Expected and actual values should be the same!", "{}", esQuery.toString());
     }
 
     @Test
     public void queryConversionTest2() throws Exception {
         mq.setPredicate(datastorePredicateFactory.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", "thisMustBePresentInTheEsQuery")));
-        JsonNode esQuery = qc.convertQuery("COUNT", mq);
+        JsonNode esQuery = qc.convertCountQuery(mq);
         //Now I must check that only the "query" field is present in the json. Set with the given predicate
         Assert.assertTrue(esQuery.has("query"));
         Assert.assertEquals(1, esQuery.size());
@@ -68,7 +67,7 @@ public class QueryConverterTest {
     @Test
     public void queryConversionTest3() throws Exception {
         mq.setPredicate(datastorePredicateFactory.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", "thisMustBePresentInTheEsQuery")));
-        JsonNode esQuery = qc.convertQuery("DELETE", mq);
+        JsonNode esQuery = qc.convertDeleteQuery(mq);
         //Now I must check that only the "query" field is present in the json. Set with the given predicate
         Assert.assertTrue(esQuery.has("query"));
         Assert.assertEquals(1, esQuery.size());
@@ -76,15 +75,8 @@ public class QueryConverterTest {
     }
 
     @Test
-    public void queryConversionTest4() throws Exception {
-        mq.setPredicate(datastorePredicateFactory.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", "thisMustBePresentInTheEsQuery")));
-        Assert.assertThrows(QueryMappingException.class, () -> qc.convertQuery("DELET", mq)); //typo on action type, must return exception
-    }
-
-
-    @Test
     public void queryConversionTest5() throws Exception {
-        JsonNode esQuery = qc.convertQuery("SEARCH", mq);
+        JsonNode esQuery = qc.convertQuery(mq);
         //now I must check that the query converted all the parameters, given the "search" actiontype
         Assert.assertEquals(4, esQuery.size());
         Assert.assertTrue(esQuery.has("_source"));

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/QueryConverterTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/QueryConverterTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.datastore.internal.model.query.MessageQueryImpl;
+import org.eclipse.kapua.service.datastore.internal.schema.MessageSchema;
+import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
+import org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory;
+import org.eclipse.kapua.service.elasticsearch.client.QueryConverter;
+import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
+import org.eclipse.kapua.service.elasticsearch.client.exception.QueryMappingException;
+import org.eclipse.kapua.service.elasticsearch.client.rest.QueryConverterImpl;
+import org.eclipse.kapua.service.storable.model.query.SortField;
+import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class QueryConverterTest {
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    DatastorePredicateFactory datastorePredicateFactory;
+    QueryConverter qc;
+    MessageQuery mq;
+
+    @Before
+    public void initialize() {
+        qc = new QueryConverterImpl();
+        mq = createBaseMessageQuery(KapuaId.ONE, 100);
+        datastorePredicateFactory = locator.getFactory(DatastorePredicateFactory.class);
+    }
+
+    @Test
+    public void queryConversionTest1() throws Exception {
+        JsonNode esQuery = qc.convertQuery("COUNT", mq);
+        Assert.assertEquals("Expected and actual values should be the same!", "{}", esQuery.toString());
+    }
+
+    @Test
+    public void queryConversionTest2() throws Exception {
+        mq.setPredicate(datastorePredicateFactory.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", "thisMustBePresentInTheEsQuery")));
+        JsonNode esQuery = qc.convertQuery("COUNT", mq);
+        //Now I must check that only the "query" field is present in the json. Set with the given predicate
+        Assert.assertTrue(esQuery.has("query"));
+        Assert.assertEquals(1, esQuery.size());
+        Assert.assertEquals("Expected and actual values should be the same!", "metrics.thisMustBePresentInTheEsQuery", esQuery.findValue(SchemaKeys.KEY_QUERY).findValue("exists").findValue("field").asText());
+    }
+
+    @Test
+    public void queryConversionTest3() throws Exception {
+        mq.setPredicate(datastorePredicateFactory.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", "thisMustBePresentInTheEsQuery")));
+        JsonNode esQuery = qc.convertQuery("DELETE", mq);
+        //Now I must check that only the "query" field is present in the json. Set with the given predicate
+        Assert.assertTrue(esQuery.has("query"));
+        Assert.assertEquals(1, esQuery.size());
+        Assert.assertEquals("Expected and actual values should be the same!", "metrics.thisMustBePresentInTheEsQuery", esQuery.findValue(SchemaKeys.KEY_QUERY).findValue("exists").findValue("field").asText());
+    }
+
+    @Test
+    public void queryConversionTest4() throws Exception {
+        mq.setPredicate(datastorePredicateFactory.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", "thisMustBePresentInTheEsQuery")));
+        Assert.assertThrows(QueryMappingException.class, () -> qc.convertQuery("DELET", mq)); //typo on action type, must return exception
+    }
+
+
+    @Test
+    public void queryConversionTest5() throws Exception {
+        JsonNode esQuery = qc.convertQuery("SEARCH", mq);
+        //now I must check that the query converted all the parameters, given the "search" actiontype
+        Assert.assertEquals(4, esQuery.size());
+        Assert.assertTrue(esQuery.has("_source"));
+        Assert.assertTrue(esQuery.has("sort"));
+        Assert.assertTrue(esQuery.has("from"));
+        Assert.assertTrue(esQuery.has("size"));;
+    }
+
+    /**
+     * Creating query for data messages with reasonable defaults.
+     *
+     * @param scopeId scope
+     * @param limit   limit results
+     * @return query
+     */
+    public MessageQuery createBaseMessageQuery(KapuaId scopeId, int limit) {
+
+        MessageQuery query = new MessageQueryImpl(scopeId);
+        query.setAskTotalCount(true);
+        query.setFetchStyle(StorableFetchStyle.SOURCE_FULL);
+        query.setLimit(limit);
+        query.setOffset(0);
+
+        List<SortField> order = new ArrayList<>();
+        order.add(SortField.descending(MessageSchema.MESSAGE_TIMESTAMP));
+        query.setSortFields(order);
+
+        return query;
+    }
+
+
+
+}

--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -191,7 +191,7 @@ Feature: Datastore tests
     When I delete the metric info data based on the last query
     And I refresh all indices
     When I query for the metrics in topic "delete/by/query/test/1" and store them as "TopicMetricList2x"
-#    Then There are exactly 0 metrics in the list "TopicMetricList2x"
+    Then There are exactly 0 metrics in the list "TopicMetricList2x"
     When I query for the current account clients and store them as "AccountClientlList"
     Then There are exactly 3 clients in the list "AccountClientlList"
     And I delete client number 1 from the list "AccountClientlList"
@@ -244,28 +244,24 @@ Feature: Datastore tests
     Then I get empty message list result
     When I count for data message
     Then I get message count 0
-    Then I delete the messages based on the last query
     And I delete the the message with the ID "fake-id" from the current account
     Given I create channel info query for current account with limit 10
     When I query for channel info
     Then I get empty channel info list result
     When I count for channel info
     Then I get channel info count 0
-    Then I delete the channel info data based on the last query
     Then I delete the the channel info data with the ID "fake-id" from the current account
     Given I create metric info query for current account with limit 10
     When I query for metric info
     Then I get empty metric info list result
     When I count for metric info
     Then I get metric info count 0
-    Then I delete the metric info data based on the last query
     Then I delete the the metric info data with the ID "fake-id" from the current account
     Given I create client info query for current account with limit 10
     When I query for client info
     Then I get empty client info list result
     When I count for client info
     Then I get client info count 0
-    Then I delete the client info data based on the last query
     Then I delete the the client info data with the ID "fake-id" from the current account
     Then I delete all indices
     And I logout

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/QueryConverter.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/QueryConverter.java
@@ -42,13 +42,25 @@ public interface QueryConverter {
     JsonNode convertQuery(Object query) throws QueryMappingException;
 
     /**
-     * Converts the Elasticsearch query to the client query, given the type of action you want to perform on Elasticsearch (query, count, etc...)
-     * The converter then adapts to the action
+     * Converts the Elasticsearch query to the client query for the count operation
      *
+     * @param query The query to convert.
+     * @return The converted query.
      * @throws QueryMappingException if query mappings are not correst.
      * @since 2.1.0
      */
-    JsonNode convertQuery(String actionType, Object query) throws QueryMappingException;
+    JsonNode convertCountQuery(Object query) throws QueryMappingException;
+
+    /**
+     * Converts the Elasticsearch query to the client query for the delete operation
+     *
+     * @param query The query to convert.
+     * @return The converted query.
+     * @throws QueryMappingException if query mappings are not correst.
+     * @since 2.1.0
+     */
+    JsonNode convertDeleteQuery(Object query) throws QueryMappingException;
+
 
     /**
      * Gets the query fetch style

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/QueryConverter.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/QueryConverter.java
@@ -34,12 +34,21 @@ public interface QueryConverter {
     /**
      * Converts the Elasticsearch query to the client query
      *
-     * @param query The queyr to convert.
+     * @param query The query to convert.
      * @return The converted query.
      * @throws QueryMappingException if query mappings are not correst.
      * @since 1.0.0
      */
     JsonNode convertQuery(Object query) throws QueryMappingException;
+
+    /**
+     * Converts the Elasticsearch query to the client query, given the type of action you want to perform on Elasticsearch (query, count, etc...)
+     * The converter then adapts to the action
+     *
+     * @throws QueryMappingException if query mappings are not correst.
+     * @since 2.1.0
+     */
+    JsonNode convertQuery(String actionType, Object query) throws QueryMappingException;
 
     /**
      * Gets the query fetch style

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/QueryConverterImpl.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/QueryConverterImpl.java
@@ -32,6 +32,12 @@ import java.util.List;
  */
 public class QueryConverterImpl implements QueryConverter {
 
+    private boolean sourceEnabled = true;
+    private boolean queryEnabled = true;
+    private boolean sortEnabled = true;
+    private boolean fromEnabled = true;
+    private boolean sizeEnabled = true;
+
     @Override
     public JsonNode convertQuery(Object query) throws QueryMappingException {
         if (!(query instanceof StorableQuery)) {
@@ -42,7 +48,7 @@ public class QueryConverterImpl implements QueryConverter {
             StorableQuery storableQuery = (StorableQuery) query;
             ObjectNode rootNode = MappingUtils.newObjectNode();
 
-            if (storableQuery.getFetchStyle() != null) {
+            if (sourceEnabled) {
                 ObjectNode includesFields = MappingUtils.newObjectNode();
                 includesFields.set(SchemaKeys.KEY_INCLUDES, MappingUtils.newArrayNode(storableQuery.getIncludes(storableQuery.getFetchStyle())));
                 includesFields.set(SchemaKeys.KEY_EXCLUDES, MappingUtils.newArrayNode(storableQuery.getExcludes(storableQuery.getFetchStyle())));
@@ -50,14 +56,14 @@ public class QueryConverterImpl implements QueryConverter {
             }
 
             // query
-            if (storableQuery.getPredicate() != null) {
+            if (queryEnabled && storableQuery.getPredicate() != null) {
                 rootNode.set(SchemaKeys.KEY_QUERY, storableQuery.getPredicate().toSerializedMap());
             }
 
             // sort
             ArrayNode sortNode = MappingUtils.newArrayNode();
             List<SortField> sortFields = storableQuery.getSortFields();
-            if (sortFields != null && !sortFields.isEmpty()) {
+            if (sortEnabled && sortFields != null && !sortFields.isEmpty()) {
                 for (SortField field : sortFields) {
                     sortNode.add(MappingUtils.newObjectNode(field.getField(), field.getSortDirection().name()));
                 }
@@ -66,11 +72,11 @@ public class QueryConverterImpl implements QueryConverter {
 
             // offset and limit settings
             Integer offset = storableQuery.getOffset();
-            if (offset != null) {
+            if (fromEnabled && offset != null) {
                 rootNode.set(SchemaKeys.KEY_FROM, MappingUtils.newNumericNode(offset));
             }
             Integer limit = storableQuery.getLimit();
-            if (limit != null) {
+            if (sizeEnabled && limit != null) {
                 rootNode.set(SchemaKeys.KEY_SIZE, MappingUtils.newNumericNode(limit));
             }
             return rootNode;
@@ -80,12 +86,35 @@ public class QueryConverterImpl implements QueryConverter {
     }
 
     @Override
+    public JsonNode convertQuery(String actionType, Object query) throws QueryMappingException {
+        if (actionType.equals("COUNT") || actionType.equals("DELETE")) {
+            queryEnabled = true;
+            sourceEnabled = false;
+            sortEnabled = false;
+            fromEnabled = false;
+            sizeEnabled = false;
+        }
+        if (actionType.equals("SEARCH")) {
+            resetEnablers();
+        }
+        return convertQuery(query);
+    }
+
+    @Override
     public Object getFetchStyle(Object query) throws QueryMappingException {
         if (!(query instanceof StorableQuery)) {
             throw new QueryMappingException("Given query is not a StorableQuery");
         }
 
         return ((StorableQuery) query).getFetchStyle();
+    }
+
+    private void resetEnablers() {
+        queryEnabled = true;
+        fromEnabled = true;
+        sourceEnabled = true;
+        sortEnabled = true;
+        sizeEnabled = true;
     }
 
 }

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/QueryConverterImpl.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/QueryConverterImpl.java
@@ -33,14 +33,26 @@ import java.util.List;
  */
 public class QueryConverterImpl implements QueryConverter {
 
-    private boolean sourceEnabled = true;
-    private boolean queryEnabled = true;
-    private boolean sortEnabled = true;
-    private boolean fromEnabled = true;
-    private boolean sizeEnabled = true;
+    private static ConvertOptions convertOptionsCount = new ConvertOptions(false, true, false, false, false);
+    private static ConvertOptions convertOptionsDelete = convertOptionsCount;
+    private static ConvertOptions convertOptionsSearch = new ConvertOptions(true, true, true, true, true);
 
     @Override
     public JsonNode convertQuery(Object query) throws QueryMappingException {
+        return convertQuery(query, convertOptionsSearch);
+    }
+
+    @Override
+    public JsonNode convertCountQuery(Object query) throws QueryMappingException {
+        return convertQuery(query, convertOptionsCount);
+    }
+
+    @Override
+    public JsonNode convertDeleteQuery(Object query) throws QueryMappingException {
+        return convertQuery(query, convertOptionsDelete);
+    }
+
+    private JsonNode convertQuery(Object query, ConvertOptions convertOptions) throws QueryMappingException {
         if (!(query instanceof StorableQuery)) {
             throw new QueryMappingException("Given query is not a StorableQuery");
         }
@@ -49,7 +61,7 @@ public class QueryConverterImpl implements QueryConverter {
             StorableQuery storableQuery = (StorableQuery) query;
             ObjectNode rootNode = MappingUtils.newObjectNode();
 
-            if (sourceEnabled) {
+            if (convertOptions.sourceEnabled) {
                 ObjectNode includesFields = MappingUtils.newObjectNode();
                 includesFields.set(SchemaKeys.KEY_INCLUDES, MappingUtils.newArrayNode(storableQuery.getIncludes(storableQuery.getFetchStyle())));
                 includesFields.set(SchemaKeys.KEY_EXCLUDES, MappingUtils.newArrayNode(storableQuery.getExcludes(storableQuery.getFetchStyle())));
@@ -57,14 +69,14 @@ public class QueryConverterImpl implements QueryConverter {
             }
 
             // query
-            if (queryEnabled && storableQuery.getPredicate() != null) {
+            if (convertOptions.queryEnabled && storableQuery.getPredicate() != null) {
                 rootNode.set(SchemaKeys.KEY_QUERY, storableQuery.getPredicate().toSerializedMap());
             }
 
             // sort
             ArrayNode sortNode = MappingUtils.newArrayNode();
             List<SortField> sortFields = storableQuery.getSortFields();
-            if (sortEnabled && sortFields != null && !sortFields.isEmpty()) {
+            if (convertOptions.sortEnabled && sortFields != null && !sortFields.isEmpty()) {
                 for (SortField field : sortFields) {
                     sortNode.add(MappingUtils.newObjectNode(field.getField(), field.getSortDirection().name()));
                 }
@@ -73,35 +85,17 @@ public class QueryConverterImpl implements QueryConverter {
 
             // offset and limit settings
             Integer offset = storableQuery.getOffset();
-            if (fromEnabled && offset != null) {
+            if (convertOptions.fromEnabled && offset != null) {
                 rootNode.set(SchemaKeys.KEY_FROM, MappingUtils.newNumericNode(offset));
             }
             Integer limit = storableQuery.getLimit();
-            if (sizeEnabled && limit != null) {
+            if (convertOptions.sizeEnabled && limit != null) {
                 rootNode.set(SchemaKeys.KEY_SIZE, MappingUtils.newNumericNode(limit));
             }
             return rootNode;
         } catch (MappingException me) {
             throw new QueryMappingException(me, "Cannot convert Storable Query");
         }
-    }
-
-    @Override
-    public JsonNode convertQuery(String actionType, Object query) throws QueryMappingException {
-        if (actionType.equals("COUNT") || actionType.equals("DELETE")) {
-            queryEnabled = true;
-            sourceEnabled = false;
-            sortEnabled = false;
-            fromEnabled = false;
-            sizeEnabled = false;
-        }
-        else if (actionType.equals("SEARCH")) {
-            resetEnablers();
-        }
-        else {
-            throw new QueryMappingException("Unsupported actiontype");
-        }
-        return convertQuery(query);
     }
 
     @Override
@@ -113,12 +107,22 @@ public class QueryConverterImpl implements QueryConverter {
         return ((StorableQuery) query).getFetchStyle();
     }
 
-    private void resetEnablers() {
-        queryEnabled = true;
-        fromEnabled = true;
-        sourceEnabled = true;
-        sortEnabled = true;
-        sizeEnabled = true;
+    private static class ConvertOptions {
+
+        protected boolean sourceEnabled;
+        protected boolean queryEnabled;
+        protected boolean sortEnabled;
+        protected boolean fromEnabled;
+        protected boolean sizeEnabled;
+
+        ConvertOptions(boolean source,boolean query,boolean sort, boolean from, boolean size) {
+            this.sourceEnabled = source;
+            this.queryEnabled = query;
+            this.sortEnabled = sort;
+            this.fromEnabled = from;
+            this.sizeEnabled = size;
+        }
+
     }
 
 }

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/QueryConverterImpl.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/QueryConverterImpl.java
@@ -26,9 +26,10 @@ import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
 import java.util.List;
 
 /**
- * Query converter implementation
+ * Query converter implementation that converts only fields supported by the given ES endpoint/action (Query, Delete, Count etc.)
+ * In order to avoid bad requests
  *
- * @since 1.0
+ * @since 2.1.0
  */
 public class QueryConverterImpl implements QueryConverter {
 
@@ -94,8 +95,11 @@ public class QueryConverterImpl implements QueryConverter {
             fromEnabled = false;
             sizeEnabled = false;
         }
-        if (actionType.equals("SEARCH")) {
+        else if (actionType.equals("SEARCH")) {
             resetEnablers();
+        }
+        else {
+            throw new QueryMappingException("Unsupported actiontype");
         }
         return convertQuery(query);
     }

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
@@ -258,8 +258,8 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
                 throw new ClientException(ClientErrorCodes.ACTION_ERROR, CLIENT_HITS_MAX_VALUE_EXCEEDED);
             }
             resultsNode = ((ArrayNode) hitsNode.get(ElasticsearchKeywords.KEY_HITS));
-        } else if (!isRequestBadRequest(queryResponse) &&
-                !isRequestNotFound(queryResponse)) {
+        } else if ((!isRequestNotFound(queryResponse) && !isRequestBadRequest(queryResponse)) ||
+                isRequestNotParsed(queryResponse)) {
             throw buildExceptionFromUnsuccessfulResponse("Query", queryResponse);
         }
 
@@ -304,8 +304,8 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
             if (totalCount > Integer.MAX_VALUE) {
                 throw new ClientException(ClientErrorCodes.ACTION_ERROR, CLIENT_HITS_MAX_VALUE_EXCEEDED);
             }
-        } else if (!isRequestBadRequest(queryResponse) &&
-                !isRequestNotFound(queryResponse)) {
+        } else if ((!isRequestNotFound(queryResponse) && !isRequestBadRequest(queryResponse)) || //for response with code different from 400 and 404...
+                    isRequestNotParsed(queryResponse)) {
             throw buildExceptionFromUnsuccessfulResponse("Count", queryResponse);
         }
 
@@ -336,8 +336,8 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
         Response deleteResponse = restCallTimeoutHandler(() -> getClient().performRequest(request), index, "DELETE BY QUERY");
 
         if (!isRequestSuccessful(deleteResponse) &&
-                !isRequestNotFound(deleteResponse) &&
-                !isRequestBadRequest(deleteResponse)) {
+                ((!isRequestNotFound(deleteResponse) && !isRequestBadRequest(deleteResponse)) || //for response with code different from 400 and 404...
+                isRequestNotParsed(deleteResponse))) {
             throw buildExceptionFromUnsuccessfulResponse("Delete by query", deleteResponse);
         }
     }
@@ -585,6 +585,15 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
      */
     private boolean isRequestNotFound(int responseCode) {
         return (404 == responseCode);
+    }
+
+    private boolean isRequestNotParsed(@NotNull Response response) throws ClientException {
+        if (isRequestBadRequest(response)) {
+            JsonNode responseNode = readResponseAsJsonNode(response);
+            return responseNode.path("error").path("type").asText().equals("parsing_exception");
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
@@ -235,7 +235,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
 
     @Override
     public <T> ResultList<T> query(String index, Object query, Class<T> clazz) throws ClientException {
-        JsonNode queryJsonNode = getModelConverter().convertQuery(query);
+        JsonNode queryJsonNode = getModelConverter().convertQuery("SEARCH", query);
         LOG.debug(QUERY_CONVERTED_QUERY, queryJsonNode);
 
         String json = writeRequestFromJsonNode(queryJsonNode);
@@ -287,7 +287,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
 
     @Override
     public long count(String index, Object query) throws ClientException {
-        JsonNode queryJsonNode = getModelConverter().convertQuery(query);
+        JsonNode queryJsonNode = getModelConverter().convertQuery("COUNT", query);
 
         LOG.debug(COUNT_CONVERTED_QUERY, queryJsonNode);
 
@@ -326,7 +326,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
 
     @Override
     public void deleteByQuery(String index, Object query) throws ClientException {
-        JsonNode queryJsonNode = getModelConverter().convertQuery(query);
+        JsonNode queryJsonNode = getModelConverter().convertQuery("DELETE", query);
 
         LOG.debug(QUERY_CONVERTED_QUERY, queryJsonNode);
 

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
@@ -235,7 +235,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
 
     @Override
     public <T> ResultList<T> query(String index, Object query, Class<T> clazz) throws ClientException {
-        JsonNode queryJsonNode = getModelConverter().convertQuery("SEARCH", query);
+        JsonNode queryJsonNode = getModelConverter().convertQuery(query);
         LOG.debug(QUERY_CONVERTED_QUERY, queryJsonNode);
 
         String json = writeRequestFromJsonNode(queryJsonNode);
@@ -286,7 +286,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
 
     @Override
     public long count(String index, Object query) throws ClientException {
-        JsonNode queryJsonNode = getModelConverter().convertQuery("COUNT", query);
+        JsonNode queryJsonNode = getModelConverter().convertCountQuery(query);
 
         LOG.debug(COUNT_CONVERTED_QUERY, queryJsonNode);
 
@@ -324,7 +324,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
 
     @Override
     public void deleteByQuery(String index, Object query) throws ClientException {
-        JsonNode queryJsonNode = getModelConverter().convertQuery("DELETE", query);
+        JsonNode queryJsonNode = getModelConverter().convertDeleteQuery(query);
 
         LOG.debug(QUERY_CONVERTED_QUERY, queryJsonNode);
 

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
@@ -258,8 +258,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
                 throw new ClientException(ClientErrorCodes.ACTION_ERROR, CLIENT_HITS_MAX_VALUE_EXCEEDED);
             }
             resultsNode = ((ArrayNode) hitsNode.get(ElasticsearchKeywords.KEY_HITS));
-        } else if ((!isRequestNotFound(queryResponse) && !isRequestBadRequest(queryResponse)) ||
-                isRequestNotParsed(queryResponse)) {
+        } else if (isRequestCauseOfConcern(queryResponse)) {
             throw buildExceptionFromUnsuccessfulResponse("Query", queryResponse);
         }
 
@@ -304,8 +303,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
             if (totalCount > Integer.MAX_VALUE) {
                 throw new ClientException(ClientErrorCodes.ACTION_ERROR, CLIENT_HITS_MAX_VALUE_EXCEEDED);
             }
-        } else if ((!isRequestNotFound(queryResponse) && !isRequestBadRequest(queryResponse)) || //for response with code different from 400 and 404...
-                    isRequestNotParsed(queryResponse)) {
+        } else if (isRequestCauseOfConcern(queryResponse)) {
             throw buildExceptionFromUnsuccessfulResponse("Count", queryResponse);
         }
 
@@ -336,8 +334,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
         Response deleteResponse = restCallTimeoutHandler(() -> getClient().performRequest(request), index, "DELETE BY QUERY");
 
         if (!isRequestSuccessful(deleteResponse) &&
-                ((!isRequestNotFound(deleteResponse) && !isRequestBadRequest(deleteResponse)) || //for response with code different from 400 and 404...
-                isRequestNotParsed(deleteResponse))) {
+                isRequestCauseOfConcern(deleteResponse)) {
             throw buildExceptionFromUnsuccessfulResponse("Delete by query", deleteResponse);
         }
     }
@@ -588,11 +585,22 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
     }
 
     private boolean isRequestNotParsed(@NotNull Response response) throws ClientException {
+        JsonNode responseNode = readResponseAsJsonNode(response);
+        return responseNode.path("error").path("type").asText().equals("parsing_exception");
+    }
+
+    /**
+     * In some cases, a query for a given index doesn't work properly because ES missed to refresh internal indexes, and does not yet "recognize" the requested index
+     * In such cases, it returns either a 404 or 400 error code BUT for the latter the exception type, in the response, is not a parsing_exception
+     * @param response The response code to check.
+     * @return {@code false} iff the above condition holds, case in which we don't want to propagate an exception
+     * @since 2.1.0
+     */
+    private boolean isRequestCauseOfConcern(@NotNull Response response) throws ClientException {
         if (isRequestBadRequest(response)) {
-            JsonNode responseNode = readResponseAsJsonNode(response);
-            return responseNode.path("error").path("type").asText().equals("parsing_exception");
+            return isRequestNotParsed(response);
         } else {
-            return false;
+            return !isRequestNotFound(response);
         }
     }
 

--- a/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/AbstractStorableQuery.java
+++ b/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/AbstractStorableQuery.java
@@ -91,13 +91,6 @@ public abstract class AbstractStorableQuery implements StorableQuery {
         }
     }
 
-    public void sanificateQuery() {
-        this.setLimit(null);
-        this.setOffset(null);
-        this.setSortFields(null);
-        this.setFetchStyle(null);
-    }
-
     /**
      * Gets the {@link StorableField}s.
      *

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacadeImpl.java
@@ -206,11 +206,8 @@ public class ChannelInfoRegistryFacadeImpl extends AbstractDatastoreFacade imple
             LOG.debug("Storage not enabled for account {}, returning empty result", query.getScopeId());
             return 0;
         }
-        //Sanification of not compatible fields for the "count" ES endpoint
-        ChannelInfoQueryImpl countCompatibleQuery = new ChannelInfoQueryImpl(query);
-        countCompatibleQuery.sanificateQuery();
 
-        return repository.count(countCompatibleQuery);
+        return repository.count(query);
     }
 
     /**

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacadeImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.internal.mediator.ClientInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.ConfigurationException;
 import org.eclipse.kapua.service.datastore.internal.model.ClientInfoListResultImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.ClientInfoQueryImpl;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.datastore.model.ClientInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
@@ -191,11 +190,7 @@ public class ClientInfoRegistryFacadeImpl extends AbstractDatastoreFacade implem
             return 0;
         }
 
-        //Sanification of not compatible fields for the "count" ES endpoint
-        ClientInfoQueryImpl countCompatibleQuery = new ClientInfoQueryImpl(query);
-        countCompatibleQuery.sanificateQuery();
-
-        return repository.count(countCompatibleQuery);
+        return repository.count(query);
     }
 
     /**

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
@@ -41,7 +41,6 @@ import org.eclipse.kapua.service.datastore.internal.model.MessageUniquenessCheck
 import org.eclipse.kapua.service.datastore.internal.model.MetricInfoImpl;
 import org.eclipse.kapua.service.datastore.internal.model.query.ChannelInfoQueryImpl;
 import org.eclipse.kapua.service.datastore.internal.model.query.ClientInfoQueryImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.MessageQueryImpl;
 import org.eclipse.kapua.service.datastore.internal.model.query.MetricInfoQueryImpl;
 import org.eclipse.kapua.service.datastore.internal.model.query.predicate.ChannelMatchPredicateImpl;
 import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
@@ -279,11 +278,7 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
             return 0;
         }
 
-        //Sanification of not compatible fields for the "count" ES endpoint
-        MessageQueryImpl countCompatibleQuery = new MessageQueryImpl(query);
-        countCompatibleQuery.sanificateQuery();
-
-        return messageRepository.count(countCompatibleQuery);
+        return messageRepository.count(query);
     }
 
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacadeImpl.java
@@ -250,11 +250,7 @@ public class MetricInfoRegistryFacadeImpl extends AbstractDatastoreFacade implem
             return 0;
         }
 
-        //Sanification of not compatible fields for the "count" ES endpoint
-        MetricInfoQueryImpl countCompatibleQuery = new MetricInfoQueryImpl(query);
-        countCompatibleQuery.sanificateQuery();
-
-        return repository.count(countCompatibleQuery);
+        return repository.count(query);
     }
 
     /**


### PR DESCRIPTION
After some investigation, I noticed that in some points of the code we were performing requests to ES that resulted in “bad requests”/400 error code responses, which were silently ignored. The cause of this was mainly due to using Query objects with fields not supported by the called endpoint/ES operation needed.

To solve this issue, I refactored the QueryConverter class to convert the correct fields for the given endpoint. In this way, even if the clients uses wrong fields, the query will be converted without errors on ES side. Also, this is done for backwards compatibility, considering that, for example, Rest-API still depends on these “wrong” fields and we don’t want to break the contract. This change doesn't need anymore the sanitisation of the query and as such is more elegant and flexible to future extensions 

Aside from this, I refined the exception handling we perform inside ElasticsearchRepositoryin order to propagate the above bad requests, something that before was not possible, considering how we caught exceptions in that class. This is done for the (very) exceptional case where a request could still result in a bad parsing of it on ES side.