### PR TITLE
:bug: [Console GWT] Fixed querying for binary Metrics

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -33,6 +33,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.KapuaButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.TabItem;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMessages;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreAsset;
@@ -138,10 +139,28 @@ public class AssetTabItem extends TabItem {
 
             @Override
             public void componentSelected(ButtonEvent ce) {
+
+                List<GwtHeader> metrics = metricsTable.getSelectedMetrics();
+
+                int binaryMetricsSelected = 0;
+                for (GwtHeader metric : metrics) {
+                    if ("binary".equals(metric.getType())) {
+                        binaryMetricsSelected++;
+                    }
+                }
+
+                if (binaryMetricsSelected == metrics.size()) {
+                    ConsoleInfo.display("Error!", "Only binary metrics selected. Binary metrics cannot be queried alone since they would not return any result");
+                    return;
+                }
+
+                if (binaryMetricsSelected > 0) {
+                    ConsoleInfo.display("Warning!", "Messages containing only binary metrics cannot be queried. The results set shown will show binary metric contained in messages that also contains selected non-binary metrics");
+                }
+
                 GwtDatastoreDevice gwtDevice = deviceTable.getSelectedDevice();
                 GwtDatastoreAsset gwtAsset = assetTable.getSelectedAsset();
-                List<GwtHeader> metricsInfo = metricsTable.getSelectedMetrics();
-                resultsTable.refresh(gwtDevice, gwtAsset, metricsInfo);
+                resultsTable.refresh(gwtDevice, gwtAsset, metrics);
             }
         });
         queryButton.disable();

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -40,6 +40,7 @@ import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreAsset;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreDevice;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtHeader;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class AssetTabItem extends TabItem {
@@ -142,20 +143,35 @@ public class AssetTabItem extends TabItem {
 
                 List<GwtHeader> metrics = metricsTable.getSelectedMetrics();
 
-                int binaryMetricsSelected = 0;
+                int binaryMetricsSelectedCount = 0;
+                List<String> binaryMetricsSelected = new ArrayList<String>();
                 for (GwtHeader metric : metrics) {
                     if ("binary".equals(metric.getType())) {
-                        binaryMetricsSelected++;
+                        binaryMetricsSelectedCount++;
+                        binaryMetricsSelected.add(metric.getName());
                     }
                 }
 
-                if (binaryMetricsSelected == metrics.size()) {
-                    ConsoleInfo.display("Error!", "Only binary metrics selected. Binary metrics cannot be queried alone since they would not return any result");
-                    return;
-                }
+                if (binaryMetricsSelectedCount > 0) {
 
-                if (binaryMetricsSelected > 0) {
-                    ConsoleInfo.display("Warning!", "Messages containing only binary metrics cannot be queried. The results set shown will show binary metric contained in messages that also contains selected non-binary metrics");
+                    StringBuilder invalidMetricsMessage = new StringBuilder();
+
+                    for (int i = 0; i < binaryMetricsSelected.size() && i < 10; i ++) {
+                        invalidMetricsMessage
+                                .append(binaryMetricsSelected.get(i))
+                                .append(", ");
+                    }
+
+                    // Removing trailing comma
+                    invalidMetricsMessage.delete(invalidMetricsMessage.length() - 2, invalidMetricsMessage.length() - 1);
+
+                    // If more than 10 metrics are invalid add "and others
+                    if (binaryMetricsSelected.size() > 10) {
+                        invalidMetricsMessage.append(" and more");
+                    }
+
+                    ConsoleInfo.display("Warning!", "Metrics " + invalidMetricsMessage + " do not support the search criteria. Remove the metrics from the selection and repeat the query");
+                    return;
                 }
 
                 GwtDatastoreDevice gwtDevice = deviceTable.getSelectedDevice();

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
@@ -39,6 +39,7 @@ import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMess
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreDevice;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtHeader;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class DeviceTabItem extends TabItem {
@@ -121,20 +122,35 @@ public class DeviceTabItem extends TabItem {
             public void componentSelected(ButtonEvent ce) {
                 List<GwtHeader> metrics = metricsTable.getSelectedMetrics();
 
-                int binaryMetricsSelected = 0;
+                int binaryMetricsSelectedCount = 0;
+                List<String> binaryMetricsSelected = new ArrayList<String>();
                 for (GwtHeader metric : metrics) {
                     if ("binary".equals(metric.getType())) {
-                        binaryMetricsSelected++;
+                        binaryMetricsSelectedCount++;
+                        binaryMetricsSelected.add(metric.getName());
                     }
                 }
 
-                if (binaryMetricsSelected == metrics.size()) {
-                    ConsoleInfo.display("Error!", "Only binary metrics selected. Binary metrics cannot be queried alone since they would not return any result");
-                    return;
-                }
+                if (binaryMetricsSelectedCount > 0) {
 
-                if (binaryMetricsSelected > 0) {
-                    ConsoleInfo.display("Warning!", "Messages containing only binary metrics cannot be queried. The results set shown will show binary metric contained in messages that also contains selected non-binary metrics");
+                    StringBuilder invalidMetricsMessage = new StringBuilder();
+
+                    for (int i = 0; i < binaryMetricsSelected.size() && i < 10; i ++) {
+                        invalidMetricsMessage
+                                .append(binaryMetricsSelected.get(i))
+                                .append(", ");
+                    }
+
+                    // Removing trailing comma
+                    invalidMetricsMessage.delete(invalidMetricsMessage.length() - 2, invalidMetricsMessage.length() - 1);
+
+                    // If more than 10 metrics are invalid add "and others
+                    if (binaryMetricsSelected.size() > 10) {
+                        invalidMetricsMessage.append(" and more");
+                    }
+
+                    ConsoleInfo.display("Warning!", "Metrics " + invalidMetricsMessage + " do not support the search criteria. Remove the metrics from the selection and repeat the query");
+                    return;
                 }
 
                 GwtDatastoreDevice gwtDevice = deviceTable.getSelectedDevice();

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
@@ -33,6 +33,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.KapuaButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.TabItem;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMessages;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreDevice;
@@ -118,9 +119,26 @@ public class DeviceTabItem extends TabItem {
 
             @Override
             public void componentSelected(ButtonEvent ce) {
+                List<GwtHeader> metrics = metricsTable.getSelectedMetrics();
+
+                int binaryMetricsSelected = 0;
+                for (GwtHeader metric : metrics) {
+                    if ("binary".equals(metric.getType())) {
+                        binaryMetricsSelected++;
+                    }
+                }
+
+                if (binaryMetricsSelected == metrics.size()) {
+                    ConsoleInfo.display("Error!", "Only binary metrics selected. Binary metrics cannot be queried alone since they would not return any result");
+                    return;
+                }
+
+                if (binaryMetricsSelected > 0) {
+                    ConsoleInfo.display("Warning!", "Messages containing only binary metrics cannot be queried. The results set shown will show binary metric contained in messages that also contains selected non-binary metrics");
+                }
+
                 GwtDatastoreDevice gwtDevice = deviceTable.getSelectedDevice();
-                List<GwtHeader> metricsInfo = metricsTable.getSelectedMetrics();
-                resultsTable.refresh(gwtDevice, metricsInfo);
+                resultsTable.refresh(gwtDevice, metrics);
             }
         });
         queryButton.disable();

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
@@ -38,6 +38,7 @@ import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMessages;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtHeader;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TopicsTabItem extends TabItem {
@@ -119,20 +120,35 @@ public class TopicsTabItem extends TabItem {
             public void componentSelected(ButtonEvent ce) {
                 List<GwtHeader> metrics = metricsTable.getSelectedMetrics();
 
-                int binaryMetricsSelected = 0;
+                int binaryMetricsSelectedCount = 0;
+                List<String> binaryMetricsSelected = new ArrayList<String>();
                 for (GwtHeader metric : metrics) {
                     if ("binary".equals(metric.getType())) {
-                        binaryMetricsSelected++;
+                        binaryMetricsSelectedCount++;
+                        binaryMetricsSelected.add(metric.getName());
                     }
                 }
 
-                if (binaryMetricsSelected == metrics.size()) {
-                    ConsoleInfo.display("Error!", "Only binary metrics selected. Binary metrics cannot be queried alone since they would not return any result");
-                    return;
-                }
+                if (binaryMetricsSelectedCount > 0) {
 
-                if (binaryMetricsSelected > 0) {
-                    ConsoleInfo.display("Warning!", "Messages containing only binary metrics cannot be queried. The results set shown will show binary metric contained in messages that also contains selected non-binary metrics");
+                    StringBuilder invalidMetricsMessage = new StringBuilder();
+
+                    for (int i = 0; i < binaryMetricsSelected.size() && i < 10; i ++) {
+                        invalidMetricsMessage
+                                .append(binaryMetricsSelected.get(i))
+                                .append(", ");
+                    }
+
+                    // Removing trailing comma
+                    invalidMetricsMessage.delete(invalidMetricsMessage.length() - 2, invalidMetricsMessage.length() - 1);
+
+                    // If more than 10 metrics are invalid add "and others
+                    if (binaryMetricsSelected.size() > 10) {
+                        invalidMetricsMessage.append(" and more");
+                    }
+
+                    ConsoleInfo.display("Warning!", "Metrics " + invalidMetricsMessage + " do not support the search criteria. Remove the metrics from the selection and repeat the query");
+                    return;
                 }
 
                 GwtTopic topic = topicTable.getSelectedTopic();

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/KapuaGwtDataModelConverter.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/KapuaGwtDataModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,10 +17,13 @@ import org.eclipse.kapua.app.console.module.data.client.util.GwtMessage;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreAsset;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreDevice;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtHeader;
+import org.eclipse.kapua.model.type.ByteArrayConverter;
+import org.eclipse.kapua.model.type.ObjectTypeConverter;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
+
 import java.util.List;
 
 public class KapuaGwtDataModelConverter {
@@ -38,7 +41,7 @@ public class KapuaGwtDataModelConverter {
     public static GwtHeader convertToHeader(MetricInfo metric) {
         GwtHeader header = new GwtHeader();
         header.setName(metric.getName());
-        header.setType(metric.getMetricType().getSimpleName());
+        header.setType(ObjectTypeConverter.toString(metric.getMetricType()));
         return header;
     }
 
@@ -70,7 +73,13 @@ public class KapuaGwtDataModelConverter {
         gwtMessage.setClientId(message.getClientId());
         gwtMessage.setTimestamp(message.getTimestamp());
         for (GwtHeader header : headers) {
-            gwtMessage.set(header.getName(), message.getPayload().getMetrics().get(header.getName()));
+            Object metricValue = message.getPayload().getMetrics().get(header.getName());
+
+            if (metricValue instanceof byte[]) {
+                metricValue = ByteArrayConverter.toString((byte[]) metricValue);
+            }
+
+            gwtMessage.set(header.getName(), metricValue);
         }
         return gwtMessage;
     }


### PR DESCRIPTION
This PR fixes the following error when querying Data Messages with `binary` metrics

```
kapua-console       | WARNING: An illegal reflective access operation has occurred
kapua-console       | WARNING: Illegal reflective access by com.google.gwt.user.server.rpc.impl.ServerSerializationStreamWriter (file:/var/opt/jetty/webapps/root/WEB-INF/lib/gwt-servlet-2.4.0.jar) to field java.lang.Throwable.detailMessage
kapua-console       | WARNING: Please consider reporting this to the maintainers of com.google.gwt.user.server.rpc.impl.ServerSerializationStreamWriter
kapua-console       | WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
kapua-console       | WARNING: All illegal access operations will be denied in a future release
```
this error occurs because GWT is not capable/configured to serialize byte[] values in GwtMetric when sending data back to the client that queried for Data Messages

**Related Issue**
_None_

**Description of the solution adopted**
- Fixed metric type serialization to use the ObjectTypeConverter utility (this serialize properly `byte[]` to `binary`
- Added conversion to Base64 of `byte[]` values

Added a new warn message in the console when the list of selected metrics contains at least one `binary` metric: 
<img width="240" height="161" alt="Screenshot 2025-09-01 at 15 56 00" src="https://github.com/user-attachments/assets/58475f1a-6a24-4acc-8af6-0e02bd1ed2a3" />
query won't proceed further because search for existence of a binary metric is not supported with current implementation hence the results would not be consistent.

Query won't proceed further

**Screenshots**
_None_

**Any side note on the changes made**
_None_