### PR TITLE
:bug: [Authorization] Fixed DomainsAligner not aligning 'groupable' attribute of Domain

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/AbstractDomain.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/AbstractDomain.java
@@ -49,8 +49,8 @@ public abstract class AbstractDomain implements Domain {
     public String toString() {
         return "DomainEntry{" +
                 "name='" + getName() + '\'' +
-                ", groupable=" + getGroupable() +
                 ", actions=" + getActions() +
+                ", groupable=" + getGroupable() +
                 ", serviceName='" + getServiceName() + '\'' +
                 '}';
     }

--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/Domain.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/Domain.java
@@ -56,6 +56,4 @@ public interface Domain {
      */
     @Deprecated
     String getServiceName();
-
-
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/DomainEntry.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/DomainEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2024, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,11 @@ package org.eclipse.kapua.model.domain;
 
 import java.util.EnumSet;
 
+/**
+ * {@link Domain} implementation.
+ *
+ * @since 2.0.0
+ */
 public class DomainEntry extends AbstractDomain implements Domain {
     private final String name;
     private final boolean groupable;
@@ -47,4 +52,13 @@ public class DomainEntry extends AbstractDomain implements Domain {
         return actions;
     }
 
+    @Override
+    public String toString() {
+        return "DomainEntry{" +
+                "name='" + name + '\'' +
+                ", actions=" + actions +
+                ", groupable=" + groupable +
+                ", serviceName='" + serviceName + '\'' +
+                '}';
+    }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -154,7 +154,6 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
             public String getServiceName() {
                 return Domain.this.getServiceName();
             }
-
         };
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
@@ -24,6 +24,7 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import java.util.Objects;
@@ -52,14 +53,14 @@ public class DomainImpl extends AbstractKapuaEntity implements Domain {
     @Column(name = "serviceName", nullable = false, updatable = false)
     private String serviceName;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "athz_domain_actions", joinColumns = @JoinColumn(name = "domain_id", referencedColumnName = "id"))
     @Column(name = "action", nullable = false)
     @Enumerated(EnumType.STRING)
     private Set<Actions> actions;
 
     @Basic
-    @Column(name = "groupable", nullable = false, updatable = false)
+    @Column(name = "groupable", nullable = false, updatable = true)
     private boolean groupable;
 
     /**
@@ -161,5 +162,19 @@ public class DomainImpl extends AbstractKapuaEntity implements Domain {
     @Override
     public int hashCode() {
         return Objects.hash(name, actions, groupable);
+    }
+
+    @Override
+    public String toString() {
+        return "DomainImpl{" +
+                "scopeId=" + scopeId +
+                ", id=" + id +
+                ", name='" + name + '\'' +
+                ", createdOn=" + createdOn +
+                ", createdBy=" + createdBy +
+                ", actions=" + actions +
+                ", groupable=" + groupable +
+                ", serviceName='" + serviceName + '\'' +
+                '}';
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainsAligner.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainsAligner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2024, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,11 @@ package org.eclipse.kapua.service.authorization.domain.shiro;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
 import org.eclipse.kapua.locator.initializers.KapuaInitializingMethod;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.domain.Domain;
+import org.eclipse.kapua.model.domain.DomainEntry;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionRepository;
 import org.eclipse.kapua.service.authorization.domain.DomainRepository;
 import org.eclipse.kapua.service.authorization.role.RolePermissionRepository;
@@ -34,20 +36,32 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Aligns {@link org.eclipse.kapua.service.authorization.domain.Domain} registered in the DB with the ones defined in the Kapua Modules.
+ * <p>
+ * Each Kapua Module can define a {@link DomainEntry} annotated with @{@link com.google.inject.multibindings.ProvidesIntoSet}.
+ * The {@link DomainsAligner} will retrieve and match them based on the {@link Domain#getName()}.
+ * <p>
+ * NOTE: Currently the creation of {@link DomainEntry}es that do not exist on the DB is disabled.
+ *
+ * @since 2.1.0
+ */
 public class DomainsAligner {
+    private final static Logger LOGGER = LoggerFactory.getLogger(DomainsAligner.class);
     private final TxManager txManager;
     private final DomainRepository domainRepository;
     private final AccessPermissionRepository accessPermissionRepository;
     private final RolePermissionRepository rolePermissionRepository;
     private final Set<Domain> knownDomains;
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Inject
-    public DomainsAligner(@Named("authorizationTxManager")
-                          TxManager txManager,
-                          DomainRepository domainRepository,
-                          AccessPermissionRepository accessPermissionRepository, RolePermissionRepository rolePermissionRepository,
-                          Set<Domain> knownDomains) {
+    public DomainsAligner(
+            @Named("authorizationTxManager") TxManager txManager,
+            DomainRepository domainRepository,
+            AccessPermissionRepository accessPermissionRepository,
+            RolePermissionRepository rolePermissionRepository,
+            Set<Domain> knownDomains
+    ) {
         this.txManager = txManager;
         this.domainRepository = domainRepository;
         this.accessPermissionRepository = accessPermissionRepository;
@@ -57,38 +71,51 @@ public class DomainsAligner {
 
     @KapuaInitializingMethod(priority = 20)
     public void populate() {
-        logger.info("Domain alignment commencing. Found {} domain declarations in wiring", knownDomains.size());
+        ConfigurationPrinter configurationPrinter =
+                ConfigurationPrinter
+                        .create()
+                        .withLogger(LOGGER)
+                        .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
+                        .withTitle("Authorization Domain Aligner")
+                        .addParameter("Wired domains", knownDomains.size());
+
+        configurationPrinter.printLog();
+
         final Map<String, Domain> knownDomainsByName = knownDomains
                 .stream()
-                .collect(Collectors.toMap(d -> d.getName(), d -> d));
-        final List<String> declaredDomainsNotInDb = new ArrayList<>(knownDomainsByName.keySet());
+                .collect(Collectors.toMap(Domain::getName, d -> d));
+
+        List<String> declaredDomainsNotInDb = new ArrayList<>(knownDomainsByName.keySet());
         try {
             KapuaSecurityUtils.doPrivileged(() -> {
                 txManager.execute(tx -> {
-                    final List<org.eclipse.kapua.service.authorization.domain.Domain> dbDomainEntries = domainRepository.query(tx, new DomainQueryImpl()).getItems();
-                    logger.info("Found {} domain declarations in database", dbDomainEntries.size());
 
-                    for (final org.eclipse.kapua.service.authorization.domain.Domain dbDomainEntry : dbDomainEntries) {
+                    List<org.eclipse.kapua.service.authorization.domain.Domain> dbDomainEntries = domainRepository.query(tx, new DomainQueryImpl()).getItems();
+                    LOGGER.info("Found {} domain declarations in database", dbDomainEntries.size());
+
+                    for (org.eclipse.kapua.service.authorization.domain.Domain dbDomainEntry : dbDomainEntries) {
                         if (!knownDomainsByName.containsKey(dbDomainEntry.getName())) {
-                            //Leave it be. As we share the database with other components, it might have been created by such components and be hidden from us
-                            logger.warn("Domain '{}' is only present in the database but has no current declaration! Details: {}", dbDomainEntry.getName(), dbDomainEntry.getDomain());
+                            // Leave it be. As we share the database with other components, it might have been created by such components and be hidden from us
+                            LOGGER.warn("Domain '{}' is only present in the database but has no current declaration! Details: {}", dbDomainEntry.getName(), dbDomainEntry.getDomain());
                             continue;
                         }
-                        //Good news, it's both declared in wiring and present in the db!
+
+                        // Good news, it's both declared in wiring and present in the db!
                         declaredDomainsNotInDb.remove(dbDomainEntry.getName());
-                        //Trigger fetch of Actions collection from db, otherwise the toString would not show the details
-                        dbDomainEntry.getActions();
-                        final Domain wiredDomain = knownDomainsByName.get(dbDomainEntry.getName());
+
+                        Domain wiredDomain = knownDomainsByName.get(dbDomainEntry.getName());
                         if (dbDomainEntry.getDomain().equals(wiredDomain)) {
-                            //We are happy!
-                            logger.debug("Domain '{}' is ok: {}", dbDomainEntry.getName(), dbDomainEntry.getDomain());
+                            // We are happy!
+                            LOGGER.debug("Domain '{}' is ok: {}", dbDomainEntry.getName(), dbDomainEntry.getDomain());
                             continue;
                         }
-                        //Align them!
+
+                        // Align them!
                         alignDomains(tx, dbDomainEntry, wiredDomain);
                     }
-//                    createMissingDomains(tx, declaredDomainsNotInDb, knownDomainsByName);
-                    logger.info("Domain alignment complete!");
+
+                    // createMissingDomains(tx, declaredDomainsNotInDb, knownDomainsByName);
+                    LOGGER.info("Domain alignment complete!");
                     return null;
                 });
             });
@@ -99,8 +126,9 @@ public class DomainsAligner {
 
     private void createMissingDomains(TxContext tx, List<String> declaredDomainsNotInDb, Map<String, Domain> knownDomainsByName) throws KapuaException {
         if (declaredDomainsNotInDb.size() > 0) {
-            logger.info("Found {} declared domains that have no counterpart in the database!", declaredDomainsNotInDb.size());
-            //Create wired domains not present in the db
+            LOGGER.info("Found {} declared domains that have no counterpart in the database!", declaredDomainsNotInDb.size());
+
+            // Create wired domains not present in the db
             for (final String declaredOnlyName : declaredDomainsNotInDb) {
                 final Domain expected = knownDomainsByName.get(declaredOnlyName);
                 createDomainInDb(tx, expected);
@@ -109,45 +137,50 @@ public class DomainsAligner {
     }
 
     private void createDomainInDb(TxContext tx, Domain expected) throws KapuaException {
-        logger.info("To be added: {}", expected);
-        final org.eclipse.kapua.service.authorization.domain.Domain newEntity = new DomainImpl();
+        LOGGER.info("To be added: {}", expected);
+
+        org.eclipse.kapua.service.authorization.domain.Domain newEntity = new DomainImpl();
         newEntity.setName(expected.getName());
         newEntity.setActions(expected.getActions());
         newEntity.setGroupable(expected.getGroupable());
         newEntity.setServiceName(expected.getServiceName());
+
         domainRepository.create(tx, newEntity);
     }
 
     private void alignDomains(TxContext tx, org.eclipse.kapua.service.authorization.domain.Domain dbDomainEntry, Domain wiredDomain) throws KapuaException {
-        logger.error("Domain  mismatch for name '{}'! Details:" +
-                        "\n\tDb entry: '{}', " +
-                        "\n\texpected: '{}'",
+        LOGGER.error("Domain mismatch for name '{}'! Details:" +
+                        "\n\tDb Entry: '{}', " +
+                        "\n\tExpected: '{}'",
                 dbDomainEntry.getName(),
                 dbDomainEntry.getDomain(),
                 wiredDomain);
 
-        //Remove actions that are defined in the db but not in the wiring
+        // Remove actions that are defined in the db but not in the wiring
         final EnumSet<Actions> actionsInExcessOnTheDb = EnumSet.copyOf(dbDomainEntry.getActions());
         actionsInExcessOnTheDb.removeAll(wiredDomain.getActions());
         if (!actionsInExcessOnTheDb.isEmpty()) {
             removeActionsInExcess(tx, dbDomainEntry.getName(), actionsInExcessOnTheDb);
-            // Thank you JPA for autoupdating the entity on transaction close
+            // Thank you JPA for auto-updating the entity on transaction close
             dbDomainEntry.getActions().removeAll(actionsInExcessOnTheDb);
         }
 
-        //Add to the db actions that are only defined in the wiring
+        // Add to the db actions that are only defined in the wiring
         final EnumSet<Actions> actionsMissingInTheDb = EnumSet.copyOf(wiredDomain.getActions());
         actionsMissingInTheDb.removeAll(dbDomainEntry.getActions());
-        //Do not remove this if. For some reason adding empty enumset to the embedded list breaks down tests
+        // Do not remove this if. For some reason adding empty enumset to the embedded list breaks down tests
         if (!actionsMissingInTheDb.isEmpty()) {
             // Thank you JPA for autoupdating the entity on transaction close
             dbDomainEntry.getActions().addAll(actionsMissingInTheDb);
         }
+
+        // Align 'groupable' attribute
+        dbDomainEntry.setGroupable(wiredDomain.getGroupable());
     }
 
     private void removeActionsInExcess(TxContext tx, String domainName, EnumSet<Actions> actionsInExcessOnTheDb) throws KapuaException {
-        for (final Actions actionToDelete : actionsInExcessOnTheDb) {
-            logger.info("Removing action '{}' from domain '{}'", actionToDelete, domainName);
+        for (Actions actionToDelete : actionsInExcessOnTheDb) {
+            LOGGER.info("Removing action '{}' from domain '{}'", actionToDelete, domainName);
             accessPermissionRepository.deleteAllByDomainAndAction(tx, domainName, actionToDelete);
             rolePermissionRepository.deleteAllByDomainAndAction(tx, domainName, actionToDelete);
         }


### PR DESCRIPTION
This PR fixes the aligning of `groupable` attribute of Domain.

**Related Issue**
_None_

**Description of the solution adopted**
Issues were: 

`DomainImpl.groupable` was annotated has not updatable
`DomainsAligner` was not aligning `groupable` when DB Domain and Domain Entry did not match

**Screenshots**
_None_

**Any side note on the changes made**
Improved javadoc, and code layout. 
Added few `toString()` overrides to improve readability while debugging