### PR TITLE
:arrow_up: [Dependencies] Bumped version of activemq-client to 5.17.7 - CVE-2025-27533

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,8 @@
         <spring-boot.version>2.7.18</spring-boot.version>
 
         <aopalliance.version>1.0</aopalliance.version>
-        <activemq-openwire-legacy.version>5.17.7</activemq-openwire-legacy.version> <!-- Bumped version to address CVE-2025-27533-->
+        <activemq-openwire-legacy.version>5.17.7</activemq-openwire-legacy.version> <!-- Bumped version to address CVE-2025-27533 coming from 'org.apache.activemq:apache-artemis:tar.gz:bin:2.31.2' -->
+        <activemq-client.version>5.17.7</activemq-client.version> <!-- Bumped version to address CVE-2025-27533 coming from 'org.apache.activemq:apache-artemis:tar.gz:bin:2.31.2' -->
         <artemis.version>2.31.2</artemis.version>
         <assertj.version>3.2.0</assertj.version>
         <checker-framework.version>3.15.0</checker-framework.version>
@@ -2504,6 +2505,11 @@
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-openwire-legacy</artifactId>
                 <version>${activemq-openwire-legacy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>${activemq-client.version}</version>
             </dependency>
 
             <!-- Camel -->


### PR DESCRIPTION
Bumped the version of `org.apache.activemq:activemq-client` to address component CVEs:

- CVE-2025-27533

**Related Issue**
Following PR relates to the same changes for other development branches:
- `develop`: https://github.com/eclipse-kapua/kapua/pull/4266

**Description of the solution adopted**
Bumped the version of `org.apache.activemq:activemq-client` to `5.17.7` via `dependencyManagement` pom section

**Screenshots**
_None_

**Any side note on the changes made**
_None_