### PR TITLE
:bug: [Docker] Add EXEC before java command for Message Broker and Events Broker

### DIFF
--- a/assembly/broker-artemis/entrypoint/run-broker
+++ b/assembly/broker-artemis/entrypoint/run-broker
@@ -58,4 +58,4 @@ JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
 JAVA_ARGS="${JAVA_ARGS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
 
 echo 'starting Artemis...'
-/opt/artemis/kapua/bin/artemis run xml:/opt/artemis/kapua/etc/bootstrap.xml
+exec /opt/artemis/kapua/bin/artemis run xml:/opt/artemis/kapua/etc/bootstrap.xml

--- a/assembly/events-broker/entrypoint/run-event-broker
+++ b/assembly/events-broker/entrypoint/run-event-broker
@@ -43,4 +43,4 @@ echo -e -n "\r\n${ARTEMIS_USER:-kapua-sys} = ENC("$(/opt/artemis/kapua/bin/artem
 echo -e "\r\namq = ${ARTEMIS_USER:-kapua-sys}" >> /opt/artemis/kapua/etc/artemis-roles.properties
 
 echo 'starting Artemis...'
-/opt/artemis/kapua/bin/artemis run xml:/opt/artemis/kapua/etc/bootstrap.xml
+exec /opt/artemis/kapua/bin/artemis run xml:/opt/artemis/kapua/etc/bootstrap.xml


### PR DESCRIPTION
This PR adds the `exec` command to the Docker Container of Message Broker and Event Broker.

**Related Issue**
This PR integrates changes in #4314 

**Description of the solution adopted**
Added `exec` command

**Screenshots**
_None_

**Any side note on the changes made**
_None_