### PR TITLE
⬆️  [Dependencies] Upgraded Elasticsearch to latest 7.17.x - CVE-2023-31418

### DIFF
--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "3306:3306"
   es:
     container_name: es
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/EsClientWrapper.java
+++ b/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/EsClientWrapper.java
@@ -42,7 +42,7 @@ import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.script.Script;
 import org.slf4j.Logger;

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <!-- Do NOT bump eclipselink further than this version. For details, see issue: https://github.com/eclipse/kapua/issues/3955 -->
         <eclipselink.version>2.7.12</eclipselink.version>
         <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
-        <elasticsearch.version>7.8.1</elasticsearch.version>
+        <elasticsearch.version>7.17.29</elasticsearch.version>
         <googleauth.version>1.5.0</googleauth.version>
         <gson.version>2.10</gson.version>
         <guava.version>32.1.2-jre</guava.version>


### PR DESCRIPTION
Bumped both the client and docker image version to latest 7.17.x