### PR TITLE
:bug: [REST API] Fixed querying for binary Metrics

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/model/MetricType.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/model/MetricType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,8 @@ import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.model.type.ObjectTypeConverter;
 
 import com.google.common.base.Strings;
+
+import java.util.Objects;
 
 public class MetricType<V extends Comparable<V>> {
 
@@ -36,4 +38,26 @@ public class MetricType<V extends Comparable<V>> {
         return type;
     }
 
+    /**
+     * @since 2.1.0
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MetricType<?> that = (MetricType<?>) o;
+        return Objects.equals(getType(), that.getType());
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getType());
+    }
 }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -97,23 +97,40 @@ public class DataMessages extends AbstractKapuaResource {
      */
     @GET
     @Produces({ MediaType.APPLICATION_XML })
-    public <V extends Comparable<V>> MessageListResult simpleQuery(@PathParam("scopeId") ScopeId scopeId,
+    public <V extends Comparable<V>> MessageListResult simpleQuery(
+            @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("clientId") List<String> clientIds,
             @QueryParam("channel") String channel,
             @QueryParam("strictChannel") boolean strictChannel,
             @QueryParam("startDate") DateParam startDateParam,
             @QueryParam("endDate") DateParam endDateParam,
             @QueryParam("metricName") String metricName,
-            @QueryParam("metricType") String metricType,
+            @QueryParam("metricType") String stringMetricType,
             @QueryParam("metricMin") String metricMinValue,
             @QueryParam("metricMax") String metricMaxValue,
             @QueryParam("sortDir") @DefaultValue("DESC") SortDirection sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
-            @QueryParam("limit") @DefaultValue("50") int limit)
-            throws KapuaException {
-        MetricType<V> internalMetricType = new MetricType<>(metricType);
-        MessageQuery query = parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientIds, channel, strictChannel, startDateParam, endDateParam, metricName, internalMetricType,
-                metricMinValue, metricMaxValue, sortDir, offset, limit);
+            @QueryParam("limit") @DefaultValue("50") int limit
+    ) throws KapuaException {
+
+        MetricType<V> metricType = new MetricType<>(stringMetricType);
+
+        MessageQuery query = parametersToQuery(
+                datastorePredicateFactory,
+                messageStoreFactory,
+                scopeId,
+                clientIds,
+                channel,
+                strictChannel,
+                startDateParam,
+                endDateParam,
+                metricName,
+                metricType,
+                metricMinValue,
+                metricMaxValue,
+                sortDir,
+                offset,
+                limit);
 
         return query(scopeId, query);
     }
@@ -207,6 +224,10 @@ public class DataMessages extends AbstractKapuaResource {
         return returnNotNullEntity(datastoreMessage);
     }
 
+    //
+    // Private methods
+    //
+
     //TODO: move this logic within the service, or at least in a collaborator shared with DataMessagesJson
     protected static <V extends Comparable<V>> MessageQuery parametersToQuery(
             DatastorePredicateFactory datastorePredicateFactory,
@@ -224,7 +245,10 @@ public class DataMessages extends AbstractKapuaResource {
             SortDirection sortDir,
             int offset,
             int limit) throws KapuaIllegalNullArgumentException {
+
         AndPredicate andPredicate = datastorePredicateFactory.newAndPredicate();
+
+        // Client ID predicates
         final List<StorablePredicate> clientPredicates = Optional.ofNullable(clientIds)
                 .orElse(new ArrayList<>())
                 .stream()
@@ -237,10 +261,13 @@ public class DataMessages extends AbstractKapuaResource {
             orPredicate.setPredicates(clientPredicates);
             andPredicate.addPredicate(orPredicate);
         }
+
+        // Channel predicate
         if (!Strings.isNullOrEmpty(channel)) {
             andPredicate.getPredicates().add(getChannelPredicate(datastorePredicateFactory, channel, strictChannel));
         }
 
+        // Start and End predicates
         Date startDate = startDateParam != null ? startDateParam.getDate() : null;
         Date endDate = endDateParam != null ? endDateParam.getDate() : null;
         if (startDate != null || endDate != null) {
@@ -248,10 +275,20 @@ public class DataMessages extends AbstractKapuaResource {
             andPredicate.getPredicates().add(timestampPredicate);
         }
 
+        // Metric predicate
         if (!Strings.isNullOrEmpty(metricName)) {
-            andPredicate.getPredicates().add(getMetricPredicate(datastorePredicateFactory, metricName, metricType, metricMinValue, metricMaxValue));
+            andPredicate.getPredicates().add(
+                    getMetricPredicate(
+                            datastorePredicateFactory,
+                            metricName,
+                            metricType,
+                            metricMinValue,
+                            metricMaxValue
+                    )
+            );
         }
 
+        // Prepare query
         MessageQuery query = messageStoreFactory.newQuery(scopeId);
         query.setPredicate(andPredicate);
         query.setOffset(offset);
@@ -273,8 +310,14 @@ public class DataMessages extends AbstractKapuaResource {
         return channelPredicate;
     }
 
-    private static <V extends Comparable<V>> StorablePredicate getMetricPredicate(DatastorePredicateFactory datastorePredicateFactory, String metricName, MetricType<V> metricType,
-            String metricMinValue, String metricMaxValue) throws KapuaIllegalNullArgumentException {
+    private static <V extends Comparable<V>> StorablePredicate getMetricPredicate(
+            DatastorePredicateFactory datastorePredicateFactory,
+            String metricName,
+            MetricType<V> metricType,
+            String metricMinValue,
+            String metricMaxValue)
+        throws KapuaIllegalNullArgumentException {
+
         if (metricMinValue == null && metricMaxValue == null) {
             Class<V> type = metricType != null ? metricType.getType() : null;
             return datastorePredicateFactory.newMetricExistsPredicate(metricName, type);
@@ -282,6 +325,7 @@ public class DataMessages extends AbstractKapuaResource {
             if (metricType == null) {
                 throw new KapuaIllegalNullArgumentException("metricType");
             }
+
             V minValue = (V) ObjectValueConverter.fromString(metricMinValue, metricType.getType());
             V maxValue = (V) ObjectValueConverter.fromString(metricMaxValue, metricType.getType());
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,6 +31,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.DateParam;
@@ -244,7 +245,7 @@ public class DataMessages extends AbstractKapuaResource {
             String metricMaxValue,
             SortDirection sortDir,
             int offset,
-            int limit) throws KapuaIllegalNullArgumentException {
+            int limit) throws KapuaIllegalArgumentException {
 
         AndPredicate andPredicate = datastorePredicateFactory.newAndPredicate();
 
@@ -316,7 +317,7 @@ public class DataMessages extends AbstractKapuaResource {
             MetricType<V> metricType,
             String metricMinValue,
             String metricMaxValue)
-        throws KapuaIllegalNullArgumentException {
+            throws KapuaIllegalArgumentException {
 
         if (metricMinValue == null && metricMaxValue == null) {
             Class<V> type = metricType != null ? metricType.getType() : null;
@@ -324,6 +325,10 @@ public class DataMessages extends AbstractKapuaResource {
         } else {
             if (metricType == null) {
                 throw new KapuaIllegalNullArgumentException("metricType");
+            }
+
+            if (new MetricType<>("binary").equals(metricType)) {
+                throw new KapuaIllegalArgumentException("metricType", "binary");
             }
 
             V minValue = (V) ObjectValueConverter.fromString(metricMinValue, metricType.getType());

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -317,18 +317,29 @@ public class DataMessages extends AbstractKapuaResource {
             MetricType<V> metricType,
             String metricMinValue,
             String metricMaxValue)
-            throws KapuaIllegalArgumentException {
+        throws KapuaIllegalArgumentException {
+
+        // Cannot perform MetricExistPredicate MetricPredicate on `binary` metrics
+        if (new MetricType<>("binary").equals(metricType)) {
+            throw new KapuaIllegalArgumentException("metricType", "binary");
+        }
 
         if (metricMinValue == null && metricMaxValue == null) {
-            Class<V> type = metricType != null ? metricType.getType() : null;
-            return datastorePredicateFactory.newMetricExistsPredicate(metricName, type);
+
+            StorablePredicate metricPredicate;
+
+            if (metricType != null) {
+                metricPredicate = datastorePredicateFactory.newMetricExistsPredicate(metricName, metricType.getType());
+            }
+            else {
+                // If metric name matches a `binary` metric, no message will be matched since ES does not support binary indexing
+                metricPredicate = datastorePredicateFactory.newMetricExistsPredicate(metricName, null);
+            }
+
+            return metricPredicate;
         } else {
             if (metricType == null) {
                 throw new KapuaIllegalNullArgumentException("metricType");
-            }
-
-            if (new MetricType<>("binary").equals(metricType)) {
-                throw new KapuaIllegalArgumentException("metricType", "binary");
             }
 
             V minValue = (V) ObjectValueConverter.fromString(metricMinValue, metricType.getType());

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -96,32 +96,50 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
-    public <V extends Comparable<V>> JsonMessageListResult simpleQueryJson(@PathParam("scopeId") ScopeId scopeId,
+    public <V extends Comparable<V>> JsonMessageListResult simpleQueryJson(
+            @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("clientId") List<String> clientIds,
             @QueryParam("channel") String channel,
             @QueryParam("strictChannel") boolean strictChannel,
             @QueryParam("startDate") DateParam startDateParam,
             @QueryParam("endDate") DateParam endDateParam,
             @QueryParam("metricName") String metricName,
-            @QueryParam("metricType") String metricType,
+            @QueryParam("metricType") String stringMetricType,
             @QueryParam("metricMin") String metricMinValue,
             @QueryParam("metricMax") String metricMaxValue,
             @QueryParam("sortDir") @DefaultValue("DESC") SortDirection sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
-            @QueryParam("limit") @DefaultValue("50") int limit)
-            throws KapuaException {
-        MetricType<V> internalMetricType = new MetricType<>(metricType);
-        MessageQuery query = DataMessages.parametersToQuery(datastorePredicateFactory, messageStoreFactory, scopeId, clientIds, channel, strictChannel, startDateParam, endDateParam, metricName,
-                internalMetricType, metricMinValue, metricMaxValue, sortDir, offset, limit);
-        query.setScopeId(scopeId);
-        final MessageListResult result = messageStoreService.query(query);
+            @QueryParam("limit") @DefaultValue("50") int limit
+    ) throws KapuaException {
+        MetricType<V> metricType = new MetricType<>(stringMetricType);
+
+        MessageQuery query = DataMessages.parametersToQuery(
+                datastorePredicateFactory,
+                messageStoreFactory,
+                scopeId,
+                clientIds,
+                channel,
+                strictChannel,
+                startDateParam,
+                endDateParam,
+                metricName,
+                metricType,
+                metricMinValue,
+                metricMaxValue,
+                sortDir,
+                offset,
+                limit);
+
+        MessageListResult result = messageStoreService.query(query);
 
         List<JsonDatastoreMessage> jsonDatastoreMessages = new ArrayList<>();
         result.getItems().forEach(m -> jsonDatastoreMessages.add(new JsonDatastoreMessage(m)));
+
         JsonMessageListResult jsonResult = new JsonMessageListResult();
         jsonResult.addItems(jsonDatastoreMessages);
         jsonResult.setTotalCount(result.getTotalCount());
         jsonResult.setLimitExceeded(result.isLimitExceeded());
+
         return jsonResult;
     }
 


### PR DESCRIPTION
This PR fixes querying for `binary` metrics via REST API

`binary` mapped metrics are not searchable in Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/binary.html

**Related Issue**
_None_

**Description of the solution adopted**
Fixed handling of parameters `metricType` and `metricMin`/`metricMax` to be consistent with the semantics of the API when `metricType` is `binary`. In fact, the API should find all messages where the metric with name `metricName` exists and (optionally) the value included in the range [`metricMin`, `metricMax`]. 
Unfortunately with current datastore engine, search for existence of a `binary` field is not supported, moreover by their nature binary values are not comparable, hence specifying the parameters `metricMin` and `metricMax` is meaningless.
For these reasons when metric type is `binary` an illegal argument error is thrown/returned. User can still use the API to query the datastore without the metric parameter and then inspect the returned messages to find the ones which satisfy the criteria. 
 
**Screenshots**
_None_

**Any side note on the changes made**
_None_