### PR TITLE
:arrow_up: [Dependencies] Bumped version of org.xerial.snappy:snappy-java.version to 1.1.10.8 - CVE-2023-34453 CVE-2023-34454 CVE-2023-34455 CVE-2023-43642

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <spring.version>4.3.30.RELEASE</spring.version>
         <spring-security.version>4.2.20.RELEASE</spring-security.version>
         <swagger-ui.version>4.19.1</swagger-ui.version>
+        <xerial.snappy-java.version>1.1.10.8</xerial.snappy-java.version>
         <zxing.version>3.4.1</zxing.version>
 
         <!-- Plugins versions -->
@@ -1607,6 +1608,11 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${xerial.snappy-java.version}</version>
             </dependency>
             <dependency>
                 <!-- Apache shiro security framework -->


### PR DESCRIPTION
This PR bumps version of `org.xerial.snappy:snappy-java.version` to 1.1.10.8 solving component CVEs:

- CVE-2023-34453 
- CVE-2023-34454 
- CVE-2023-34455 
- CVE-2023-43642

**Related Issue**
_None_

**Description of the solution adopted**
Added explicit declaration of `org.xerial.snappy:snappy-java.version` and set fixed version to `1.1.10.8`

**Screenshots**
_None_

**Any side note on the changes made**
_None_