### PR TITLE
:bug: [Docker] Allow java process to receive properly the sigterm from container

### DIFF
--- a/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
+++ b/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
@@ -26,4 +26,4 @@ JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DE
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
 
-java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-lifecycle-2.1.0-SNAPSHOT-app.jar
+exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-lifecycle-2.1.0-SNAPSHOT-app.jar

--- a/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
+++ b/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
@@ -26,4 +26,4 @@ JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DE
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
 
-java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-telemetry-2.1.0-SNAPSHOT-app.jar
+exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-telemetry-2.1.0-SNAPSHOT-app.jar

--- a/assembly/service/authentication/entrypoint/run-service-authentication
+++ b/assembly/service/authentication/entrypoint/run-service-authentication
@@ -24,4 +24,4 @@ JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DE
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
 
-java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-service-authentication-2.1.0-SNAPSHOT-app.jar
+exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-service-authentication-2.1.0-SNAPSHOT-app.jar


### PR DESCRIPTION
Brief description of the PR.
The java process for consumers and service doesn't receive the sigterm from Docker container properly.
This pr will fix it.

**Related Issue**
none

**Description of the solution adopted**
Added 'EXEC' before the java command in the consumers/service entrypoints. In this way the java process will have the process id 1 and will receive the sigterm from the docker container properly.

**Screenshots**
none

**Any side note on the changes made**
none