### PR TITLE
🐛 [Datastore] Fixed retrieval of byte[] metrics from the Datastore

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
@@ -33,6 +33,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.KapuaButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.TabItem;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMessages;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtHeader;
@@ -116,8 +117,25 @@ public class TopicsTabItem extends TabItem {
 
             @Override
             public void componentSelected(ButtonEvent ce) {
-                GwtTopic topic = topicTable.getSelectedTopic();
                 List<GwtHeader> metrics = metricsTable.getSelectedMetrics();
+
+                int binaryMetricsSelected = 0;
+                for (GwtHeader metric : metrics) {
+                    if ("binary".equals(metric.getType())) {
+                        binaryMetricsSelected++;
+                    }
+                }
+
+                if (binaryMetricsSelected == metrics.size()) {
+                    ConsoleInfo.display("Error!", "Only binary metrics selected. Binary metrics cannot be queried alone since they would not return any result");
+                    return;
+                }
+
+                if (binaryMetricsSelected > 0) {
+                    ConsoleInfo.display("Warning!", "Messages containing only binary metrics cannot be queried. The results set shown will show binary metric contained in messages that also contains selected non-binary metrics");
+                }
+
+                GwtTopic topic = topicTable.getSelectedTopic();
                 resultsTable.refresh(topic, metrics);
             }
         });

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
@@ -15,20 +15,18 @@ package org.eclipse.kapua.job.engine.commons.logger;
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.type.DateConverter;
 import org.eclipse.kapua.service.job.execution.JobExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import java.text.DateFormat;
 import java.text.MessageFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 /**
  * Logger for {@link org.eclipse.kapua.service.job.Job} processing.
@@ -403,11 +401,7 @@ public class JobLogger {
         }
     }
 
-
     private String formatDate(Date date) {
-        TimeZone tz = TimeZone.getTimeZone("UTC");
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'");
-        df.setTimeZone(tz);
-        return df.format(date);
+        return DateConverter.toString(date);
     }
 }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
@@ -18,7 +18,6 @@ import java.time.ZonedDateTime;
 
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.message.KapuaPosition;
-import org.eclipse.kapua.model.xml.DateXmlAdapter;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,7 +29,7 @@ public class KapuaPositionTest {
 
     private static final String NEWLINE = System.lineSeparator();
 
-    private static ZonedDateTime referenceDate = ZonedDateTime.of(2017, 1, 18, 12, 10, 46, 238000000, ZoneId.of(DateXmlAdapter.TIME_ZONE_UTC));
+    private static ZonedDateTime referenceDate = ZonedDateTime.of(2017, 1, 18, 12, 10, 46, 238000000, ZoneId.of("UTC"));
 
     private static final String POSITION_DISPLAY_STR = "^altitude=.*" +
             "~~heading=.*" +

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucMetric.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucMetric.java
@@ -12,12 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.qa.common.cucumber;
 
+import org.eclipse.kapua.model.type.ObjectTypeConverter;
+import org.eclipse.kapua.model.type.ObjectValueConverter;
+
 public class CucMetric {
 
     private String metric;
     private String type;
     private String value;
     private int message;
+
+    private Class<?> typeCasted;
+
+    private Object valueCasted;
 
     public CucMetric(String metric, String type, String value, int message) {
         this.metric = metric;
@@ -56,5 +63,16 @@ public class CucMetric {
 
     public void setMessage(int message) {
         this.message = message;
+    }
+
+    public Class<?> getTypeCasted() throws ClassNotFoundException {
+        if (typeCasted == null) {
+            typeCasted = ObjectTypeConverter.fromString(type);
+        }
+        return typeCasted;
+    }
+
+    public Object getValueCasted() throws ClassNotFoundException {
+        return ObjectValueConverter.fromString(value, getTypeCasted());
     }
 }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreTransportI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreTransportI9nTest.java
@@ -19,7 +19,10 @@ import io.cucumber.junit.CucumberOptions;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = "classpath:features/datastore/Datastore.feature",
+        features = {
+                "classpath:features/datastore/Datastore.feature",
+                "classpath:features/datastore/DatastoreMetricStore.feature",
+        },
         glue = {"org.eclipse.kapua.qa.common",
                "org.eclipse.kapua.qa.integration.steps",
                 "org.eclipse.kapua.service.account.steps",

--- a/qa/integration/src/test/resources/features/datastore/DatastoreMetricStore.feature
+++ b/qa/integration/src/test/resources/features/datastore/DatastoreMetricStore.feature
@@ -1,0 +1,122 @@
+###############################################################################
+# Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+@datastore
+@env_none
+
+Feature: Datastore tests
+  Test storage and retrieval of supported metric types.
+  This should be converted as a UnitTest
+
+  @setup
+  Scenario: Setup test resources (job-engine is required to init DB)
+    Given Init Security Context
+    And Start Docker environment with resources
+      | db                  |
+      | es                  |
+      | job-engine          |
+
+  Scenario: Store string metric
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I store a message with clientId "testStringMetric" on topic "topic/string" with timestamp now and metrics
+      | metric       | type    | value          |
+      | stringMetric | string  | stringMetric   |
+    And I refresh all indices
+    When searching for the last DatastoreMessage stored
+    Then verify last DatastoreMessage stored exist
+    And verify the last stored message matches the last DatastoreMessageCreator
+
+  Scenario: Store integer metric
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I store a message with clientId "testIntegerMetric" on topic "topic/integer" with timestamp now and metrics
+      | metric        | type    | value |
+      | integerMetric | integer | 123   |
+    And I refresh all indices
+    When searching for the last DatastoreMessage stored
+    Then verify last DatastoreMessage stored exist
+    And verify the last stored message matches the last DatastoreMessageCreator
+
+  Scenario: Store long metric
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I store a message with clientId "testLongMetric" on topic "topic/long" with timestamp now and metrics
+      | metric        | type    | value        |
+      | longMetric    | long    | 2147489999   |
+    And I refresh all indices
+    When searching for the last DatastoreMessage stored
+    Then verify last DatastoreMessage stored exist
+    And verify the last stored message matches the last DatastoreMessageCreator
+
+  Scenario: Store float metric
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I store a message with clientId "testFloatMetric" on topic "topic/float" with timestamp now and metrics
+      | metric        | type    | value |
+      | floatMetric   | float   | 12.3  |
+    And I refresh all indices
+    When searching for the last DatastoreMessage stored
+    Then verify last DatastoreMessage stored exist
+    And verify the last stored message matches the last DatastoreMessageCreator
+
+  Scenario: Store double metric
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I store a message with clientId "testDoubleMetric" on topic "topic/double" with timestamp now and metrics
+      | metric        | type    | value |
+      | doubleMetric  | double  | 1.23  |
+    And I refresh all indices
+    When searching for the last DatastoreMessage stored
+    Then verify last DatastoreMessage stored exist
+    And verify the last stored message matches the last DatastoreMessageCreator
+
+  Scenario: Store boolean metric
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I store a message with clientId "testBooleanMetric" on topic "topic/boolean" with timestamp now and metrics
+      | metric        | type    | value |
+      | booleanMetric | boolean | true  |
+    And I refresh all indices
+    When searching for the last DatastoreMessage stored
+    Then verify last DatastoreMessage stored exist
+    And verify the last stored message matches the last DatastoreMessageCreator
+
+  Scenario: Store binary metric
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I store a message with clientId "testBinartMetric" on topic "topic/binary" with timestamp now and metrics
+      | metric        | type      | value              |
+      | binaryMetric  | binary    | YmluYXJ5TWV0cmlj   |
+    And I refresh all indices
+    When searching for the last DatastoreMessage stored
+    Then verify last DatastoreMessage stored exist
+    And verify the last stored message matches the last DatastoreMessageCreator
+
+  Scenario: Store date metric
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I store a message with clientId "testDateMetric" on topic "topic/date" with timestamp now and metrics
+      | metric        | type    | value                     |
+      | dateMetric    | date    | 2025-01-01T00:00:00.000Z  |
+    And I refresh all indices
+    When searching for the last DatastoreMessage stored
+    Then verify last DatastoreMessage stored exist
+    And verify the last stored message matches the last DatastoreMessageCreator
+
+  @teardown
+  Scenario: Stop full docker environment
+    Given I logout
+    And Stop Docker environment
+    And Clean Locator Instance
+

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ByteArrayConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ByteArrayConverter.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.type;
 
-import com.google.common.base.Strings;
-
 import javax.xml.bind.DatatypeConverter;
 
 /**
@@ -70,8 +68,12 @@ public class ByteArrayConverter {
      * @since 1.0.0
      */
     public static byte[] fromString(String base64) {
-        if (Strings.isNullOrEmpty(base64)) {
+        if (base64 == null) {
             return null;
+        }
+
+        if (base64.isEmpty()) {
+            return new byte[0];
         }
 
         return DatatypeConverter.parseBase64Binary(base64);

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ByteArrayConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ByteArrayConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,14 +12,32 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.type;
 
+import com.google.common.base.Strings;
+
 import javax.xml.bind.DatatypeConverter;
 
+/**
+ * Converts a {@link Byte}[] to {@link String} and vice-versa
+ *
+ * @since 1.0.0
+ */
 public class ByteArrayConverter {
 
     private ByteArrayConverter() {
     }
 
+    /**
+     * Converts the given {@link Byte}[] to a Base64 {@link String}
+     *
+     * @param byteArray The {@link Byte}[] to convert, can be {@code null}
+     * @return The Base64 representation.
+     * @since 1.0.0
+     */
     public static String toString(Byte[] byteArray) {
+        if (byteArray == null) {
+            return null;
+        }
+
         byte[] unboxedByteArray = new byte[byteArray.length];
 
         for (int i = 0; i < byteArray.length; i++) {
@@ -29,11 +47,33 @@ public class ByteArrayConverter {
         return toString(unboxedByteArray);
     }
 
+    /**
+     * Converts the given {@code byte}[] to a Base64 {@link String}
+     *
+     * @param byteArray The {@code byte}[] to convert, can be {@code null}
+     * @return The Base64 representation.
+     * @since 1.0.0
+     */
     public static String toString(byte[] byteArray) {
+        if (byteArray == null) {
+            return null;
+        }
+
         return DatatypeConverter.printBase64Binary(byteArray);
     }
 
+    /**
+     * Converts the given Base64 {@link String} into a {@code byte}[]
+     *
+     * @param base64 The Base64 {@link String}, can be {@code null}.
+     * @return The converted {@code byte[]}
+     * @since 1.0.0
+     */
     public static byte[] fromString(String base64) {
+        if (Strings.isNullOrEmpty(base64)) {
+            return null;
+        }
+
         return DatatypeConverter.parseBase64Binary(base64);
     }
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/DateConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/DateConverter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model.type;
+
+import com.google.common.base.Strings;
+
+import javax.xml.bind.DatatypeConverter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Converts {@link Date} into {@link String} and vice-versa
+ *
+ * @since 2.1.0
+ */
+public class DateConverter {
+
+    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final TimeZone TIME_ZONE_UTC = TimeZone.getTimeZone("UTC");
+
+    private DateConverter() {
+    }
+
+    /**
+     * Converts the given {@link Date} to {@link String} using the {@link #DATE_FORMAT} format
+     *
+     * @param date The {@link Date} to convert, can be {@code null}
+     * @return The {@link String} formatted {@link Date}
+     * @since 2.1.0
+     */
+    public static String toString(Date date) {
+        if (date == null) {
+            return null;
+        }
+
+        SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
+        format.setTimeZone(TIME_ZONE_UTC);
+        return format.format(date);
+    }
+
+    /**
+     * Converts the given {@link String} into {@link Date}
+     *
+     * @param stringDate The {@link String} date to convert, can be null
+     * @return The converted{@link Date}
+     * @since 2.1.0
+     */
+    public static Date fromString(String stringDate) {
+        if (Strings.isNullOrEmpty(stringDate)) {
+            return null;
+        }
+
+        return DatatypeConverter.parseDateTime(stringDate).getTime();
+    }
+}

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectTypeConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectTypeConverter.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.type;
 
+import com.google.common.base.Strings;
+
 import java.util.Date;
 
 public class ObjectTypeConverter {
@@ -56,7 +58,7 @@ public class ObjectTypeConverter {
     }
 
     public static Class<?> fromString(String value) throws ClassNotFoundException {
-        if (value != null) {
+        if (!Strings.isNullOrEmpty(value)) {
             switch (value) {
                 case TYPE_STRING:
                     return String.class;

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
@@ -50,6 +50,7 @@ public class ObjectValueConverter {
             } else if (clazz == Date.class) {
                 stringValue = DateConverter.toString((Date) value);
             } else {
+                // FIXME: This should specifically check for listed classes and KapuaId and throw error if other class is given. This is because this class cannot convert back other classes!
                 // String
                 // Integer
                 // Long
@@ -99,6 +100,7 @@ public class ObjectValueConverter {
 
                 value = Enum.valueOf(enumType, stringValue);
             } else {
+                // FIXME: this should throw an exception since it cannot handle the given class and returning String value might lead to error!
                 value = stringValue;
             }
         }

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdImpl;
 
 import java.math.BigInteger;
+import java.util.Date;
 
 /**
  * Utilities to convert the value of objects to serialize them.
@@ -46,6 +47,8 @@ public class ObjectValueConverter {
                 stringValue = ByteArrayConverter.toString((byte[]) value);
             } else if (clazz == Byte[].class) {
                 stringValue = ByteArrayConverter.toString((Byte[]) value);
+            } else if (clazz == Date.class) {
+                stringValue = DateConverter.toString((Date) value);
             } else {
                 // String
                 // Integer
@@ -87,6 +90,8 @@ public class ObjectValueConverter {
                 value = Boolean.parseBoolean(stringValue);
             } else if (type == byte[].class || type == Byte[].class) {
                 value = ByteArrayConverter.fromString(stringValue);
+            } else if (type == Date.class) {
+                value = DateConverter.fromString(stringValue);
             } else if (type == KapuaId.class || KapuaId.class.isAssignableFrom(type)) {
                 value = new KapuaIdImpl(new BigInteger(stringValue));
             } else if (type.isEnum()) {

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
@@ -93,7 +93,7 @@ public class ObjectValueConverter {
                 value = ByteArrayConverter.fromString(stringValue);
             } else if (type == Date.class) {
                 value = DateConverter.fromString(stringValue);
-            } else if (type == KapuaId.class || KapuaId.class.isAssignableFrom(type)) {
+            } else if (KapuaId.class.isAssignableFrom(type)) {
                 value = new KapuaIdImpl(new BigInteger(stringValue));
             } else if (type.isEnum()) {
                 Class<? extends Enum> enumType = (Class<? extends Enum>) type;

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/BinaryXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/BinaryXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,15 +16,20 @@ import org.eclipse.kapua.model.type.ByteArrayConverter;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
+/**
+ * {@link Byte}[] {@link XmlAdapter}
+ *
+ * @since 1.0.0
+ */
 public class BinaryXmlAdapter extends XmlAdapter<String, byte[]> {
 
     @Override
     public String marshal(byte[] binary) {
-        return binary != null ? ByteArrayConverter.toString(binary) : null;
+        return ByteArrayConverter.toString(binary);
     }
 
     @Override
     public byte[] unmarshal(String binary) {
-        return binary != null ? ByteArrayConverter.fromString(binary) : null;
+        return ByteArrayConverter.fromString(binary);
     }
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/DateXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/DateXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,35 +12,25 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.xml;
 
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import org.eclipse.kapua.model.type.DateConverter;
 
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.util.Date;
+
+/**
+ * {@link Date} {@link XmlAdapter}
+ *
+ * @since 1.0.0
+ */
 public class DateXmlAdapter extends XmlAdapter<String, Date> {
 
-    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-
-    public static final String TIME_ZONE_UTC = "UTC";
-
     @Override
-    public String marshal(Date v) throws Exception {
-        if (v == null) {
-            return null;
-        }
-
-        SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
-        format.setTimeZone(TimeZone.getTimeZone(TIME_ZONE_UTC));
-        return format.format(v);
+    public String marshal(Date date) throws Exception {
+        return DateConverter.toString(date);
     }
 
     @Override
-    public Date unmarshal(String v) {
-        if (v == null || v.isEmpty()) {
-            return null;
-        }
-
-        return DatatypeConverter.parseDateTime(v).getTime();
+    public Date unmarshal(String stringDate) {
+        return DateConverter.fromString(stringDate);
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/ByteArrayConverterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/ByteArrayConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,67 +13,80 @@
 package org.eclipse.kapua.model.type;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
-import org.hamcrest.core.IsInstanceOf;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-
-
+/**
+ * Tests for {@link ByteArrayConverter}
+ *
+ * @since 1.3.0
+ */
 @Category(JUnitTests.class)
 public class ByteArrayConverterTest {
 
     Byte[] byteClassArray;
-    byte[] byteArray;
-    String expectedString;
+    byte[] bytePrimitiveArray;
+    String byteArrayString;
 
     @Before
     public void initialize() {
         byteClassArray = new Byte[]{-128, -10, 0, 1, 10, 127};
-        byteArray = new byte[]{-128, -10, 0, 1, 10, 127};
-        expectedString = "gPYAAQp/";
+        bytePrimitiveArray = new byte[]{-128, -10, 0, 1, 10, 127};
+        byteArrayString = "gPYAAQp/";
     }
 
     @Test
-    public void byteArrayConverterTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Constructor<ByteArrayConverter> byteArrayConverter = ByteArrayConverter.class.getDeclaredConstructor();
-        Assert.assertTrue(Modifier.isPrivate(byteArrayConverter.getModifiers()));
-        byteArrayConverter.setAccessible(true);
-        byteArrayConverter.newInstance();
+    public void toStringConvertByteClassArray() {
+        String convertedByteArrayString = ByteArrayConverter.toString(byteClassArray);
+
+        Assert.assertEquals(byteArrayString, convertedByteArrayString);
     }
 
     @Test
-    public void toStringByteClassParameterTest() {
-        Assert.assertEquals("Expected and actual values should be the same.", expectedString, ByteArrayConverter.toString(byteClassArray));
-    }
+    public void toStringConvertByteClassNull() {
+        String convertedByteArrayString = ByteArrayConverter.toString((Byte[]) null);
 
-    @Test(expected = NullPointerException.class)
-    public void toStringNullByteClassParameterTest() {
-        ByteArrayConverter.toString((Byte[]) null);
+        Assert.assertNull(convertedByteArrayString);
     }
 
     @Test
-    public void toStringTest() {
-        Assert.assertEquals("Expected and actual values should be the same.", expectedString, ByteArrayConverter.toString(byteArray));
-    }
+    public void toStringConvertBytePrimitiveArray() {
+        String convertedByteArrayString = ByteArrayConverter.toString(bytePrimitiveArray);
 
-    @Test(expected = NullPointerException.class)
-    public void toStringNullParameterTest() {
-        ByteArrayConverter.toString((byte[]) null);
+        Assert.assertEquals(byteArrayString, convertedByteArrayString);
     }
 
     @Test
-    public void fromStringTest() {
-        String stringValue = "String Value";
-        Assert.assertThat("Instance of byte[] expected.", ByteArrayConverter.fromString(stringValue), IsInstanceOf.instanceOf(byte[].class));
+    public void toStringConvertBytePrimitiveNull() {
+        String convertedByteArrayString = ByteArrayConverter.toString((byte[]) null);
+
+        Assert.assertNull(convertedByteArrayString);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void fromStringNullParameterTest() {
-        ByteArrayConverter.fromString(null);
+
+    @Test
+    public void fromStringConvertString() {
+        byte[] convertedByteArray = ByteArrayConverter.fromString(byteArrayString);
+
+        Assert.assertArrayEquals(convertedByteArray, bytePrimitiveArray);
     }
+
+    @Test
+    public void fromStringConvertStringNull() {
+        byte[] convertedByteArray = ByteArrayConverter.fromString(null);
+
+        Assert.assertNull(convertedByteArray);
+    }
+
+    @Test
+    public void fromStringConvertStringEmpty() {
+        byte[] convertedByteArray = ByteArrayConverter.fromString("");
+
+        Assert.assertNotNull(convertedByteArray);
+        Assert.assertArrayEquals(convertedByteArray, new byte[0]);
+    }
+
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/DateConverterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/DateConverterTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model.type;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Date;
+
+/**
+ * Tests for {@link DateConverter}
+ *
+ * @since 2.1.0
+ */
+@Category(JUnitTests.class)
+public class DateConverterTest {
+
+    Date date;
+    String dateString;
+
+    @Before
+    public void initialize() {
+        date = new Date(1735689600000L);
+
+        dateString = "2025-01-01T00:00:00.000Z";
+    }
+
+    @Test
+    public void toStringConvertDate() {
+        String convertedDateString = DateConverter.toString(date);
+
+        Assert.assertEquals(dateString, convertedDateString);
+    }
+
+    @Test
+    public void toStringConvertDateNull() {
+        String convertedDateString = DateConverter.toString(null);
+
+        Assert.assertNull(convertedDateString);
+    }
+
+    @Test
+    public void fromStringConvertString() {
+        Date convertedDate = DateConverter.fromString(dateString);
+
+        Assert.assertEquals(date, convertedDate);
+    }
+
+    @Test
+    public void fromStringConvertStringNull() {
+        Date convertedDate = DateConverter.fromString(null);
+
+        Assert.assertNull(convertedDate);
+    }
+
+}

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectTypeConverterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectTypeConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,60 +12,191 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.type;
 
-import org.eclipse.kapua.model.id.KapuaIdImpl;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 import java.util.Date;
 
-
+/**
+ * Tests for {@link ObjectTypeConverter}
+ *
+ * @since 1.3.0
+ */
 @Category(JUnitTests.class)
 public class ObjectTypeConverterTest {
 
+    //
+    // toString
+    //
+
     @Test
-    public void objectTypeConverterTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Constructor<ObjectTypeConverter> objectTypeConverter = ObjectTypeConverter.class.getDeclaredConstructor();
-        Assert.assertTrue(Modifier.isPrivate(objectTypeConverter.getModifiers()));
-        objectTypeConverter.setAccessible(true);
-        objectTypeConverter.newInstance();
+    public void toStringClassString() {
+        String convertedClassString = ObjectTypeConverter.toString(String.class);
+
+        Assert.assertEquals("string", convertedClassString);
     }
 
     @Test
-    public void toStringTest() {
-        Class[] classes = {String.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Date.class, byte[].class, Byte[].class, KapuaIdImpl.class};
-        String[] expectedString = {"string", "integer", "long", "float", "double", "boolean", "date", "binary", "binary", "org.eclipse.kapua.model.id.KapuaIdImpl"};
-        for (int i = 0; i < classes.length; i++) {
-            Assert.assertEquals("Expected and actual values should be the same.", expectedString[i], ObjectTypeConverter.toString(classes[i]));
-        }
+    public void toStringClassInteger() {
+        String convertedClassString = ObjectTypeConverter.toString(Integer.class);
+
+        Assert.assertEquals("integer", convertedClassString);
     }
 
     @Test
-    public void toStringNullParameterTest() {
-        Assert.assertNull("Null expected.", ObjectTypeConverter.toString(null));
+    public void toStringClassLong() {
+        String convertedClassString = ObjectTypeConverter.toString(Long.class);
+
+        Assert.assertEquals("long", convertedClassString);
     }
 
     @Test
-    public void fromStringTest() throws ClassNotFoundException {
-        String[] stringValue = {"string", "integer", "int", "long", "float", "double", "boolean", "date", "binary", "org.eclipse.kapua.model.id.KapuaIdImpl"};
-        Class[] expectedClasses = {String.class, Integer.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Date.class, byte[].class, KapuaIdImpl.class};
-        for (int i = 0; i < stringValue.length; i++) {
-            Assert.assertEquals("Expected and actual values should be the same.", expectedClasses[i].toString(), ObjectTypeConverter.fromString(stringValue[i]).toString());
-        }
+    public void toStringClassFloat() {
+        String convertedClassString = ObjectTypeConverter.toString(Float.class);
+
+        Assert.assertEquals("float", convertedClassString);
     }
 
     @Test
-    public void fromStringNullParameterTest() throws ClassNotFoundException {
-        Assert.assertNull("Null expected.", ObjectTypeConverter.fromString(null));
+    public void toStringClassDouble() {
+        String convertedClassString = ObjectTypeConverter.toString(Double.class);
+
+        Assert.assertEquals("double", convertedClassString);
+    }
+
+    @Test
+    public void toStringClassBoolean() {
+        String convertedClassString = ObjectTypeConverter.toString(Boolean.class);
+
+        Assert.assertEquals("boolean", convertedClassString);
+    }
+
+    @Test
+    public void toStringClassDate() {
+        String convertedClassString = ObjectTypeConverter.toString(Date.class);
+
+        Assert.assertEquals("date", convertedClassString);
+    }
+
+    @Test
+    public void toStringClassBinaryClass() {
+        String convertedClassString = ObjectTypeConverter.toString(Byte[].class);
+
+        Assert.assertEquals("binary", convertedClassString);
+    }
+
+    @Test
+    public void toStringClassBinaryPrimitive() {
+        String convertedClassString = ObjectTypeConverter.toString(byte[].class);
+
+        Assert.assertEquals("binary", convertedClassString);
+    }
+
+    @Test
+    public void toStringClassSomeClass() {
+        String convertedClassString = ObjectTypeConverter.toString(KapuaId.class);
+
+        Assert.assertEquals("org.eclipse.kapua.model.id.KapuaId", convertedClassString);
+    }
+
+    @Test
+    public void toStringClassNull() {
+        String convertedClassString = ObjectTypeConverter.toString(null);
+
+        Assert.assertNull(convertedClassString);
+    }
+
+
+    //
+    // fromString
+    //
+
+    @Test
+    public void fromStringStringString() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("string");
+
+        Assert.assertEquals(String.class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringInteger() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("integer");
+
+        Assert.assertEquals(Integer.class, convertedClassString);
+
+        convertedClassString = ObjectTypeConverter.fromString("int");
+
+        Assert.assertEquals(Integer.class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringLong() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("long");
+
+        Assert.assertEquals(Long.class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringFloat() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("float");
+
+        Assert.assertEquals(Float.class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringDouble() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("double");
+
+        Assert.assertEquals(Double.class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringBoolean() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("boolean");
+
+        Assert.assertEquals(Boolean.class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringDate() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("date");
+
+        Assert.assertEquals(Date.class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringBinary() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("binary");
+
+        Assert.assertEquals(byte[].class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringSomeClass() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("org.eclipse.kapua.model.id.KapuaId");
+
+        Assert.assertEquals(KapuaId.class, convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringNull() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString(null);
+
+        Assert.assertNull(convertedClassString);
+    }
+
+    @Test
+    public void fromStringStringEmpty() throws ClassNotFoundException {
+        Class<?> convertedClassString = ObjectTypeConverter.fromString("");
+
+        Assert.assertNull(convertedClassString);
     }
 
     @Test(expected = ClassNotFoundException.class)
-    public void fromStringInvalidStringValueTest() throws ClassNotFoundException {
-        String invalidStringValue = "Non-exciting class";
-        ObjectTypeConverter.fromString(invalidStringValue);
+    public void fromStringStringNotClass() throws ClassNotFoundException {
+        ObjectTypeConverter.fromString("org.eclipse.kapua.this.is.not.a.Class");
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectValueConverterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectValueConverterTest.java
@@ -232,6 +232,15 @@ public class ObjectValueConverterTest {
     }
 
     @Test
+    public void fromStringKapuaId() {
+        Object convertedObject = ObjectValueConverter.fromString("1", KapuaId.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertTrue(KapuaId.class.isAssignableFrom(convertedObject.getClass()));
+        Assert.assertEquals(KapuaId.ONE, convertedObject);
+    }
+
+    @Test
     public void fromStringEnum() {
         Object convertedObject = ObjectValueConverter.fromString("TEST", ObjectValueConverterTestEnum.class);
 

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectValueConverterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectValueConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,69 +14,236 @@ package org.eclipse.kapua.model.type;
 
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
+import java.util.Date;
 
-
+/**
+ * Tests for {@link ObjectValueConverter}
+ *
+ * @since 1.3.0
+ */
 @Category(JUnitTests.class)
 public class ObjectValueConverterTest {
 
+    //
+    // toString
+    //
+
     @Test
-    public void objectValueConverterTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Constructor<ObjectValueConverter> objectValueConverter = ObjectValueConverter.class.getDeclaredConstructor();
-        Assert.assertTrue(Modifier.isPrivate(objectValueConverter.getModifiers()));
-        objectValueConverter.setAccessible(true);
-        objectValueConverter.newInstance();
+    public void toStringObjectString() {
+        String convertedObjectString = ObjectValueConverter.toString("aString");
+
+        Assert.assertEquals("aString", convertedObjectString);
     }
 
     @Test
-    public void toStringTest() {
-        Byte[] byteArray1 = {-128, -10, 0, 1, 10, 127};
-        byte[] byteArray2 = {-128, -10, 0, 1, 10, 127};
-        Object[] objects = {byteArray1, byteArray2, 0, 10, 100000, "String", 'c', -10, -1000000000, -100000000000L, 10L, 10.0f, 10.10d, true, false, KapuaId.ONE, ObjectValieConverterTestEnum.TEST};
-        String[] expectedString = {"gPYAAQp/", "gPYAAQp/", "0", "10", "100000", "String", "c", "-10", "-1000000000", "-100000000000", "10", "10.0", "10.1", "true", "false", "1", "TEST"};
-        Object object = new Object();
+    public void toStringObjectInteger() {
+        String convertedObjectString = ObjectValueConverter.toString(1024);
 
-        for (int i = 0; i < objects.length; i++) {
-            Assert.assertEquals("Expected and actual values should be the same.", expectedString[i], ObjectValueConverter.toString(objects[i]));
-        }
-        Assert.assertNull("Null expected.", ObjectValueConverter.toString(null));
-        Assert.assertEquals("Expected and actual values should be the same.", object.toString(), ObjectValueConverter.toString(object));
+        Assert.assertEquals("1024", convertedObjectString);
     }
 
     @Test
-    public void fromStringTest() {
-        String[] stringValue = {"String", "-2147483648", "11", "-9223372036854775808", "9223372036854775807", "10F", "10.10d", "true", "false", "Object", "1", "TEST"};
-        Class[] classes = {String.class, Integer.class, Integer.class, Long.class, Long.class, Float.class, Double.class, Boolean.class, Boolean.class, Object.class, KapuaId.class, ObjectValieConverterTestEnum.class};
-        Object[] expectedObjects = {"String", -2147483648, 11, -9223372036854775808L, 9223372036854775807L, 10F, 10.1d, true, false, "Object", KapuaId.ONE, ObjectValieConverterTestEnum.TEST};
-        Class[] byteClasses = {byte[].class, Byte[].class};
+    public void toStringObjectLong() {
+        String convertedObjectString = ObjectValueConverter.toString(1024L);
 
-        for (int i = 0; i < stringValue.length; i++) {
-            Assert.assertEquals(expectedObjects[i], ObjectValueConverter.fromString(stringValue[i], classes[i]));
-        }
+        Assert.assertEquals("1024", convertedObjectString);
+    }
 
-        for (Class byteClass : byteClasses) {
-        Assert.assertThat("Instance of byte[] expected.", ObjectValueConverter.fromString("byteArray", byteClass), IsInstanceOf.instanceOf(byte[].class));
-        }
+    @Test
+    public void toStringObjectFloat() {
+        String convertedObjectString = ObjectValueConverter.toString(10.24f);
 
-        for (Class clazz : classes) {
-            Assert.assertNull(ObjectValueConverter.fromString(null, clazz));
-        }
+        Assert.assertEquals("10.24", convertedObjectString);
+    }
+
+    @Test
+    public void toStringObjectDouble() {
+        String convertedObjectString = ObjectValueConverter.toString(10.24d);
+
+        Assert.assertEquals("10.24", convertedObjectString);
+    }
+
+    @Test
+    public void toStringObjectBoolean() {
+        String convertedObjectString = ObjectValueConverter.toString(Boolean.TRUE);
+
+        Assert.assertEquals("true", convertedObjectString);
+    }
+
+    @Test
+    public void toStringObjectDate() {
+        String convertedObjectString = ObjectValueConverter.toString(new Date(1735689600000L));
+
+        Assert.assertEquals("2025-01-01T00:00:00.000Z", convertedObjectString);
+    }
+
+    @Test
+    public void toStringObjectBinaryClass() {
+        String convertedObjectString = ObjectValueConverter.toString(new Byte[]{-128, -10, 0, 1, 10, 127});
+
+        Assert.assertEquals("gPYAAQp/", convertedObjectString);
+    }
+
+    @Test
+    public void toStringObjectBinaryPrimitive() {
+        String convertedObjectString = ObjectValueConverter.toString(new byte[]{-128, -10, 0, 1, 10, 127});
+
+        Assert.assertEquals("gPYAAQp/", convertedObjectString);
+    }
+
+    @Test
+    public void toStringObjectSomeClass() {
+        String convertedObjectString = ObjectValueConverter.toString(KapuaId.ONE);
+
+        Assert.assertEquals("1", convertedObjectString);
+    }
+
+    @Test
+    public void toStringObjectEnum() {
+        String convertedObjectString = ObjectValueConverter.toString(ObjectValueConverterTestEnum.TEST);
+
+        Assert.assertEquals("TEST", convertedObjectString);
+    }
+
+    @Test
+    public void toStringObjectNull() {
+        String convertedObjectString = ObjectValueConverter.toString(null);
+
+        Assert.assertNull(convertedObjectString);
+    }
+
+    //
+    // fromString
+    //
+
+    @Test
+    public void fromStringString() {
+        Object convertedObject = ObjectValueConverter.fromString("aString", String.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(String.class, convertedObject.getClass());
+        Assert.assertEquals("aString", convertedObject);
+    }
+
+    @Test
+    public void fromStringInteger() {
+        Object convertedObject = ObjectValueConverter.fromString("1024", Integer.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(Integer.class, convertedObject.getClass());
+        Assert.assertEquals(1024, convertedObject);
     }
 
     @Test(expected = NumberFormatException.class)
-    public void fromStringInvalidStringValueTest() {
-        String[] invalidStringValue = {"-2147483649", "2147483648", "-9223372036854775809", "9223372036854775808", "10F",};
-        Class[] invalidClasses = {Integer.class, Integer.class, Long.class, Long.class, Integer.class};
+    public void fromStringIntegerNai() {
+        ObjectValueConverter.fromString("NaI", Integer.class);
+    }
 
-        for (int i = 0; i < invalidStringValue.length; i++) {
-            ObjectValueConverter.fromString(invalidStringValue[i], invalidClasses[i]);
-        }
+    @Test
+    public void fromStringLong() {
+        Object convertedObject = ObjectValueConverter.fromString("1024", Long.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(Long.class, convertedObject.getClass());
+        Assert.assertEquals(1024L, convertedObject);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void fromStringLongNal() {
+        ObjectValueConverter.fromString("NaL", Long.class);
+    }
+
+    @Test
+    public void fromStringFloat() {
+        Object convertedObject = ObjectValueConverter.fromString("10.24", Float.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(Float.class, convertedObject.getClass());
+        Assert.assertEquals(10.24f, convertedObject);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void fromStringFloatNaf() {
+        ObjectValueConverter.fromString("NaF", Float.class);
+    }
+
+    @Test
+    public void fromStringDouble() {
+        Object convertedObject = ObjectValueConverter.fromString("10.24", Double.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(Double.class, convertedObject.getClass());
+        Assert.assertEquals(10.24d, convertedObject);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void fromStringDoubleNad() {
+        ObjectValueConverter.fromString("NaD", Double.class);
+    }
+
+    @Test
+    public void fromStringBoolean() {
+        Object convertedObject = ObjectValueConverter.fromString("true", Boolean.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(Boolean.class, convertedObject.getClass());
+        Assert.assertEquals(Boolean.TRUE, convertedObject);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void fromStringBooleanNab() {
+        ObjectValueConverter.fromString("NaB", Double.class);
+    }
+
+    @Test
+    public void fromStringDate() {
+        Object convertedObject = ObjectValueConverter.fromString("2025-01-01T00:00:00.000Z", Date.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(Date.class, convertedObject.getClass());
+        Assert.assertEquals(new Date(1735689600000L), convertedObject);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fromStringDateNad() {
+        ObjectValueConverter.fromString("NaD", Date.class);
+    }
+
+    @Test
+    public void fromStringByteClass() {
+        Object convertedObject = ObjectValueConverter.fromString("gPYAAQp/", Byte[].class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(byte[].class, convertedObject.getClass());
+        Assert.assertArrayEquals(new byte[]{-128, -10, 0, 1, 10, 127}, (byte[]) convertedObject);
+    }
+
+    @Test
+    public void fromStringBytePrimitive() {
+        Object convertedObject = ObjectValueConverter.fromString("gPYAAQp/", byte[].class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(byte[].class, convertedObject.getClass());
+        Assert.assertArrayEquals(new byte[]{-128, -10, 0, 1, 10, 127}, (byte[]) convertedObject);
+    }
+
+    @Test
+    public void fromStringEnum() {
+        Object convertedObject = ObjectValueConverter.fromString("TEST", ObjectValueConverterTestEnum.class);
+
+        Assert.assertNotNull(convertedObject);
+        Assert.assertEquals(ObjectValueConverterTestEnum.class, convertedObject.getClass());
+        Assert.assertEquals(ObjectValueConverterTestEnum.TEST, convertedObject);
+    }
+
+    @Test
+    public void fromStringNull() {
+        Object convertedObject = ObjectValueConverter.fromString(null, Object.class);
+
+        Assert.assertNull(convertedObject);
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectValueConverterTestEnum.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectValueConverterTestEnum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,10 @@
 package org.eclipse.kapua.model.type;
 
 /**
+ * {@link Enum} for {@link ObjectValueConverterTest}
+ *
  * @since 1.5.0
  */
-public enum ObjectValieConverterTestEnum {
+public enum ObjectValueConverterTestEnum {
     TEST
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/DateXmlAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/DateXmlAdapterTest.java
@@ -26,6 +26,10 @@ import java.util.TimeZone;
 @Category(JUnitTests.class)
 public class DateXmlAdapterTest {
 
+    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
+    public static final String TIME_ZONE_UTC = "UTC";
+
     DateXmlAdapter dateXmlAdapter;
     Date date;
 
@@ -37,8 +41,8 @@ public class DateXmlAdapterTest {
 
     @Test
     public void marshalTest() throws Exception {
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DateXmlAdapter.DATE_FORMAT);
-        dateFormat.setTimeZone(TimeZone.getTimeZone(DateXmlAdapter.TIME_ZONE_UTC));
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+        dateFormat.setTimeZone(TimeZone.getTimeZone(TIME_ZONE_UTC));
         String expectedString = dateFormat.format(date);
         Assert.assertEquals("Expected and actual values should be the same.", expectedString, dateXmlAdapter.marshal(date));
     }
@@ -50,8 +54,8 @@ public class DateXmlAdapterTest {
 
     @Test
     public void unmarshalTest() {
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DateXmlAdapter.DATE_FORMAT);
-        dateFormat.setTimeZone(TimeZone.getTimeZone(DateXmlAdapter.TIME_ZONE_UTC));
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+        dateFormat.setTimeZone(TimeZone.getTimeZone(TIME_ZONE_UTC));
         String dateStringValue = dateFormat.format(date);
 
         Assert.assertEquals("Expected and actual values should be the same.", date, dateXmlAdapter.unmarshal(dateStringValue));

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -29,6 +29,7 @@ import java.text.ParseException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 import java.util.Date;
 import java.util.regex.Pattern;
 
@@ -463,6 +464,12 @@ public class DatastoreUtils extends AbstractStoreUtils {
                 }
             } else {
                 throw new IllegalArgumentException(String.format("Type [%s] cannot be converted to Date!", getValueClass(value)));
+            }
+        } else if (CLIENT_METRIC_TYPE_BINARY_ACRONYM.equals(acronymType)) {
+            try {
+                convertedValue = Base64.getDecoder().decode((String) value);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(String.format("Type [%s] cannot be converted to Byte[]. Value to convert [%s]", getValueClass(value), value));
             }
         } else {
             // no need to translate for others field type

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -16,6 +16,7 @@ package org.eclipse.kapua.service.datastore.internal.mediator;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
+import org.eclipse.kapua.model.type.ByteArrayConverter;
 import org.eclipse.kapua.service.elasticsearch.client.AbstractStoreUtils;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettings;
@@ -29,7 +30,6 @@ import java.text.ParseException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 import java.util.Date;
 import java.util.regex.Pattern;
 
@@ -467,7 +467,7 @@ public class DatastoreUtils extends AbstractStoreUtils {
             }
         } else if (CLIENT_METRIC_TYPE_BINARY_ACRONYM.equals(acronymType)) {
             try {
-                convertedValue = Base64.getDecoder().decode((String) value);
+                convertedValue = ByteArrayConverter.fromString((String) value);
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException(String.format("Type [%s] cannot be converted to Byte[]. Value to convert [%s]", getValueClass(value), value));
             }

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -113,6 +113,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -136,6 +137,7 @@ public class DatastoreSteps extends TestBase {
     private static final String MESSAGE_COUNT_RESULT = "messageCountResult";
     private static final String DOUBLE = "double";
     private static final String LAST_ACCOUNT = "LastAccount";
+    private static final String LAST_ACCOUNT_ID = "LastAccountId";
     private static final String MESSAGE_QUERY = "messageQuery";
     private static final String DEVICE = "Device";
     private static final String DATE_FORMAT_HH_MM_SS = "HH:mm:ss dd/MM/yyyy";
@@ -317,7 +319,6 @@ public class DatastoreSteps extends TestBase {
     @Before
     public void beforeScenario(Scenario scenario) {
         updateScenario(scenario);
-
     }
 
     @After(value = "not (@setup or @teardown)", order = 10)
@@ -1597,6 +1598,109 @@ public class DatastoreSteps extends TestBase {
             elasticsearchClient.deleteIndexes(indexes);
         } catch (Exception ex) {
             verifyException(ex);
+        }
+    }
+
+    @Given("I store a message with clientId {string} on topic {string} with timestamp now and metrics")
+    public void storeMessageOnTopicTimestampMetric(String clientId, String topic, List<CucMetric> cucMetrics) throws ClassNotFoundException, ParseException, KapuaException {
+        storeMessageOnTopicTimestampMetric(clientId, topic, new Date(), cucMetrics);
+    }
+
+    @Given("I store a message with clientId {string} on topic {string} with timestamp {string} and metrics")
+    public void storeMessageOnTopicTimestampMetric(String clientId, String topic, String timestamp, List<CucMetric> cucMetrics) throws ClassNotFoundException, ParseException, KapuaException {
+
+       storeMessageOnTopicTimestampMetric(
+               clientId,
+               topic,
+               KapuaDateUtils.parseDate(timestamp),
+               cucMetrics
+       );
+    }
+
+    public void storeMessageOnTopicTimestampMetric(String clientId, String topic, Date timestamp, List<CucMetric> cucMetrics) throws ClassNotFoundException, ParseException, KapuaException {
+        KapuaId currentAccountId = (KapuaId) stepData.get(LAST_ACCOUNT_ID);
+
+        // Build channel
+        KapuaDataChannel kapuaDataChannel = dataMessageFactory.newKapuaDataChannel();
+        kapuaDataChannel.setSemanticParts(Arrays.asList(topic.split("/")));
+
+        // Build payload
+        KapuaDataPayload kapuaDataPayload = dataMessageFactory.newKapuaDataPayload();
+
+        for (CucMetric cucMetric : cucMetrics) {
+            kapuaDataPayload.getMetrics().put(cucMetric.getMetric(), cucMetric.getValueCasted());
+        }
+
+        // Build message
+        KapuaDataMessage datastoreMessageCreator = dataMessageFactory.newKapuaDataMessage();
+        datastoreMessageCreator.setScopeId(currentAccountId);
+        datastoreMessageCreator.setClientId(clientId);
+        datastoreMessageCreator.setCapturedOn(timestamp);
+        datastoreMessageCreator.setReceivedOn(timestamp);
+        datastoreMessageCreator.setSentOn(timestamp);
+        datastoreMessageCreator.setChannel(kapuaDataChannel);
+        datastoreMessageCreator.setPayload(kapuaDataPayload);
+
+        StorableId datastoreMessageId = messageStoreService.store(datastoreMessageCreator);
+
+        stepData.put("lastDatastoreMessageCreator", datastoreMessageCreator);
+        stepData.put("lastStoredMessageId", datastoreMessageId);
+    }
+
+    @When("searching for the last DatastoreMessage stored")
+    public void searchLastDatastoreMessageStored() throws KapuaException {
+        Account account = (Account) stepData.get(LAST_ACCOUNT);
+        StorableId msgId = (StorableId) stepData.get("lastStoredMessageId");
+
+        DatastoreMessage lastDatastoreMessateStored = messageStoreService.find(account.getId(), msgId, StorableFetchStyle.SOURCE_FULL);
+        stepData.put("lastDatastoreMessageStored", lastDatastoreMessateStored);
+    }
+
+    @Then("verify last DatastoreMessage stored exist")
+    public void verifyLastDatastoreMessageStoredExists() {
+        Assert.assertNotNull("lastStoredDatastoreMessage", stepData.get("lastDatastoreMessageStored"));
+    }
+
+    @Then("verify the last stored message matches the last DatastoreMessageCreator")
+    public void lastMessageStoredMatchedCreator() {
+        KapuaDataMessage datastoreMessageCreator = (KapuaDataMessage) stepData.get("lastDatastoreMessageCreator");
+        DatastoreMessage lastDatastoreMessageStored = (DatastoreMessage) stepData.get("lastDatastoreMessageStored");
+
+        // Verify Message
+        Assert.assertNotNull("datastoreMessageCreator", datastoreMessageCreator);
+        Assert.assertNotNull("lastDatastoreMessageStored", lastDatastoreMessageStored);
+        Assert.assertEquals(datastoreMessageCreator.getClientId(), lastDatastoreMessageStored.getClientId());
+        Assert.assertEquals(datastoreMessageCreator.getCapturedOn(), lastDatastoreMessageStored.getCapturedOn());
+
+        // Verify Channel
+        KapuaDataChannel datastoreChannelCreator = datastoreMessageCreator.getChannel();
+        KapuaDataChannel lastDatastoreChannelStored = lastDatastoreMessageStored.getChannel();
+        Assert.assertNotNull("datastoreChannelCreator", datastoreChannelCreator);
+        Assert.assertNotNull("lastDatastoreChannelStored", lastDatastoreChannelStored);
+        Assert.assertEquals(datastoreChannelCreator.toPathString(), lastDatastoreChannelStored.toPathString());
+
+        // Verify Payload
+        KapuaPayload datastorePayloadCreator = datastoreMessageCreator.getPayload();
+        KapuaPayload lastDatastorePayload = lastDatastoreMessageStored.getPayload();
+        Assert.assertNotNull("datastorePayloadCreator", datastorePayloadCreator);
+        Assert.assertNotNull("lastDatastorePayload", lastDatastorePayload);
+        Assert.assertEquals(datastorePayloadCreator.getBody(), lastDatastorePayload.getBody());
+
+        for (Map.Entry<String, Object> metricCreator : datastorePayloadCreator.getMetrics().entrySet()) {
+            Object lastMetricStored = lastDatastorePayload.getMetrics().get(metricCreator.getKey());
+
+            Assert.assertNotNull("lastMetricStored." + metricCreator.getKey(), lastMetricStored);
+            Assert.assertEquals(metricCreator.getValue().getClass(), lastMetricStored.getClass());
+
+            if (metricCreator.getValue().getClass().isArray() ) {
+                Assert.assertArrayEquals(
+                        new Object[]{metricCreator.getValue()},
+                        new Object[]{lastMetricStored}
+                );
+            }
+            else {
+                Assert.assertEquals(metricCreator.getValue(), lastMetricStored);
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes the retrieval of `byte[]` metrics.

Currently they were stored correctly but returned as type `String` when read back from the Datastore

**Related Issue**
_None_

**Description of the solution adopted**
Fixed conversion of value of metric acronym is `bin`
Added a bunch of tests on metric storage and retrieval for each of the supported Metric types

**Screenshots**
_None_

**Any side note on the changes made**
Improved the structure of type Converters and their usage