### PR TITLE
:sparkles: [Broker] Improve security plugin performances

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ArtemisSecurityModule.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ArtemisSecurityModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,10 +20,14 @@ import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSetting;
 import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSettingKey;
 import org.eclipse.kapua.commons.cache.LocalCache;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Provides;
 
 public class ArtemisSecurityModule extends AbstractKapuaModule {
+
+    private static final Logger logger = LoggerFactory.getLogger(ArtemisSecurityModule.class);
 
     @Override
     protected void configureModule() {
@@ -41,19 +45,25 @@ public class ArtemisSecurityModule extends AbstractKapuaModule {
             MetricsSecurityPlugin metricsSecurityPlugin,
             PluginUtility pluginUtility,
             RunWithLock runWithLock) {
+        int connectionTokenSize = brokerSettings.getInt(BrokerSettingKey.CACHE_CONNECTION_TOKEN_SIZE);
+        int connectionTokenTtl = brokerSettings.getInt(BrokerSettingKey.CACHE_CONNECTION_TOKEN_TTL);
+        int sessionContextSize = brokerSettings.getInt(BrokerSettingKey.CACHE_SESSION_CONTEXT_SIZE);
+        int sessionContextTtl = brokerSettings.getInt(BrokerSettingKey.CACHE_SESSION_CONTEXT_TTL);
+        logger.info("Connection token: size {} / ttl {} - session context: size {} / ttl {}",
+                connectionTokenSize, connectionTokenTtl, sessionContextSize, sessionContextTtl);
         return new SecurityContext(loginMetric,
                 brokerSettings.getBoolean(BrokerSettingKey.PRINT_SECURITY_CONTEXT_REPORT, false),
                 new LocalCache<>(
-                        brokerSettings.getInt(BrokerSettingKey.CACHE_CONNECTION_TOKEN_SIZE),
-                        brokerSettings.getInt(BrokerSettingKey.CACHE_CONNECTION_TOKEN_TTL),
+                        connectionTokenSize,
+                        connectionTokenTtl,
                         null),
                 new LocalCache<>(
-                        brokerSettings.getInt(BrokerSettingKey.CACHE_SESSION_CONTEXT_SIZE),
-                        brokerSettings.getInt(BrokerSettingKey.CACHE_SESSION_CONTEXT_TTL),
+                        sessionContextSize,
+                        sessionContextTtl,
                         null),
                 new LocalCache<>(
-                        brokerSettings.getInt(BrokerSettingKey.CACHE_SESSION_CONTEXT_SIZE),
-                        brokerSettings.getInt(BrokerSettingKey.CACHE_SESSION_CONTEXT_TTL),
+                        sessionContextSize,
+                        sessionContextTtl,
                         null),
                 metricsSecurityPlugin,
                 pluginUtility,

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/RunWithLock.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/RunWithLock.java
@@ -27,13 +27,13 @@ import java.util.stream.Stream;
 public class RunWithLock {
 
     public enum LockType {
-        EXTERNAL,
-        INTERNAL
+        CONNECTION_ID,
+        CLIENT_ID
     }
 
     //TODO make it configurable?
     //TODO how many threads are available?
-    private static final int LOCKS_SIZE = 128;
+    private static final int LOCKS_SIZE = 256;
     private final Map<LockType, Lock[]> locks;
 
     @Inject

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
@@ -182,18 +182,18 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
 //            return authenticateExternalConnCallable(connectionInfo, connectionId, username, password, remotingConnection);
         }
         else {
-            return serverContext.getSecurityContext().callWithLock(LockType.CLIENT_ID, connectionInfo.getClientId(),
-                () -> authenticateExternalConnCallable(connectionInfo, connectionId, username, password, remotingConnection));
+            String fullClientId = Utils.getFullClientId(getScopeId(username), connectionInfo.getClientId());
+            return serverContext.getSecurityContext().callWithLock(LockType.CLIENT_ID, fullClientId,
+                () -> authenticateExternalConnCallable(connectionInfo, connectionId, fullClientId, username, password, remotingConnection));
         }
     }
 
-    private Subject authenticateExternalConnCallable(ConnectionInfo connectionInfo, String connectionId, String username, String password, RemotingConnection remotingConnection) {
+    private Subject authenticateExternalConnCallable(ConnectionInfo connectionInfo, String connectionId, String fullClientId, String username, String password, RemotingConnection remotingConnection) {
         loginMetric.getExternalConnector().getAttempt().inc();
         Context timeTotal = loginMetric.getExternalAddConnection().time();
         try {
             logger.info("Authenticate external: user: {} - clientId: {} - connectionIp: {} - connectionId: {} - isOpen: {}",
                     username, connectionInfo.getClientId(), connectionInfo.getClientIp(), remotingConnection.getID(), remotingConnection.getTransportConnection().isOpen());
-            String fullClientId = Utils.getFullClientId(getScopeId(username), connectionInfo.getClientId());
             AuthRequest authRequest = new AuthRequest(
                     serverContext.getClusterName(),
                     serverContext.getBrokerIdentity().getBrokerHost(), SecurityAction.brokerConnect.name(),

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
@@ -23,6 +23,7 @@ import org.apache.activemq.artemis.core.security.CheckType;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager5;
+import org.eclipse.kapua.broker.artemis.plugin.security.RunWithLock.LockType;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.LoginMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.PublishMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.SubscribeMetric;
@@ -53,7 +54,6 @@ import javax.jms.JMSException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.security.auth.Subject;
 import javax.security.auth.login.CredentialException;
-import javax.security.cert.X509Certificate;
 import java.security.cert.Certificate;
 import java.util.Set;
 
@@ -130,23 +130,6 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
         }
     }
 
-//    private String extractAndValidateClientId(RemotingConnection remotingConnection) {
-//        String clientId = remotingConnection.getClientID();
-//        //set a random client id value if not set by the client
-//        //from JMS 2 specs "Although setting client ID remains mandatory when creating an unshared durable subscription, it is optional when creating a shared durable subscription."
-//        if (Strings.isNullOrEmpty(clientId)) {
-//            clientId = clientIdPrefix + INDEX.getAndIncrement();
-//            logger.info("Updated empty client id to: {}", clientId);
-//        }
-//        //leave the clientId validation to the DeviceCreator. Here just check for / or ::
-//        //ArgumentValidator.match(clientId, DeviceValidationRegex.CLIENT_ID, "deviceCreator.clientId");
-//        if (clientId != null && (clientId.contains("/") || clientId.contains("::"))) {
-//            //TODO look for the right exception mapped to MQTT invalid client id error code
-//            throw new SecurityException("Invalid Client Id!");
-//        }
-//        return clientId;
-//    }
-
     private String extractAndValidateClientId(RemotingConnection remotingConnection) {
         String clientId = remotingConnection.getClientID();
         //leave the clientId validation to the DeviceCreator. Here just check for / or ::
@@ -158,6 +141,7 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
         return clientId;
     }
 
+    //TODO SEE EXTERNAL FOR THE LOCK
     private Subject authenticateInternalConn(ConnectionInfo connectionInfo, String connectionId, String username, String password, RemotingConnection remotingConnection) {
         loginMetric.getInternalConnector().getAttempt().inc();
         String usernameToCompare = SystemSetting.getInstance().getString(SystemSettingKey.BROKER_INTERNAL_CONNECTOR_USERNAME);
@@ -192,10 +176,13 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
 
     private Subject authenticateExternalConn(ConnectionInfo connectionInfo, String connectionId, String username, String password, RemotingConnection remotingConnection) throws Exception {
         if (connectionInfo.getClientId()==null) {
-            return authenticateExternalConnCallable(connectionInfo, connectionId, username, password, remotingConnection);
+            logger.warn("Client Id is null for connection id {} - login denied", connectionId);
+            return null;
+//            throw new SecurityException("Invalid Client Id!");
+//            return authenticateExternalConnCallable(connectionInfo, connectionId, username, password, remotingConnection);
         }
         else {
-            return serverContext.getSecurityContext().callWithLock(connectionInfo.getClientId(),
+            return serverContext.getSecurityContext().callWithLock(LockType.CLIENT_ID, connectionInfo.getClientId(),
                 () -> authenticateExternalConnCallable(connectionInfo, connectionId, username, password, remotingConnection));
         }
     }
@@ -214,7 +201,8 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
                     serverContext.getBrokerIdentity().getBrokerHost(), serverContext.getBrokerIdentity().getBrokerId());
             SessionContext currentSessionContext = serverContext.getSecurityContext().getSessionContextByClientId(fullClientId);
 
-            serverContext.getSecurityContext().updateStealingLinkAndIllegalState(authRequest, connectionId, currentSessionContext != null ? currentSessionContext.getConnectionId() : null);
+            boolean isStealingLink = serverContext.getSecurityContext().updateStealingLinkAndIllegalState(
+                    authRequest, connectionId, currentSessionContext != null ? currentSessionContext.getConnectionId() : null);
             AuthResponse authResponse = serverContext.getAuthServiceClient().brokerConnect(authRequest);
             validateAuthResponse(authResponse);
             KapuaPrincipal principal = new KapuaPrincipalImpl(authResponse);
@@ -226,11 +214,14 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
             remotingConnection.setClientID(fullClientId);
             logger.info("Authenticate external: connectionId: {} - old: {}", sessionContext.getConnectionId(), currentSessionContext != null ? currentSessionContext.getConnectionId() : "N/A");
             Subject subject = null;
-            //this call is synchronized on sessionId value
+            //this call is synchronized on connectionId value
             if (serverContext.getSecurityContext().setSessionContext(sessionContext, authResponse.getAcls())) {
                 subject = serverContext.getSecurityContext().buildFromPrincipal(sessionContext.getPrincipal());
             }
             loginMetric.getExternalConnector().getSuccess().inc();
+            if (isStealingLink) {
+                serverContext.cleanUpConnectionData(logger, loginMetric, currentSessionContext.getConnectionId(), pluginUtility.isInternal(remotingConnection), null, null);
+            }
             return subject;
         } catch (Exception e) {
             loginMetric.getExternalConnector().getFailure().inc();
@@ -355,15 +346,13 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
         try {
             SslHandler sslhandler = (SslHandler) nettyServerConnection.getChannel().pipeline().get("ssl");
             if (sslhandler != null) {
-                Certificate[] localCertificates = sslhandler.engine().getSession().getLocalCertificates();
-                Certificate[] clientCertificates = sslhandler.engine().getSession().getPeerCertificates();
-                X509Certificate[] x509ClientCertificates = sslhandler.engine().getSession().getPeerCertificateChain();//???
-                return clientCertificates;
+                return sslhandler.engine().getSession().getPeerCertificates();
             } else {
                 return null;
             }
         } catch (SSLPeerUnverifiedException e) {
-            logger.error("", e);
+            logger.warn("SSLPeerUnverifiedException: {}", e.getMessage());
+            logger.debug("", e);
             return null;
         }
     }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerContext.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerContext.java
@@ -90,7 +90,7 @@ public class ServerContext {
         return addressAccessTracker;
     }
 
-    public void closeConnection(Logger logger, LoginMetric loginMetric,RemotingConnection remotingConnection, String connectionId) {
+    public void closeConnection(Logger logger, LoginMetric loginMetric, RemotingConnection remotingConnection, String connectionId) {
         remotingConnection.disconnect(false);
         remotingConnection.destroy();
         cleanUpConnectionData(logger, loginMetric, connectionId, false, null, null);

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerContext.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerContext.java
@@ -13,10 +13,21 @@
 package org.eclipse.kapua.broker.artemis.plugin.security;
 
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.artemis.plugin.security.RunWithLock.LockType;
+import org.eclipse.kapua.broker.artemis.plugin.security.ServerPlugin.Failure;
 import org.eclipse.kapua.broker.artemis.plugin.security.context.SecurityContext;
+import org.eclipse.kapua.broker.artemis.plugin.security.metric.LoginMetric;
 import org.eclipse.kapua.broker.artemis.plugin.utils.BrokerIdentity;
 import org.eclipse.kapua.client.security.ServiceClient;
+import org.eclipse.kapua.client.security.ServiceClient.SecurityAction;
+import org.eclipse.kapua.client.security.bean.AuthRequest;
+import org.eclipse.kapua.client.security.context.SessionContext;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.Timer.Context;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -78,4 +89,69 @@ public class ServerContext {
     public AddressAccessTracker getAddressAccessTracker() {
         return addressAccessTracker;
     }
+
+    public void closeConnection(Logger logger, LoginMetric loginMetric,RemotingConnection remotingConnection, String connectionId) {
+        remotingConnection.disconnect(false);
+        remotingConnection.destroy();
+        cleanUpConnectionData(logger, loginMetric, connectionId, false, null, null);
+    }
+
+    public void cleanUpConnectionData(Logger logger, LoginMetric loginMetric,
+            String connectionId, boolean isInternal,
+            Failure reason, Exception exception) {
+        Context timeTotal = loginMetric.getRemoveConnection().time();
+        try {
+            securityContext.callWithLock(LockType.CONNECTION_ID, connectionId, () -> {
+                SessionContext sessionContext = securityContext.getSessionContext(connectionId);
+                //if null probably stealing link occurred and the disconnect stuff are done on connection
+                //or during the force disconnections
+                if (sessionContext != null) {
+                    securityContext.updateConnectionTokenOnDisconnection(connectionId);
+                    logErrorMessage(logger, connectionId, exception, reason);
+                    SessionContext sessionContextByClient = securityContext.cleanSessionContext(sessionContext);
+                    if (!isInternal) {
+                        AuthRequest authRequest = new AuthRequest(
+                                clusterName,
+                                brokerIdentity.getBrokerHost(),
+                                SecurityAction.brokerDisconnect.name(), sessionContext);
+                        securityContext.updateStealingLinkAndIllegalState(authRequest, connectionId, sessionContextByClient != null ? sessionContextByClient.getConnectionId() : null);
+                        authServiceClient.brokerDisconnect(authRequest);
+                    }
+                    else {
+                        logger.info("Closing internal connection {} - nothing else to do", connectionId);
+                    }
+                } else {
+                    logger.debug("Cannot find any session context for connection id: {}", connectionId);
+                    loginMetric.getCleanupNullSessionFailure().inc();
+                }
+                return (Void)null;
+            });
+        } catch (Exception e) {
+            loginMetric.getCleanupGenericFailure().inc();
+            logger.error("Cleanup connection data error: {}", e.getMessage(), e);
+        } finally {
+            timeTotal.stop();
+        }
+    }
+
+    private void logErrorMessage(Logger logger, String connectionId, Exception exception, Failure reason) {
+        if (exception != null) {
+            String message = "";
+            if (StringUtils.isEmpty(exception.getMessage())) {
+                message = exception.getCause() != null ? exception.getCause().getMessage() : null;
+            }
+            else {
+                message = exception.getMessage();
+            }
+            //try to find something meaningful to log (otherwise skip it!)
+            if (!StringUtils.isEmpty(message)) {
+                logger.info("### cleanUpConnectionData connection: {} - reason: {} - Error: {}", connectionId, reason, message);
+            }
+            else {
+                logger.debug("### cleanUpConnectionData connection: {} - reason: {} - Error: {}", connectionId, reason, message);
+            }
+            logger.debug("### cleanUpConnectionData error", exception);
+        }
+    }
+
 }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -14,7 +14,6 @@ package org.eclipse.kapua.broker.artemis.plugin.security;
 
 import com.codahale.metrics.Timer.Context;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
@@ -26,8 +25,8 @@ import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.utils.critical.CriticalComponent;
 import org.apache.commons.lang3.SerializationUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.broker.artemis.plugin.security.RunWithLock.LockType;
 import org.eclipse.kapua.broker.artemis.plugin.security.connector.AcceptorHandler;
 import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEvent;
 import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEvent.EventType;
@@ -37,10 +36,6 @@ import org.eclipse.kapua.broker.artemis.plugin.security.metric.PublishMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.SubscribeMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSetting;
 import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSettingKey;
-import org.eclipse.kapua.client.security.AuthErrorCodes;
-import org.eclipse.kapua.client.security.KapuaIllegalDeviceStateException;
-import org.eclipse.kapua.client.security.ServiceClient.SecurityAction;
-import org.eclipse.kapua.client.security.bean.AuthRequest;
 import org.eclipse.kapua.client.security.context.SessionContext;
 import org.eclipse.kapua.client.security.context.Utils;
 import org.eclipse.kapua.commons.core.ServiceModuleBundle;
@@ -52,8 +47,6 @@ import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationErrorCodes;
-import org.eclipse.kapua.service.authentication.exception.KapuaAuthenticationException;
 import org.eclipse.kapua.service.client.message.MessageConstants;
 import org.eclipse.kapua.service.device.connection.listener.DeviceConnectionEventListenerService;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
@@ -172,6 +165,7 @@ public class ServerPlugin implements ActiveMQServerPlugin {
     public void afterCreateConnection(RemotingConnection connection) throws ActiveMQException {
         connection.addCloseListener(() -> {
             try {
+                logger.info("$$$$$$$$$$ calling CLOSE for connection id: {}", connection.getID());
                 cleanUpConnectionData(connection, Failure.CLOSED);
             } catch (Exception e) {
                 //shouldn't happen so log it and throw runtime?
@@ -183,12 +177,20 @@ public class ServerPlugin implements ActiveMQServerPlugin {
 
             @Override
             public void connectionFailed(ActiveMQException exception, boolean failedOver, String scaleDownTargetNodeID) {
-                cleanUpConnectionData(connection, Failure.FAILED, exception);
+                logger.info("$$$$$$$$$$ calling FAIL for connection id: {}", connection.getID());
+                serverContext.cleanUpConnectionData(
+                        logger, loginMetric,
+                        pluginUtility.getConnectionId(connection), pluginUtility.isInternal(connection),
+                        Failure.FAILED, exception);
             }
 
             @Override
             public void connectionFailed(ActiveMQException exception, boolean failedOver) {
-                cleanUpConnectionData(connection, Failure.FAILED, exception);
+                logger.info("$$$$$$$$$$ calling FAIL for connection id: {}", connection.getID());
+                serverContext.cleanUpConnectionData(
+                        logger, loginMetric,
+                        pluginUtility.getConnectionId(connection), pluginUtility.isInternal(connection),
+                        Failure.FAILED, exception);
             }
         });
         ActiveMQServerPlugin.super.afterCreateConnection(connection);
@@ -231,7 +233,6 @@ public class ServerPlugin implements ActiveMQServerPlugin {
     public void beforeSend(ServerSession session, Transaction tx, Message message, boolean direct,
                            boolean noAutoCreateQueue) throws ActiveMQException {
         Context sendContext = publishMetric.getTime().time();
-        logger.info("======> {}", message.getAddress());
         try {
             String address = message.getAddress();
             int messageSize = message.getEncodeSize();
@@ -243,30 +244,36 @@ public class ServerPlugin implements ActiveMQServerPlugin {
                 //anyway this exception shouldn't occur
                 throw new ActiveMQSecurityException("Operation not allowed");
             }
-            logger.debug("Publishing message on address {} from clientId: {} - clientIp: {}", address, sessionContext.getClientId(), sessionContext.getClientIp());
-            if (!sessionContext.isInternal()) {
-                if (isLwt(address)) {
-                    //handle the missing message case
-                    logger.info("Detected missing message for client {}... Flag session to tell disconnector to avoid disconnect event sending", sessionContext.getClientId());
-                    sessionContext.setMissing(true);
+            if (sessionContext!=null) {
+                logger.debug("Publishing message on address {} from clientId: {} - clientIp: {}", address, sessionContext.getClientId(), sessionContext.getClientIp());
+                if (!sessionContext.isInternal()) {
+                    if (isLwt(address)) {
+                        //handle the missing message case
+                        logger.info("Detected missing message for client {}... Flag session to tell disconnector to avoid disconnect event sending", sessionContext.getClientId());
+                        sessionContext.setMissing(true);
+                    }
+                    if (publishInfoMessageSizeLimit < messageSize) {
+                        logger.info("Published message size over threshold. size: {} - destination: {} - account id: {} - username: {} - clientId: {}",
+                                messageSize, address, sessionContext.getAccountName(), sessionContext.getUsername(), sessionContext.getClientId());
+                    }
+                    fillAdditionalMessagePropertiesExternal(message, sessionContext, address);
+                    publishMetric.getMessageSizeAllowed().update(messageSize);
+                } else {
+                    if (publishInfoMessageSizeLimit < messageSize) {
+                        logger.info("Published message size over threshold. size: {} - destination: {}",
+                                messageSize, address);
+                    }
+                    fillAdditionalMessagePropertiesInternal(message, sessionContext, address);
+                    publishMetric.getMessageSizeAllowedInternal().update(messageSize);
                 }
-                if (publishInfoMessageSizeLimit < messageSize) {
-                    logger.info("Published message size over threshold. size: {} - destination: {} - account id: {} - username: {} - clientId: {}",
-                            messageSize, address, sessionContext.getAccountName(), sessionContext.getUsername(), sessionContext.getClientId());
-                }
-                fillAdditionalMessagePropertiesExternal(message, sessionContext, address);
-                publishMetric.getMessageSizeAllowed().update(messageSize);
-            } else {
-                if (publishInfoMessageSizeLimit < messageSize) {
-                    logger.info("Published message size over threshold. size: {} - destination: {}",
-                            messageSize, address);
-                }
-                fillAdditionalMessagePropertiesInternal(message, sessionContext, address);
-                publishMetric.getMessageSizeAllowedInternal().update(messageSize);
+                serverContext.getAddressAccessTracker().update(address);
+                logger.debug("Published message on address {} from clientId: {} - clientIp: {}", address, sessionContext.getClientId(), sessionContext.getClientIp());
+                ActiveMQServerPlugin.super.beforeSend(session, tx, message, direct, noAutoCreateQueue);
             }
-            serverContext.getAddressAccessTracker().update(address);
-            logger.debug("Published message on address {} from clientId: {} - clientIp: {}", address, sessionContext.getClientId(), sessionContext.getClientIp());
-            ActiveMQServerPlugin.super.beforeSend(session, tx, message, direct, noAutoCreateQueue);
+            else {
+                logger.warn("### session context null for remoting connection {} and connection id {}", session.getRemotingConnection(), pluginUtility.getConnectionId(session.getRemotingConnection()));
+                throw new ActiveMQSecurityException("Operation not allowed");
+            }
         }
         finally {
             sendContext.stop();
@@ -340,8 +347,7 @@ public class ServerPlugin implements ActiveMQServerPlugin {
             String connectionFullClientId = Utils.getFullClientId(sessionContext);
             if (fullClientId.equals(connectionFullClientId)) {
                 logger.info("\tclientId to check: {} - full client id: {}... CLOSE", clientIdToCheck, connectionFullClientId);
-                remotingConnection.disconnect(false);
-                remotingConnection.destroy();
+                serverContext.closeConnection(logger, loginMetric, remotingConnection, sessionContext.getConnectionId());
                 return 1;
             } else {
                 logger.info("\tclientId to check: {} - full client id: {}... no action", clientIdToCheck, connectionFullClientId);
@@ -356,12 +362,11 @@ public class ServerPlugin implements ActiveMQServerPlugin {
             int removed = 0;
             String connectionIdTmp = pluginUtility.getConnectionId(remotingConnection);
             if (connectionId.equals(connectionIdTmp)) {
-                logger.info("\tconnection: {} - compared to: {} ... CLOSE", connectionId, connectionIdTmp);
-                remotingConnection.disconnect(false);
-                remotingConnection.destroy();
+                logger.debug("\tconnectionId: {} - compared to: {} ... CLOSE", connectionId, connectionIdTmp);
+                serverContext.closeConnection(logger, loginMetric, remotingConnection, connectionId);
                 removed++;
             } else {
-                logger.info("\tclientId to check: {} - compared to: {} ... no action", connectionId, connectionIdTmp);
+                logger.debug("\tconnectionId to check: {} - compared to: {} ... no action", connectionId, connectionIdTmp);
             }
             return removed;
         }).mapToInt(Integer::new).sum();
@@ -412,94 +417,21 @@ public class ServerPlugin implements ActiveMQServerPlugin {
     }
 
     private void cleanUpConnectionData(RemotingConnection connection, Failure reason) throws Exception {
-        SessionContext sessioncontext = serverContext.getSecurityContext().getSessionContextWithCacheFallback(
-                pluginUtility.getConnectionId(connection));
+        String connectionId = pluginUtility.getConnectionId(connection);
+        SessionContext sessioncontext = serverContext.getSecurityContext().getSessionContextWithCacheFallback(connectionId);
         String clientId = sessioncontext!=null ? Utils.getFullClientId(sessioncontext) : null;
         if (clientId == null) {
-            cleanUpConnectionData(connection, reason, null);
+            serverContext.cleanUpConnectionData(
+                    logger, loginMetric, connectionId, pluginUtility.isInternal(connection), reason, null);
         }
         else {
-            serverContext.getSecurityContext().callWithLock(clientId,
+            serverContext.getSecurityContext().callWithLock(LockType.CLIENT_ID, clientId,
                 () -> {
-                    cleanUpConnectionData(connection, reason, null);
+                    serverContext.cleanUpConnectionData(
+                            logger, loginMetric, connectionId, pluginUtility.isInternal(connection), reason, null);
                     return (Void) null;
                 });
         }
     }
 
-    private void cleanUpConnectionData(RemotingConnection connection, Failure reason, Exception exception) {
-        Context timeTotal = loginMetric.getRemoveConnection().time();
-        try {
-            String connectionId = pluginUtility.getConnectionId(connection);
-            serverContext.getSecurityContext().updateConnectionTokenOnDisconnection(connectionId);
-            if (exception != null) {
-                //try to find something meaningful to log (otherwise skip it!)
-                String message = extractErorMessage(exception);
-                if (!StringUtils.isEmpty(message)) {
-                    logger.info("### cleanUpConnectionData connection: {} - reason: {} - Error: {}", connectionId, reason, message);
-                }
-                else {
-                    logger.debug("### cleanUpConnectionData connection: {} - reason: {} - Error: {}", connectionId, reason, message);
-                }
-                logger.debug("### cleanUpConnectionData error", exception);
-            }
-            SessionContext sessionContext = serverContext.getSecurityContext().getSessionContext(connectionId);
-            if (sessionContext != null) {
-                SessionContext sessionContextByClient = serverContext.getSecurityContext().cleanSessionContext(sessionContext);
-                if (!pluginUtility.isInternal(connection)) {
-                    AuthRequest authRequest = new AuthRequest(
-                            serverContext.getClusterName(),
-                            serverContext.getBrokerIdentity().getBrokerHost(),
-                            SecurityAction.brokerDisconnect.name(), sessionContext);
-                    if (exception != null) {
-                        updateError(authRequest, exception);
-                    }
-                    serverContext.getSecurityContext().updateStealingLinkAndIllegalState(authRequest, connectionId, sessionContextByClient != null ? sessionContextByClient.getConnectionId() : null);
-                    serverContext.getAuthServiceClient().brokerDisconnect(authRequest);
-                }
-            } else {
-                logger.debug("Cannot find any session context for connection id: {}", connectionId);
-                loginMetric.getCleanupNullSessionFailure().inc();
-            }
-        } catch (Exception e) {
-            loginMetric.getCleanupGenericFailure().inc();
-            logger.error("Cleanup connection data error: {}", e.getMessage(), e);
-        } finally {
-            timeTotal.stop();
-        }
-    }
-
-    private String extractErorMessage(Exception exception) {
-        if (StringUtils.isEmpty(exception.getMessage())) {
-            return exception.getCause() != null ? exception.getCause().getMessage() : null;
-        }
-        else {
-            return exception.getMessage();
-        }
-    }
-
-    private void updateError(AuthRequest authRequest, Exception exception) {
-        //Exception must be not null!
-        authRequest.setExceptionClass(exception.getClass().getName());
-        String errorCode = KapuaAuthenticationErrorCodes.AUTHENTICATION_ERROR.name();
-        if (exception instanceof ActiveMQException) {
-            ActiveMQException activeMQException = (ActiveMQException) exception;
-            //analyze the exception code
-            ActiveMQExceptionType exceptionType = activeMQException.getType();
-            if (!ActiveMQExceptionType.REMOTE_DISCONNECT.equals(exceptionType)) {
-                errorCode = AuthErrorCodes.UNEXPECTED_STATUS.name();
-            }
-        } else if (exception instanceof KapuaIllegalDeviceStateException) {
-            AuthErrorCodes authErrorCode = (AuthErrorCodes) ((KapuaIllegalDeviceStateException) exception).getCode();
-            if (authErrorCode != null) {
-                errorCode = authErrorCode.name();
-            }
-        } else if (exception instanceof KapuaAuthenticationException) {
-            KapuaAuthenticationErrorCodes authErrorCode = (KapuaAuthenticationErrorCodes) ((KapuaAuthenticationException) exception).getCode();
-            if (authErrorCode != null) {
-                errorCode = authErrorCode.name();
-            }
-        }
-        authRequest.setErrorCode(errorCode);
-    }
 }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -165,7 +165,6 @@ public class ServerPlugin implements ActiveMQServerPlugin {
     public void afterCreateConnection(RemotingConnection connection) throws ActiveMQException {
         connection.addCloseListener(() -> {
             try {
-                logger.info("$$$$$$$$$$ calling CLOSE for connection id: {}", connection.getID());
                 cleanUpConnectionData(connection, Failure.CLOSED);
             } catch (Exception e) {
                 //shouldn't happen so log it and throw runtime?
@@ -177,7 +176,6 @@ public class ServerPlugin implements ActiveMQServerPlugin {
 
             @Override
             public void connectionFailed(ActiveMQException exception, boolean failedOver, String scaleDownTargetNodeID) {
-                logger.info("$$$$$$$$$$ calling FAIL for connection id: {}", connection.getID());
                 serverContext.cleanUpConnectionData(
                         logger, loginMetric,
                         pluginUtility.getConnectionId(connection), pluginUtility.isInternal(connection),
@@ -186,7 +184,6 @@ public class ServerPlugin implements ActiveMQServerPlugin {
 
             @Override
             public void connectionFailed(ActiveMQException exception, boolean failedOver) {
-                logger.info("$$$$$$$$$$ calling FAIL for connection id: {}", connection.getID());
                 serverContext.cleanUpConnectionData(
                         logger, loginMetric,
                         pluginUtility.getConnectionId(connection), pluginUtility.isInternal(connection),

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/context/Acl.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/context/Acl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,14 +33,12 @@ public class Acl {
     private static final char ANY_WORDS = '#';
     private static final char SEPARATOR = '/';
 
-    private final LoginMetric loginMetric;
     private final WildcardConfiguration wildcardConfiguration;
     private final HierarchicalRepository<KapuaPrincipal> read;
     private final HierarchicalRepository<KapuaPrincipal> write;
     private final HierarchicalRepository<KapuaPrincipal> admin;
 
     public Acl(LoginMetric loginMetric, KapuaPrincipal principal, List<AuthAcl> authAcls) throws KapuaIllegalArgumentException {
-        this.loginMetric = loginMetric;
         wildcardConfiguration = new WildcardConfiguration();
         wildcardConfiguration.setSingleWord(SINGLE_WORD);
         wildcardConfiguration.setAnyWords(ANY_WORDS);

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/context/SecurityContext.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/context/SecurityContext.java
@@ -148,7 +148,7 @@ public final class SecurityContext {
     public boolean setSessionContext(SessionContext sessionContext, List<AuthAcl> authAcls) throws Exception {
         logger.debug("Updating session context for connection id: {}", sessionContext.getConnectionId());
         String connectionId = sessionContext.getConnectionId();
-        return runWithLock.run(LockType.INTERNAL, connectionId, () -> {
+        return runWithLock.run(LockType.CONNECTION_ID, connectionId, () -> {
             if (updateConnectionTokenOnConnection(connectionId) == null) {
                 logger.debug("Setting session context for connection id: {}", connectionId);
                 activeConnections.add(connectionId);
@@ -164,6 +164,14 @@ public final class SecurityContext {
         });
     }
 
+    /**
+     * Put the new token in cache.<br>
+     * If no previous token where present means no stealing link occurs (probably) and return null.<br>
+     * If a previous token is found it will be returned.
+     *
+     * @param connectionId
+     * @return
+     */
     private ConnectionToken updateConnectionTokenOnConnection(String connectionId) {
         ConnectionToken connectionToken = connectionTokenCache.getAndRemove(connectionId);
         if (connectionToken == null) {
@@ -172,58 +180,55 @@ public final class SecurityContext {
         } else {
             //the disconnect callback is called before the connect so nothing to add to the context
             loginMetric.getDisconnectCallbackCallFailure().inc();
-            logger.warn("Connect callback called before the disconnection callback ({} - {} - {})", connectionId, connectionToken.getAction(), connectionToken.getActionDate());
+            logger.debug("Connect callback called before the disconnection callback ({} - {} - {})",
+                    connectionId, connectionToken.getAction(), connectionToken.getActionDate());
         }
         return connectionToken;
     }
 
     public void updateConnectionTokenOnDisconnection(String connectionId) throws Exception {
-        runWithLock.run(LockType.INTERNAL, connectionId, () -> {
-            if (connectionTokenCache.getAndRemove(connectionId) == null) {
-                //put the connection token
-                connectionTokenCache.put(connectionId,
-                        new ConnectionToken(SecurityAction.brokerDisconnect, KapuaDateUtils.getKapuaSysDate()));
-            }
-            return (Void) null;
-        });
+        if (connectionTokenCache.getAndRemove(connectionId) == null) {
+            //put the connection token
+            connectionTokenCache.put(connectionId,
+                new ConnectionToken(SecurityAction.brokerDisconnect, KapuaDateUtils.getKapuaSysDate()));
+        }
     }
 
     public SessionContext cleanSessionContext(SessionContext sessionContext) throws Exception {
-        logger.debug("Updating session context for connection id: {}", sessionContext.getConnectionId());
         String connectionId = sessionContext.getConnectionId();
-        return runWithLock.run(LockType.INTERNAL, connectionId, () -> {
-            logger.info("Cleaning session context for connection id: {}", connectionId);
-            //cleaning context and filling cache
-            SessionContext sessionContextOld = sessionContextMap.remove(connectionId);
-            if (sessionContextOld != null) {
-                sessionContextCache.put(connectionId, sessionContextOld);
-            }
-            Acl aclOld = aclMap.remove(connectionId);
-            if (aclOld != null) {
-                aclCache.put(connectionId, aclOld);
-            }
-            activeConnections.remove(connectionId);
+        logger.debug("Updating session context for connection id: {}", connectionId);
+        logger.info("Before cleanSessionContext ({}) {}", connectionId, this);
+        logger.info("Cleaning session context for connection id: {}", connectionId);
+        //cleaning context and filling cache
+        SessionContext sessionContextOld = sessionContextMap.remove(connectionId);
+        if (sessionContextOld != null) {
+            sessionContextCache.put(connectionId, sessionContextOld);
+        }
+        Acl aclOld = aclMap.remove(connectionId);
+        if (aclOld != null) {
+            aclCache.put(connectionId, aclOld);
+        }
+        activeConnections.remove(connectionId);
 
-            String fullClientId = Utils.getFullClientId(sessionContext);
-            SessionContext currentSessionContext = sessionContextMapByClient.get(fullClientId);
-            //if no stealing link remove the context by client id
-            //on a stealing link currentSessionContext could be null if the disconnect of the latest connected client happens before the others
-            if (currentSessionContext == null) {
-                logger.warn("Cannot find session context by full client id: {}", fullClientId);
-                loginMetric.getSessionContextByClientIdFailure().inc();
+        String fullClientId = Utils.getFullClientId(sessionContext);
+        SessionContext currentSessionContext = sessionContextMapByClient.get(fullClientId);
+        //if no stealing link remove the context by client id
+        //on a stealing link currentSessionContext could be null if the disconnect of the latest connected client happens before the others
+        if (currentSessionContext == null) {
+            logger.warn("Cannot find session context by full client id: {}", fullClientId);
+            loginMetric.getSessionContextByClientIdFailure().inc();
+        } else {
+            if (connectionId.equals(currentSessionContext.getConnectionId())) {
+                sessionContextMapByClient.remove(fullClientId);
+                logger.debug("Disconnect: NO stealing - remove session context by clientId: {} - connection id: {}",
+                    currentSessionContext.getClientId(), currentSessionContext.getConnectionId());
             } else {
-                if (connectionId.equals(currentSessionContext.getConnectionId())) {
-                    //redundant assignment
-                    currentSessionContext = sessionContextMapByClient.remove(fullClientId);
-                    logger.debug("Disconnect: NO stealing - remove session context by clientId: {} - connection id: {}",
-                        currentSessionContext.getClientId(), currentSessionContext.getConnectionId());
-                } else {
-                    logger.info("Disconnect: stealing - leave session context by clientId: {} - connection id: {} (old connection id: {})",
-                        currentSessionContext.getClientId(), currentSessionContext.getConnectionId(), sessionContext.getConnectionId());
-                }
+                logger.info("Disconnect: stealing - leave session context by clientId: {} - connection id: {} (old connection id: {})",
+                    currentSessionContext.getClientId(), currentSessionContext.getConnectionId(), connectionId);
             }
-            return currentSessionContext;
-        });
+        }
+        logger.info("After cleanSessionContext ({}) {}", connectionId, this);
+        return currentSessionContext;
     }
 
     public SessionContext getSessionContextByClientId(String fullClientId) {
@@ -231,7 +236,7 @@ public final class SecurityContext {
     }
 
     public SessionContext getSessionContextWithCacheFallback(String connectionId) throws Exception {
-        return runWithLock.run(LockType.INTERNAL, connectionId, () -> {
+        return runWithLock.run(LockType.CONNECTION_ID, connectionId, () -> {
             SessionContext sessionContext = sessionContextMap.get(connectionId);
             if (sessionContext == null) {
                 sessionContext = sessionContextCache.get(connectionId);
@@ -240,8 +245,8 @@ public final class SecurityContext {
         });
     }
 
-    public <T> T callWithLock(String key, Callable<T> callable) throws Exception {
-        return runWithLock.run(LockType.EXTERNAL, key, callable);
+    public <T> T callWithLock(LockType lockType, String key, Callable<T> callable) throws Exception {
+        return runWithLock.run(lockType, key, callable);
     }
 
     public SessionContext getSessionContext(String connectionId) {
@@ -291,9 +296,11 @@ public final class SecurityContext {
         return subject;
     }
 
-    public void updateStealingLinkAndIllegalState(AuthRequest authRequest, String connectionId, String oldConnectionId) {
-        authRequest.setStealingLink(isStealingLink(connectionId, oldConnectionId));
+    public boolean updateStealingLinkAndIllegalState(AuthRequest authRequest, String connectionId, String oldConnectionId) {
+        boolean isStealingLink = isStealingLink(connectionId, oldConnectionId);
+        authRequest.setStealingLink(isStealingLink);
         authRequest.setIllegalState(isIllegalState(authRequest));
+        return isStealingLink;
     }
 
     private boolean isStealingLink(String connectionId, String oldConnectionId) {

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/context/SecurityContext.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/context/SecurityContext.java
@@ -197,8 +197,6 @@ public final class SecurityContext {
     public SessionContext cleanSessionContext(SessionContext sessionContext) throws Exception {
         String connectionId = sessionContext.getConnectionId();
         logger.debug("Updating session context for connection id: {}", connectionId);
-        logger.info("Before cleanSessionContext ({}) {}", connectionId, this);
-        logger.info("Cleaning session context for connection id: {}", connectionId);
         //cleaning context and filling cache
         SessionContext sessionContextOld = sessionContextMap.remove(connectionId);
         if (sessionContextOld != null) {
@@ -215,8 +213,8 @@ public final class SecurityContext {
         //if no stealing link remove the context by client id
         //on a stealing link currentSessionContext could be null if the disconnect of the latest connected client happens before the others
         if (currentSessionContext == null) {
-            logger.warn("Cannot find session context by full client id: {}", fullClientId);
-            loginMetric.getSessionContextByClientIdFailure().inc();
+            logger.debug("Cannot find session context by full client id: {}", fullClientId);
+            loginMetric.getSessionContextByClientIdNotFound().inc();
         } else {
             if (connectionId.equals(currentSessionContext.getConnectionId())) {
                 sessionContextMapByClient.remove(fullClientId);
@@ -227,7 +225,6 @@ public final class SecurityContext {
                     currentSessionContext.getClientId(), currentSessionContext.getConnectionId(), connectionId);
             }
         }
-        logger.info("After cleanSessionContext ({}) {}", connectionId, this);
         return currentSessionContext;
     }
 

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/metric/LoginMetric.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/metric/LoginMetric.java
@@ -37,7 +37,7 @@ public class LoginMetric {
     private static final String CLOSED_CONNECTION = "closed_connection";
     private static final String DUPLICATE_SESSION_METADATA = "duplicate_session_metadata";
     private static final String DISCONNECT_CALLBACK_CALL = "disconnect_callback_call";
-    private static final String SESSION_CONTEXT_BY_CLIENT_ID = "session_context_by_client_id";
+    private static final String SESSION_CONTEXT_BY_CLIENT_ID = "session_context_by_client_id_not_found";
     private static final String ACL_CACHE_HIT = "acl_cache_hit";
     private static final String ACL_CREATION = "acl_creation";
     private static final String DISCONNECT_BY_EVENT = DISCONNECT + "_by_event";
@@ -52,7 +52,7 @@ public class LoginMetric {
     private final Counter loginClosedConnectionFailure;
     private final Counter duplicateSessionMetadataFailure;
     private final Counter disconnectCallbackCallFailure;//disconnect callback called before the connect callback (usually when a stealing link happens)
-    private final Counter sessionContextByClientIdFailure;//no session context is found by client id on disconnect on cleanupConnectionData (disconnect)
+    private final Counter sessionContextByClientIdNotFound;//no session context is found by client id on disconnect on cleanupConnectionData (disconnect)
     private final Counter aclCacheHit;//acl found from cache (it happens when a client id disconnected but some address related to this client id deleted after)
     private final Counter aclCreationFailure;//error while creating acl
 
@@ -75,7 +75,7 @@ public class LoginMetric {
         loginClosedConnectionFailure = metricsService.getCounter(metricModuleName, COMPONENT_LOGIN, CLOSED_CONNECTION, MetricsLabel.FAILURE);
         duplicateSessionMetadataFailure = metricsService.getCounter(metricModuleName, COMPONENT_LOGIN, DUPLICATE_SESSION_METADATA, MetricsLabel.FAILURE);
         disconnectCallbackCallFailure = metricsService.getCounter(metricModuleName, COMPONENT_LOGIN, DISCONNECT_CALLBACK_CALL, MetricsLabel.FAILURE);
-        sessionContextByClientIdFailure = metricsService.getCounter(metricModuleName, COMPONENT_LOGIN, SESSION_CONTEXT_BY_CLIENT_ID, MetricsLabel.FAILURE);
+        sessionContextByClientIdNotFound = metricsService.getCounter(metricModuleName, COMPONENT_LOGIN, SESSION_CONTEXT_BY_CLIENT_ID);
         aclCacheHit = metricsService.getCounter(metricModuleName, COMPONENT_LOGIN, ACL_CACHE_HIT);
         aclCreationFailure = metricsService.getCounter(metricModuleName, COMPONENT_LOGIN, ACL_CREATION, MetricsLabel.FAILURE);
 
@@ -138,8 +138,8 @@ public class LoginMetric {
      *
      * @return
      */
-    public Counter getSessionContextByClientIdFailure() {
-        return sessionContextByClientIdFailure;
+    public Counter getSessionContextByClientIdNotFound() {
+        return sessionContextByClientIdNotFound;
     }
 
     /**

--- a/broker/artemis/plugin/src/main/resources/kapua-broker-setting.properties
+++ b/broker/artemis/plugin/src/main/resources/kapua-broker-setting.properties
@@ -12,9 +12,9 @@ broker.acceptor.mqttInternal=tcp://0.0.0.0:1893?tcpSendBufferSize=1048576;tcpRec
 broker.acceptor.amqp=tcp://0.0.0.0:5672?allowLinkStealing=true;tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpMinLargeMessageSize=102400;amqpDuplicateDetection=true
 broker.security.published.message_size.log_threshold=100000
 #cache size and ttl (in seconds)
-broker.cache.connection_token.size=1000
-broker.cache.connection_token.ttl=20
-broker.cache.session_context.size=1000
-broker.cache.session_context.ttl=20
+broker.cache.connection_token.size=5000
+broker.cache.connection_token.ttl=30
+broker.cache.session_context.size=5000
+broker.cache.session_context.ttl=30
 broker.cache.scope_id.size=100
 broker.cache.scope_id.ttl=60

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
@@ -159,4 +159,8 @@ public class LocalCache<K, V> implements Cache<K, V> {
     public boolean containsKey(K k) {
         return cache.asMap().containsKey(k);
     }
+
+    public long getSize() {
+        return cache.size();
+    }
 }


### PR DESCRIPTION
Brief description of the PR.
enhances the connection context objects lifecycle and the login/logout synchronization mechanism

**Related Issue**
none

**Description of the solution adopted**
Artemis broker, under high load, serves primarly the new connection requests than the close connection requests (close connection callbacks to be called).
So, if some device behaves badly, and no rate limiter is placed in front of the broker, this could lead to a high number of connections established but not necessarly active. We have few objects to keep connection context info in different hash maps and, these objects, are removed once the close clonnection callback is called. If there are a lot of connections no more active and, the close connection is not been called yet, we have a lot of object no more needed. So, in few words, wasted memory that couldn't be freed up until the broker calls the close connections callback.
This pr enhances the way we handle the connection context objects lifecycle.
In case of a stealing link the old context objects are removed during the new login operations.
The whole login and logout process are encapsulated into a "synchronize by clientId" execution block. If the clientId is not availble, the synchonization is done by connectionId.
In this way the login/logout process for the same clientId/connectionId are executed once a time and not in parallel.
Synchronizations are performed only within clientId or connectionId so doesn't affect the other clients/connections

**Screenshots**
none

**Any side note on the changes made**
none
