### PR TITLE
:arrow_up: [Dependencies] Bumped version of Jetty to 9.4.58.v20250814 - CVE-2025-5115

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <jaxb-impl.version>2.3.6</jaxb-impl.version>
         <jbatch.version>1.0.2</jbatch.version>
         <jersey.version>2.38</jersey.version>
-        <jetty.version>9.4.57.v20241219</jetty.version>
+        <jetty.version>9.4.58.v20250814</jetty.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.10</jose4j.version>


### PR DESCRIPTION
This PR bumps the version of Jetty dependencies to 9.4.58.v20250814 to address components CVEs:

- org.eclipse.jetty.http2:http2-common: CVE-2025-5115
- org.eclipse.jetty.http2:http2-server: CVE-2025-5115

**Related Issue**
_None_

**Description of the solution adopted**
Updated netty version

**Screenshots**
_None_

**Any side note on the changes made**
_None_