### PR TITLE
:arrow_up: [Dependencies] Bumped version of io.netty to 4.1.124 - CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <logback.version>1.5.12</logback.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.124.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <ow2-asm.version>9.4</ow2-asm.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>


### PR DESCRIPTION
This PR bumps the version of `io.netty` dependencies to 4.1.124 to address components CVEs:

- io.netty:netty-codec-http2: CVE-2025-55163 

**Related Issue**
_None_

**Description of the solution adopted**
Updated netty version

**Screenshots**
_None_

**Any side note on the changes made**
_None_