### PR TITLE
:bug: [Datastore] Fixed serialisation of MetricExistPredicate to convert binary metrics

### DIFF
--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/MetricExistsPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/MetricExistsPredicateImpl.java
@@ -67,13 +67,18 @@ public class MetricExistsPredicateImpl extends ExistsPredicateImpl implements Me
     public ObjectNode toSerializedMap() throws MappingException {
         StringBuilder fieldNameSb = new StringBuilder();
 
-        fieldNameSb.append(MessageField.METRICS.field())
-                .append(".")
-                .append(datastoreUtils.normalizeMetricName(getName()));
+        fieldNameSb
+            .append(MessageField.METRICS.field())
+            .append(".")
+            .append(datastoreUtils.normalizeMetricName(getName()));
 
         if (getType() != null) {
             fieldNameSb.append(".")
-                    .append(datastoreUtils.getClientMetricFromAcronym(type.getSimpleName().toLowerCase()));
+                .append(
+                    datastoreUtils.getClientMetricFromAcronym(
+                        datastoreUtils.convertToClientMetricType(getType())
+                    )
+                );
         }
 
         ObjectNode termNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(PredicateConstants.FIELD_KEY, fieldNameSb.toString())});


### PR DESCRIPTION
This PR fixes the serialisation of MetricExistPredicate to convert correctly exist on binary metrics.

**Related Issue**
This PR relates to changes in #4256

**Description of the solution adopted**
Changed from `getClass().toLowerCase()` to the dedicated `DatastoreUtils.convertToClientMetricType(...)` that converts the `type` according to the datastore logics
 
**Screenshots**
_None_

**Any side note on the changes made**
_None_