### PR TITLE
🐛 [Device Management] MQTT connection to message-broker not working on device management

### DIFF
--- a/assembly/broker-artemis/docker/Dockerfile
+++ b/assembly/broker-artemis/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM @docker.account@/java-base
 
 COPY maven /
 
-ENV BROKER_HOST=message-broker
+ENV BROKER_HOST=${BROKER_HOST:-message-broker}
 ENV BROKER_ID=broker-id
 
 ENV DATASTORE_ADDR es:9200
@@ -41,13 +41,13 @@ RUN useradd -u 1002 -g 0 -d '/opt/artemis' -s '/sbin/nologin' artemis && \
 ENV JAVA_ARGS "-Dcommons.db.schema.update=true \
                    -Dcommons.db.connection.host=\${SQL_DB_ADDR} \
                    -Dcommons.db.connection.port=\${SQL_DB_PORT} \
+                   -Dbroker.host=\${BROKER_HOST} \
                    -Dcommons.eventbus.url="${EVENT_BROKER_URL}" \
                    -Dcommons.eventbus.username="${EVENT_BROKER_USERNAME}" \
                    -Dcommons.eventbus.password="${EVENT_BROKER_PASSWORD}" \
                    -Dcommons.servicebus.url="${SERVICE_BROKER_URL}" \
                    -Dcommons.servicebus.username="${SERVICE_BROKER_USERNAME}" \
                    -Dcommons.servicebus.password="${SERVICE_BROKER_PASSWORD}" \
-                   -Dbroker.ip=message-broker \
                    -Dlocator.class.impl=org.eclipse.kapua.locator.guice.GuiceLocatorImpl \
                    -Dlocator.guice.stage=PRODUCTION \
                    -Dcertificate.jwt.private.key=file:///etc/opt/kapua/key.pk8 \

--- a/docs/developer-guide/en/qa.md
+++ b/docs/developer-guide/en/qa.md
@@ -185,7 +185,6 @@ One example of these file is shown bellow:
                  },
         strict = true,
         monochrome = true)
-@CucumberProperty(key="broker.ip", value="localhost")
 @CucumberProperty(key="kapua.config.url", value="")
 @CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
 @CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="5")


### PR DESCRIPTION
Currently, device management is not working on a local ESF connected to kapua. The error shown is:

<img width="298" height="306" alt="image" src="https://github.com/user-attachments/assets/50ae400c-fd27-4017-b53e-1d2bb75d7935" />

After some investigation I found the problem is in the address assigned to the broker, where the console tries to connect to via MQTT: “localhost” should be, instead, the name of the message-broker container (message-broker).
It’s strange that QA did not spot this problem. This is probably because dev. management tests use a local MQTT client, where “localhost:1883/1893” is correctly resolved as the broker address

**Description of the solution adopted**
Probably the "docker-file" of the message-broker was still using an old way to resolve broker address: using the "broker.ip" system variable. Replacing it with the correct "broker.host", aligning it with other containers like telemetry consumer, solved the issue
