### PR TITLE
:arrow_up: [Dependencies] Bumped version of activemq-openwire-legacy to 5.17.7 - CVE-2025-27533

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <spring-boot.version>2.7.18</spring-boot.version>
 
         <aopalliance.version>1.0</aopalliance.version>
+        <activemq-openwire-legacy.version>5.17.7</activemq-openwire-legacy.version> <!-- Bumped version to address CVE-2025-27533-->
         <artemis.version>2.31.2</artemis.version>
         <assertj.version>3.2.0</assertj.version>
         <checker-framework.version>3.15.0</checker-framework.version>
@@ -2498,6 +2499,11 @@
                         <artifactId>slf4j-simple</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-openwire-legacy</artifactId>
+                <version>${activemq-openwire-legacy.version}</version>
             </dependency>
 
             <!-- Camel -->


### PR DESCRIPTION
Bumped the version of `org.apache.activemq:activemq-openwire-legacy` to address component CVEs:

- CVE-2025-27533

**Related Issue**
Following PR relates to the same changes for other development branches:
- `release-1.6.x`: #4261  
- `develop`: https://github.com/eclipse-kapua/kapua/pull/4263

**Description of the solution adopted**
Bumped the version of `org.apache.activemq:activemq-openwire-legacy` to `5.17.7` via `dependencyManagement` pom section

**Screenshots**
_None_

**Any side note on the changes made**
_None_