### PR TITLE
🐛 [Docker] FIX: extend Env. variables to support different types of DBMS

### DIFF
--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -16,13 +16,7 @@ FROM @docker.account@/jetty-base
 
 COPY maven /
 
-ENV BROKER_ADDR broker
-ENV BROKER_PORT 1883
-
 ENV DATASTORE_ADDR es:9200
-
-ENV SQL_DB_ADDR db
-ENV SQL_DB_PORT 3306
 
 ENV EVENT_BROKER_URL=${EVENT_BROKER_URL:-amqp://events-broker:5672}
 ENV EVENT_BROKER_USERNAME=${EVENT_BROKER_USERNAME:-kapua-sys}
@@ -58,6 +52,17 @@ ENV JAVA_OPTS "-Dapi.cors.origins.allowed=\${API_CORS_ORIGINS_ALLOWED} \
                -Dauthentication.token.expire.after=\${AUTH_TOKEN_TTL} \
                -Dauthentication.refresh.token.expire.after=\${REFRESH_AUTH_TOKEN_TTL} \
                -Dapi.cors.refresh.interval=\${CORS_ENDPOINTS_REFRESH_INTERVAL} \
+               -Dcommons.db.jdbc.database.target=\${DB_TARGET:-} \
+               -Dcommons.db.connection.host=\${DB_HOST:-db} \
+               -Dcommons.db.name=\${DB_NAME:-kapuadb} \
+               -Dcommons.db.connection.port=\${DB_PORT:-3306} \
+               -Dcommons.db.schema=\${DB_SCHEMA_NAME:-kapuadb} \
+               -Dcommons.db.username=\${DB_USERNAME:-kapua} \
+               -Dcommons.db.password=\${DB_PASSWORD:-kapua} \
+               -Dcommons.db.connection.scheme=\${DB_CONNECTION_SCHEME:-jdbc:h2:tcp} \
+               -Dcommons.db.jdbcConnectionUrlResolver=\${DB_RESOLVER:-DEFAULT} \
+               -Dcommons.db.jdbc.driver=\${DB_DRIVER:-org.h2.Driver} \
+               -Dcommons.db.connection.additionalOptions=\${DB_CONNECTION_ADDITIONAL_OPTIONS} \
                \${JETTY_DEBUG_OPTS} \
                \${JETTY_JMX_OPTS}"
 

--- a/assembly/broker-artemis/entrypoint/run-broker
+++ b/assembly/broker-artemis/entrypoint/run-broker
@@ -44,5 +44,18 @@ echo 'copying libraries...'
 cp /opt/artemis/base-lib/* /opt/artemis/kapua/lib
 echo 'copying libraries... DONE'
 
+#options for DB connection
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.jdbc.database.target=${DB_TARGET:-}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.connection.host=${DB_HOST:-db}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.name=${DB_NAME:-kapuadb}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.connection.port=${DB_PORT:-3306}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.schema=${DB_SCHEMA_NAME:-kapuadb}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.username=${DB_USERNAME:-kapua}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.password=${DB_PASSWORD:-kapua}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.connection.scheme=${DB_CONNECTION_SCHEME:-jdbc:h2:tcp}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DEFAULT}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
+JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
+
 echo 'starting Artemis...'
 /opt/artemis/kapua/bin/artemis run xml:/opt/artemis/kapua/etc/bootstrap.xml

--- a/assembly/console/docker/Dockerfile
+++ b/assembly/console/docker/Dockerfile
@@ -21,16 +21,11 @@ ENV BROKER_PORT 1883
 
 ENV DATASTORE_ADDR es:9200
 
-ENV SQL_DB_ADDR db
-ENV SQL_DB_PORT 3306
-
 ENV SERVICE_BROKER_ADDR amqp://events-broker:5672
 
 ENV JOB_ENGINE_BASE_ADDR http://job-engine:8080/v1
 
 ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
-               -Dcommons.db.connection.host=\${SQL_DB_ADDR} \
-               -Dcommons.db.connection.port=\${SQL_DB_PORT} \
                -Dlocator.guice.stage=PRODUCTION \
                -Dbroker.host=\${BROKER_ADDR} \
                -Ddatastore.elasticsearch.nodes=\${DATASTORE_ADDR} \
@@ -42,6 +37,17 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Djob.engine.client.auth.mode=access_token \
                -Dcipher.key=\${CIPHER_KEY} \
                -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
+               -Dcommons.db.jdbc.database.target=\${DB_TARGET:-} \
+               -Dcommons.db.connection.host=\${DB_HOST:-db} \
+               -Dcommons.db.name=\${DB_NAME:-kapuadb} \
+               -Dcommons.db.connection.port=\${DB_PORT:-3306} \
+               -Dcommons.db.schema=\${DB_SCHEMA_NAME:-kapuadb} \
+               -Dcommons.db.username=\${DB_USERNAME:-kapua} \
+               -Dcommons.db.password=\${DB_PASSWORD:-kapua} \
+               -Dcommons.db.connection.scheme=\${DB_CONNECTION_SCHEME:-jdbc:h2:tcp} \
+               -Dcommons.db.jdbcConnectionUrlResolver=\${DB_RESOLVER:-DEFAULT} \
+               -Dcommons.db.jdbc.driver=\${DB_DRIVER:-org.h2.Driver} \
+               -Dcommons.db.connection.additionalOptions=\${DB_CONNECTION_ADDITIONAL_OPTIONS} \
                \${JETTY_DEBUG_OPTS} \
                \${JETTY_JMX_OPTS}"
 

--- a/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
+++ b/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
@@ -13,4 +13,17 @@
 
 JAVA_OPTS="${JAVA_OPTS} --add-opens java.base/java.lang=ALL-UNNAMED"
 
+#options for DB connection
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.database.target=${DB_TARGET:-}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.host=${DB_HOST:-db}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.name=${DB_NAME:-kapuadb}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.port=${DB_PORT:-3306}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.schema=${DB_SCHEMA_NAME:-kapuadb}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.username=${DB_USERNAME:-kapua}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.password=${DB_PASSWORD:-kapua}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.scheme=${DB_CONNECTION_SCHEME:-jdbc:h2:tcp}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DEFAULT}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
+
 java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-lifecycle-2.1.0-SNAPSHOT-app.jar

--- a/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
+++ b/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
@@ -13,4 +13,17 @@
 
 JAVA_OPTS="${JAVA_OPTS} --add-opens java.base/java.lang=ALL-UNNAMED"
 
+#options for DB connection
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.database.target=${DB_TARGET:-}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.host=${DB_HOST:-db}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.name=${DB_NAME:-kapuadb}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.port=${DB_PORT:-3306}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.schema=${DB_SCHEMA_NAME:-kapuadb}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.username=${DB_USERNAME:-kapua}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.password=${DB_PASSWORD:-kapua}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.scheme=${DB_CONNECTION_SCHEME:-jdbc:h2:tcp}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DEFAULT}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
+
 java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-telemetry-2.1.0-SNAPSHOT-app.jar

--- a/assembly/job-engine/docker/Dockerfile
+++ b/assembly/job-engine/docker/Dockerfile
@@ -21,9 +21,6 @@ ENV BROKER_PORT 1883
 
 ENV DATASTORE_ADDR es:9200
 
-ENV SQL_DB_ADDR db
-ENV SQL_DB_PORT 3306
-
 ENV EVENT_BROKER_URL=${EVENT_BROKER_URL:-amqp://events-broker:5672}
 ENV EVENT_BROKER_USERNAME=${EVENT_BROKER_USERNAME:-kapua-sys}
 ENV EVENT_BROKER_PASSWORD=${EVENT_BROKER_PASSWORD:-kapua-password}
@@ -32,8 +29,17 @@ ENV SERVICE_BROKER_USERNAME=${SERVICE_BROKER_USERNAME:-kapua-sys}
 ENV SERVICE_BROKER_PASSWORD=${SERVICE_BROKER_PASSWORD:-kapua-password}
 
 ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
-               -Dcommons.db.connection.host=\${SQL_DB_ADDR} \
-               -Dcommons.db.connection.port=\${SQL_DB_PORT} \
+               -Dcommons.db.jdbc.database.target=\${DB_TARGET:-} \
+               -Dcommons.db.connection.host=\${DB_HOST:-db} \
+               -Dcommons.db.name=\${DB_NAME:-kapuadb} \
+               -Dcommons.db.connection.port=\${DB_PORT:-3306} \
+               -Dcommons.db.schema=\${DB_SCHEMA_NAME:-kapuadb} \
+               -Dcommons.db.username=\${DB_USERNAME:-kapua} \
+               -Dcommons.db.password=\${DB_PASSWORD:-kapua} \
+               -Dcommons.db.connection.scheme=\${DB_CONNECTION_SCHEME:-jdbc:h2:tcp} \
+               -Dcommons.db.jdbcConnectionUrlResolver=\${DB_RESOLVER:-DEFAULT} \
+               -Dcommons.db.jdbc.driver=\${DB_DRIVER:-org.h2.Driver} \
+               -Dcommons.db.connection.additionalOptions=\${DB_CONNECTION_ADDITIONAL_OPTIONS} \
                -Dlocator.guice.stage=PRODUCTION \
                -Dbroker.host=\${BROKER_ADDR} \
                -Ddatastore.elasticsearch.nodes=\${DATASTORE_ADDR} \

--- a/assembly/service/authentication/entrypoint/run-service-authentication
+++ b/assembly/service/authentication/entrypoint/run-service-authentication
@@ -11,4 +11,17 @@
 #        Eurotech
 ################################################################################
 
+#options for DB connection
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.database.target=${DB_TARGET:-}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.host=${DB_HOST:-db}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.name=${DB_NAME:-kapuadb}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.port=${DB_PORT:-3306}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.schema=${DB_SCHEMA_NAME:-kapuadb}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.username=${DB_USERNAME:-kapua}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.password=${DB_PASSWORD:-kapua}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.scheme=${DB_CONNECTION_SCHEME:-jdbc:h2:tcp}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DEFAULT}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
+JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
+
 java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-service-authentication-2.1.0-SNAPSHOT-app.jar

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -38,6 +38,17 @@ services:
       - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_DATASTORE
       - LOGBACK_LOG_LEVEL
+      - DB_TARGET
+      - DB_HOST
+      - DB_NAME
+      - DB_PORT
+      - DB_SCHEMA_NAME
+      - DB_USERNAME
+      - DB_PASSWORD
+      - DB_CONNECTION_ADDITIONAL_OPTIONS
+      - DB_CONNECTION_SCHEME
+      - DB_RESOLVER
+      - DB_DRIVER
   service-authentication:
     image: kapua/kapua-service-authentication:${IMAGE_VERSION}
     container_name: service-auth
@@ -48,6 +59,17 @@ services:
       - events-broker
     environment:
       - LOGBACK_LOG_LEVEL
+      - DB_TARGET
+      - DB_HOST
+      - DB_NAME
+      - DB_PORT
+      - DB_SCHEMA_NAME
+      - DB_USERNAME
+      - DB_PASSWORD
+      - DB_CONNECTION_ADDITIONAL_OPTIONS
+      - DB_CONNECTION_SCHEME
+      - DB_RESOLVER
+      - DB_DRIVER
   consumer-telemetry:
     container_name: consumer-telemetry
     image: kapua/kapua-consumer-telemetry:${IMAGE_VERSION}
@@ -62,6 +84,17 @@ services:
       - BROKER_URL
       - CRYPTO_SECRET_KEY
       - LOGBACK_LOG_LEVEL
+      - DB_TARGET
+      - DB_HOST
+      - DB_NAME
+      - DB_PORT
+      - DB_SCHEMA_NAME
+      - DB_USERNAME
+      - DB_PASSWORD
+      - DB_CONNECTION_ADDITIONAL_OPTIONS
+      - DB_CONNECTION_SCHEME
+      - DB_RESOLVER
+      - DB_DRIVER
   consumer-lifecycle:
     container_name: consumer-lifecycle
     image: kapua/kapua-consumer-lifecycle:${IMAGE_VERSION}
@@ -75,6 +108,17 @@ services:
       - BROKER_URL
       - CRYPTO_SECRET_KEY
       - LOGBACK_LOG_LEVEL
+      - DB_TARGET
+      - DB_HOST
+      - DB_NAME
+      - DB_PORT
+      - DB_SCHEMA_NAME
+      - DB_USERNAME
+      - DB_PASSWORD
+      - DB_CONNECTION_ADDITIONAL_OPTIONS
+      - DB_CONNECTION_SCHEME
+      - DB_RESOLVER
+      - DB_DRIVER
   kapua-console:
     container_name: kapua-console
     image: kapua/kapua-console:${IMAGE_VERSION}
@@ -89,6 +133,17 @@ services:
       - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_DATASTORE
       - LOGBACK_LOG_LEVEL
+      - DB_TARGET
+      - DB_HOST
+      - DB_NAME
+      - DB_PORT
+      - DB_SCHEMA_NAME
+      - DB_USERNAME
+      - DB_PASSWORD
+      - DB_CONNECTION_ADDITIONAL_OPTIONS
+      - DB_CONNECTION_SCHEME
+      - DB_RESOLVER
+      - DB_DRIVER
   kapua-api:
     container_name: kapua-api
     image: kapua/kapua-api:${IMAGE_VERSION}
@@ -111,6 +166,17 @@ services:
       - CORS_ENDPOINTS_REFRESH_INTERVAL=${CORS_ENDPOINTS_REFRESH_INTERVAL:-60}
       - COMMONS_VERSION
       - COMMONS_BUILD_NUMBER
+      - DB_TARGET
+      - DB_HOST
+      - DB_NAME
+      - DB_PORT
+      - DB_SCHEMA_NAME
+      - DB_USERNAME
+      - DB_PASSWORD
+      - DB_CONNECTION_ADDITIONAL_OPTIONS
+      - DB_CONNECTION_SCHEME
+      - DB_RESOLVER
+      - DB_DRIVER
   job-engine:
     container_name: job-engine
     image: kapua/kapua-job-engine:${IMAGE_VERSION}
@@ -124,3 +190,14 @@ services:
       - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_DATASTORE
       - LOGBACK_LOG_LEVEL
+      - DB_TARGET
+      - DB_HOST
+      - DB_NAME
+      - DB_PORT
+      - DB_SCHEMA_NAME
+      - DB_USERNAME
+      - DB_PASSWORD
+      - DB_CONNECTION_ADDITIONAL_OPTIONS
+      - DB_CONNECTION_SCHEME
+      - DB_RESOLVER
+      - DB_DRIVER


### PR DESCRIPTION
Added env. variables settings to support switching to different types of DBMS other than h2, if needed