### PR TITLE
:bug: [Authorization] Fixed repeated adding of original predicates

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/GroupQueryHelperImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/GroupQueryHelperImpl.java
@@ -137,7 +137,6 @@ public class GroupQueryHelperImpl implements GroupQueryHelper {
 
             if (query.getPredicate() != null) {
                 andPredicate.and(query.getPredicate());
-                andPredicate.and(query.getPredicate());
             }
 
             query.setPredicate(andPredicate);


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/eclipse-kapua/kapua/pull/3726 likely due to incorrect rebase conflicts.

The original predicate was added twice by mistake

**Related Issue**
This PR fixes an issue introduced in #3726

**Description of the solution adopted**
Removed duplicated line

**Screenshots**
_None_

**Any side note on the changes made**
_None_