### PR TITLE
✨ [Device Management] - API to upload a JSON snapshot fragment returns 204 if the fragment is not in Kapua snapshot format

### DIFF
--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -242,7 +242,8 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
         // Argument Validation
         ArgumentValidator.notNull(scopeId, SCOPE_ID);
         ArgumentValidator.notNull(deviceId, DEVICE_ID);
-        ArgumentValidator.notNull(deviceConfiguration, "componentConfiguration");
+        ArgumentValidator.notNull(deviceConfiguration, "deviceConfiguration");
+        ArgumentValidator.notEmptyOrNull(deviceConfiguration.getComponentConfigurations(), "deviceConfiguration.configuration");
         // Check Access
         authorizationService.checkPermission(permissionFactory.newPermission(Domains.DEVICE_MANAGEMENT, Actions.write, scopeId));
         // Prepare the request


### PR DESCRIPTION
before this PR, you had this bug:

1. Connect an ESF device to EC

2. Download a JSON snapshot from the connected device directly from the Web UI of ESF (see attachment)

3. Upload such snapshot to ESF using the rest-API 

4. The rest-api returns 204


Expected Result 

The error should be 400 - Bad request


Here I fixed the issue adding a check for the presence of at least 1 component configuration inside the deviceConfiguration passed via rest-api