### PR TITLE
:arrow_up: [Dependencies] Updated Jersey dependencies from 2.38 to 2.47 - CVE-2025-12383

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <jaxb-core.version>2.3.0.1</jaxb-core.version>
         <jaxb-impl.version>2.3.6</jaxb-impl.version>
         <jbatch.version>1.0.2</jbatch.version>
-        <jersey.version>2.38</jersey.version>
+        <jersey.version>2.47</jersey.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/MoxyJsonFeatureCustomJsonProvider.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/MoxyJsonFeatureCustomJsonProvider.java
@@ -14,39 +14,66 @@ package org.eclipse.kapua.app.api.core;
 
 import org.glassfish.jersey.internal.InternalProperties;
 import org.glassfish.jersey.internal.util.PropertiesHelper;
+
+import javax.inject.Inject;
 import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.Providers;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.helpers.DefaultValidationEventHandler;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+/**
+ * A custom feature used to set a custom moxyJsonProvider
+ */
 public class MoxyJsonFeatureCustomJsonProvider implements Feature {
-    //A custom feature used to set a custom moxyJsonProvider
-
     private static final String JSON_FEATURE = MoxyJsonFeatureCustomJsonProvider.class.getSimpleName();
 
     @Override
     public boolean configure(final FeatureContext context) {
-        final Configuration config = context.getConfiguration();
-        // Disable other JSON providers. In this way the org.glassfish.jersey.moxy.json.MoxyJsonFeature (registered as default by MOXy) will skip the registration of the default provider
-        context.property(PropertiesHelper.getPropertyNameForRuntime(InternalProperties.JSON_FEATURE, config.getRuntimeType()),
-                JSON_FEATURE);
+        Configuration config = context.getConfiguration();
+
+        // Disable other JSON providers.
+        // In this way the org.glassfish.jersey.moxy.json.MoxyJsonFeature (registered as default by MOXy) will skip the registration of the default provider
+        context.property(
+                PropertiesHelper.getPropertyNameForRuntime(InternalProperties.JSON_FEATURE, config.getRuntimeType()),
+                JSON_FEATURE
+        );
         context.register(CustomMoxyJsonProvider.class);
+
         return true;
     }
 
     @Provider
     public static class CustomMoxyJsonProvider extends org.glassfish.jersey.moxy.json.internal.ConfigurableMoxyJsonProvider {
-        //A custom moxyJsonProvider that sets the unmarshaller validationEventHandler to the default one. This one allows to propagate exceptions to the stack when an error is found (for example, when an exception has been thrown from one of our custom "xmlAdapters")
+
+        @Inject
+        public CustomMoxyJsonProvider(@Context Providers providers, @Context Configuration config) {
+            super(providers, config);
+        }
+
+        /**
+         * A custom moxyJsonProvider that sets the unmarshaller validationEventHandler to the default one. This one allows to propagate exceptions to the stack when an error is found (for example, when an exception has been thrown from one of our custom "xmlAdapters")
+         *
+         * @param type - The Class to be unmarshalled (i.e. <i>Customer</i> or <i>List</i>)
+         * @param genericType - The type of object to be unmarshalled (i.e <i>Customer</i> or <i>List&lt;Customer&gt;</i>).
+         * @param annotations - The annotations corresponding to domain object.
+         * @param mediaType - The media type for the HTTP entity.
+         * @param httpHeaders - HTTP headers associated with HTTP entity.
+         * @param unmarshaller - The instance of <i>Unmarshaller</i> that will be used to unmarshal the JSON message.
+         * @throws JAXBException
+         */
         @Override
         protected void preReadFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, Unmarshaller unmarshaller) throws JAXBException {
             super.preReadFrom(type, genericType, annotations, mediaType, httpHeaders, unmarshaller);
+
             unmarshaller.setEventHandler(new DefaultValidationEventHandler());
         }
     }


### PR DESCRIPTION
This PR bumps the version of Jersey dependencies from 2.38 to 2.47 to address components CVEs.

- CVE-2025-12383

**Related Issue**
_None_

**Description of the solution adopted**
Updated version of Jersey components

**Screenshots**
_None_

**Any side note on the changes made**
_None_