### PR TITLE
🐛 [Configurations] - Fixed a definition for CredentialService configuration (AD's ID: password.minLength)

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationManagerImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationManagerImpl.java
@@ -486,4 +486,36 @@ public class ServiceConfigurationManagerImpl implements ServiceConfigurationMana
             return Optional.empty();
         });
     }
+
+    /**
+     * Sets custom values (default, min, max) for the given KapuaTad object
+     * Defined for convenience to be used by subclasses
+     * @since 2.0.0
+     */
+    protected void setCustomKapuaTad(KapuaTad tad, String defaultValue, String minValue, String maxValue) {
+        if (defaultValue != null) {
+            tad.setDefault(defaultValue);
+        }
+        if (minValue != null) {
+            tad.setMin(minValue);
+        }
+        if (maxValue != null) {
+            tad.setMax(maxValue);
+        }
+    }
+
+    /**
+     * Extracts from the given KapuaTocd object the KapuaTad with the given 'defaultValue' name, and sets the custom values (default, min, max)
+     * Defined for convenience to be used by subclasses
+     * @since 2.0.0
+     */
+    protected void setCustomDefinition(KapuaTocd definition, String kapuaTadName, String defaultValue, String minValue, String maxValue) {
+        Optional<KapuaTad> definitioToChange =
+                definition.getAD()
+                        .stream()
+                        .filter(a -> a.getName().equals(kapuaTadName))
+                        .findAny();
+        definitioToChange.ifPresent(kapuaTad -> setCustomKapuaTad(kapuaTad, defaultValue, minValue, maxValue));
+    }
+
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialServiceConfigurationManagerImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialServiceConfigurationManagerImpl.java
@@ -55,6 +55,19 @@ public class CredentialServiceConfigurationManagerImpl extends ServiceConfigurat
     }
 
     @Override
+    protected Optional<KapuaTocd> doGetConfigMetadata(TxContext txContext, KapuaId scopeId, boolean excludeDisabled) throws KapuaException {
+        Optional<KapuaTocd> credentialServiceConfigDefinition = super.doGetConfigMetadata(txContext, scopeId, excludeDisabled);
+        credentialServiceConfigDefinition.ifPresent(kapuaTocd -> setCustomDefinition(
+                kapuaTocd,
+                AccountPasswordLengthProviderImpl.PASSWORD_MIN_LENGTH_ACCOUNT_CONFIG_KEY,
+                null,
+                String.valueOf(systemPasswordLengthProvider.getSystemMinimumPasswordLength()),
+                String.valueOf(systemPasswordLengthProvider.getSystemMaximumPasswordLength())
+        ));
+        return credentialServiceConfigDefinition;
+    }
+
+    @Override
     protected boolean validateNewConfigValuesCoherence(TxContext txContext, KapuaTocd ocd, Map<String, Object> updatedProps, KapuaId scopeId, Optional<KapuaId> parentId) throws KapuaException {
         if (updatedProps.get(AccountPasswordLengthProviderImpl.PASSWORD_MIN_LENGTH_ACCOUNT_CONFIG_KEY) != null) {
             // If we're going to set a new limit, check that it's not less than system limit


### PR DESCRIPTION
If we request configurations for PID “org.eclipse.kapua.service.authentication.credential.CredentialService” this is the result we get for the 'provisioned.password.length.default' AD field :

<img width="480" height="347" alt="Screenshot 2025-09-30 at 14 53 53" src="https://github.com/user-attachments/assets/ecc15ddc-2be1-425d-bb08-cd0cb1080da3" />

Notice how the “min” field is not coherent with the system setting we impose in our back-end regarding the minimum length of 12 chars

We should provide a fix to correct the information, in order to correclty inform client the real minimun value for credential length

The present PR address the issue, changing the CredentialServiceConfigurationManagerImpl code to customize such definition property
