### PR TITLE
⬆️ [Dependencies] Bumped version of Apache Activemq components to 5.16.8 - CVE-2025-27533

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Dependencies versions -->
-        <activemq.version>5.16.7</activemq.version>
+        <activemq.version>5.16.8</activemq.version>
         <activemq-openwire-legacy.version>5.16.8</activemq-openwire-legacy.version> <!-- Bumped version to address CVE-2023-46604 and CVE-2025-27533-->
         <aopalliance.version>1.0</aopalliance.version>
         <artemis.version>2.19.0</artemis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
         <!-- Dependencies versions -->
         <activemq.version>5.16.8</activemq.version>
-        <activemq-openwire-legacy.version>5.16.8</activemq-openwire-legacy.version> <!-- Bumped version to address CVE-2023-46604 and CVE-2025-27533-->
+        <activemq-openwire-legacy.version>5.16.8</activemq-openwire-legacy.version> <!-- Bumped version to address CVE-2023-46604 and CVE-2025-27533 coming from 'org.apache.activemq:apache-artemis:tar.gz:bin:2.19.0' in 'kapua-assembly-events-broker' module -->
         <aopalliance.version>1.0</aopalliance.version>
         <artemis.version>2.19.0</artemis.version>
         <assertj.version>3.2.0</assertj.version>


### PR DESCRIPTION
This PR bumps the version of all Apache ActiveMQ components from 5.16.7 to 5.16.8.

This solves the following CVE:
- ` org.apache.activemq:activemq-client:5.16.7` - CVE-2025-27533

**Related Issue**
Relates to changes made in https://github.com/eclipse-kapua/kapua/pull/4261 to address CVEs.

**Description of the solution adopted**
Bumped the component version

**Screenshots**
_None_

**Any side note on the changes made**
Added a detailed description on why `activemq-openwire-legacy` has its own version override which was not added in https://github.com/eclipse-kapua/kapua/pull/4261