### PR TITLE
:bug: [OpenAPI] Fixed GET /dataMessages/ 'metricName', 'metricType', 'metricMin' and 'metricMax' documentation - errata

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId.yaml
@@ -50,22 +50,22 @@ paths:
           schema:
             type: string
             format: 'date-time'
-        - description: The metric name to filter results.
+        - description: The metric name to filter results. If provided, 'metricType' is also required
           name: metricName
           in: query
           schema:
             type: string
-        - description: The metric type to filter results. If filled 'metricName' is required.
+        - description: The metric type to filter results. If provided 'metricName' is required. Metrics of type 'binary' are not supported for this query.
           name: metricType
           in: query
           schema:
             type: string
-        - description: The minimum metric value to filter results. If filled 'metricName' and 'metricType' are required. If filled 'metricType' cannot be 'binary'.
+        - description: The minimum metric value to filter results. If provided 'metricName' and 'metricType' are required.
           name: metricMin
           in: query
           schema:
             type: string
-        - description: The maximum metric value to filter results. If filled 'metricName' and 'metricType' are required. If filled 'metricType' cannot be 'binary'.
+        - description: The maximum metric value to filter results. If provided 'metricName' and 'metricType' are required.
           name: metricMax
           in: query
           schema:


### PR DESCRIPTION
This PR updates the documentation messages for `metricName`, `metricType`, `metricMin` and `metricMax`.

**Related Issue**
This PR is an errata for https://github.com/eclipse-kapua/kapua/pull/4260/files

**Description of the solution adopted**
Fixed documentation for fields. 
Now doc reports the following description

- metricName: The metric name to filter results. If filled, 'metricType' is also required
- metricType: The metric type to filter results. If filled 'metricName' is required. Metrics of type 'binary' are not supported for this query.
- metricMin: The minimum metric value to filter results. If filled 'metricName' and 'metricType' are required.
- metricMax: The maximum metric value to filter results. If filled 'metricName' and 'metricType' are required.


**Screenshots**
_None_

**Any side note on the changes made**
_None_