### PR TITLE
:arrow_up: [Dependencies] Bumped version of Apache commons-fileuploadto 1.6.0 - CVE-2025-48976

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-configuration2.version>2.10.1</commons-configuration2.version>
         <commons-compress.version>1.27.1</commons-compress.version>
-        <commons-fileupload.versison>1.5</commons-fileupload.versison>
+        <commons-fileupload.versison>1.6.0</commons-fileupload.versison>
         <commons-imaging.version>1.0-alpha3</commons-imaging.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>3.4</commons-lang.version>


### PR DESCRIPTION
This PR bumps the version of Apache `commons-fileupload` from `1.5` to `1.6.0` to address component CVE

- CVE-2025-48976

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the dependency version

**Screenshots**
_None_

**Any side note on the changes made**
_None_