### PR TITLE
:bug: [Authorization] Now call /{scopeId}/authorization/claims correctly retrieves all the claims

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
@@ -19,6 +19,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import com.google.inject.Provider;
+import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.commons.core.ServiceModule;
@@ -94,8 +95,9 @@ import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionFactoryI
 import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionImplJpaRepository;
 import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionServiceImpl;
 import org.eclipse.kapua.service.authorization.role.shiro.RoleServiceImpl;
+import org.eclipse.kapua.service.authorization.shiro.claims.BruteForceClaimsFetcher;
 import org.eclipse.kapua.service.authorization.shiro.claims.ClaimsFetcher;
-import org.eclipse.kapua.service.authorization.shiro.claims.ClaimsFetcherImpl;
+import org.eclipse.kapua.service.authorization.shiro.claims.SimpleClaimsFetcher;
 import org.eclipse.kapua.service.authorization.shiro.setting.KapuaAuthorizationSetting;
 import org.eclipse.kapua.storage.TxManager;
 
@@ -201,17 +203,34 @@ public class AuthorizationModule extends AbstractKapuaModule {
 
     @Provides
     @Singleton
+    @Named("bruteForceClaimsFetcher")
+    ClaimsFetcher bruteForceClaimsFetcher(
+            AuthorizationService authorizationService,
+            PermissionFactory permissionFactory,
+            DomainRegistryService domainService,
+            DomainFactory domainFactory) {
+        return new BruteForceClaimsFetcher(
+                authorizationService,
+                permissionFactory,
+                domainService,
+                domainFactory);
+    }
+
+    @Provides
+    @Singleton
     @Named("defaultClaimsFetcher")
     ClaimsFetcher defaultClaimsFetcher(
             AuthorizationService authorizationService,
             AuthenticationService authenticationService,
             PermissionFactory permissionFactory,
-            Set<Domain> knownDomains) {
-        return new ClaimsFetcherImpl(
+            DomainRegistryService domainService,
+            DomainFactory domainFactory) throws KapuaException {
+        return new SimpleClaimsFetcher(
                 authorizationService,
                 authenticationService,
                 permissionFactory,
-                knownDomains);
+                domainService,
+                domainFactory);
     }
 
     @Provides

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
@@ -13,13 +13,11 @@
 package org.eclipse.kapua.service.authorization.shiro;
 
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import com.google.inject.Provider;
-import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.commons.core.ServiceModule;
@@ -95,9 +93,8 @@ import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionFactoryI
 import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionImplJpaRepository;
 import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionServiceImpl;
 import org.eclipse.kapua.service.authorization.role.shiro.RoleServiceImpl;
-import org.eclipse.kapua.service.authorization.shiro.claims.BruteForceClaimsFetcher;
 import org.eclipse.kapua.service.authorization.shiro.claims.ClaimsFetcher;
-import org.eclipse.kapua.service.authorization.shiro.claims.SimpleClaimsFetcher;
+import org.eclipse.kapua.service.authorization.shiro.claims.ClaimsFetcherImpl;
 import org.eclipse.kapua.service.authorization.shiro.setting.KapuaAuthorizationSetting;
 import org.eclipse.kapua.storage.TxManager;
 
@@ -203,29 +200,14 @@ public class AuthorizationModule extends AbstractKapuaModule {
 
     @Provides
     @Singleton
-    @Named("bruteForceClaimsFetcher")
-    ClaimsFetcher bruteForceClaimsFetcher(
-            AuthorizationService authorizationService,
-            PermissionFactory permissionFactory,
-            DomainRegistryService domainService,
-            DomainFactory domainFactory) {
-        return new BruteForceClaimsFetcher(
-                authorizationService,
-                permissionFactory,
-                domainService,
-                domainFactory);
-    }
-
-    @Provides
-    @Singleton
     @Named("defaultClaimsFetcher")
     ClaimsFetcher defaultClaimsFetcher(
             AuthorizationService authorizationService,
             AuthenticationService authenticationService,
             PermissionFactory permissionFactory,
             DomainRegistryService domainService,
-            DomainFactory domainFactory) throws KapuaException {
-        return new SimpleClaimsFetcher(
+            DomainFactory domainFactory) {
+        return new ClaimsFetcherImpl(
                 authorizationService,
                 authenticationService,
                 permissionFactory,

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/claims/ClaimsFetcherImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/claims/ClaimsFetcherImpl.java
@@ -13,18 +13,22 @@
 package org.eclipse.kapua.service.authorization.shiro.claims;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.model.domain.Actions;
-import org.eclipse.kapua.model.domain.Domain;
+import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.AuthenticationService;
 import org.eclipse.kapua.service.authentication.token.LoginInfo;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.access.AccessPermission;
+import org.eclipse.kapua.service.authorization.domain.DomainFactory;
+import org.eclipse.kapua.service.authorization.domain.DomainRegistryService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.authorization.role.RolePermission;
 
 import javax.inject.Inject;
+import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,22 +45,30 @@ public class ClaimsFetcherImpl implements ClaimsFetcher {
 
     private final AuthenticationService authenticationService;
     private final AuthorizationService authorizationService;
-    private final Set<Domain> knownDomains;
     private final PermissionFactory permissionFactory;
+    private final DomainRegistryService domainService;
+    private final DomainFactory domainFactory;
+    private Set<Domain> knownDomains;
 
     @Inject
     public ClaimsFetcherImpl(AuthorizationService authorizationService,
-                             AuthenticationService authenticationService,
-                             PermissionFactory permissionFactory,
-                             Set<Domain> knownDomains) {
+                               AuthenticationService authenticationService,
+                               PermissionFactory permissionFactory,
+                               DomainRegistryService domainService,
+                               DomainFactory domainFactory) {
         this.authorizationService = authorizationService;
         this.authenticationService = authenticationService;
         this.permissionFactory = permissionFactory;
-        this.knownDomains = knownDomains;
+        this.domainService = domainService;
+        this.domainFactory = domainFactory;
     }
 
     @Override
     public Set<String> fetchUserClaims(KapuaId inScope) throws KapuaException {
+        if (this.knownDomains == null ) {
+            this.knownDomains = KapuaSecurityUtils.doPrivileged(() -> new HashSet<>(domainService.query(domainFactory.newQuery(null)).getItems()));
+        }
+
         LoginInfo loginInfo = authenticationService.getLoginInfo();
         //Retrieve all permissions from both AccessPermissions and RolePermissions
         Set<AccessPermission> accessPermissions = loginInfo.getAccessPermission();

--- a/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/AuthorizationModuleTests.java
+++ b/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/AuthorizationModuleTests.java
@@ -14,14 +14,14 @@ package org.eclipse.kapua.service.authorization.steps;
 
 import com.google.inject.Provides;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
-import org.eclipse.kapua.model.domain.Domain;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.domain.DomainFactory;
+import org.eclipse.kapua.service.authorization.domain.DomainRegistryService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.authorization.shiro.claims.ClaimsFetcher;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.util.Set;
 
 public class AuthorizationModuleTests extends AbstractKapuaModule {
 
@@ -31,11 +31,13 @@ public class AuthorizationModuleTests extends AbstractKapuaModule {
     ClaimsFetcher noGroupsClaimsFetcher(
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
-            Set<Domain> knownDomains) {
+            DomainRegistryService domainService,
+            DomainFactory domainFactory) {
         return new NoGroupsClaimsFetcher(
                 authorizationService,
                 permissionFactory,
-                knownDomains);
+                domainService,
+                domainFactory);
     }
 
     @Override

--- a/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/NoGroupsClaimsFetcher.java
+++ b/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/NoGroupsClaimsFetcher.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+//A ClaimsFetcher that enumerates all possible domain&actions
+//BE AWARE THAT PERFORMS WRONG IN PRESENCE OF PERMISSIONS RESTRICTED TO GROUPS
 
 /**
  * {@link ClaimsFetcher} implementation.

--- a/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/NoGroupsClaimsFetcher.java
+++ b/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/NoGroupsClaimsFetcher.java
@@ -29,8 +29,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-//A ClaimsFetcher that enumerates all possible domain&actions
-//BE AWARE THAT PERFORMS WRONG IN PRESENCE OF PERMISSIONS RESTRICTED TO GROUPS
 
 /**
  * {@link ClaimsFetcher} implementation.

--- a/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/NoGroupsClaimsFetcher.java
+++ b/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/NoGroupsClaimsFetcher.java
@@ -13,14 +13,18 @@
 package org.eclipse.kapua.service.authorization.steps;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.model.domain.Domain;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.domain.DomainFactory;
+import org.eclipse.kapua.service.authorization.domain.DomainRegistryService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.authorization.shiro.claims.ClaimsFetcher;
 
 import javax.inject.Inject;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,20 +43,28 @@ import java.util.stream.Stream;
 public class NoGroupsClaimsFetcher implements ClaimsFetcher {
 
     private final AuthorizationService authorizationServiceProvider;
-    private final Set<Domain> knownDomains;
     private final PermissionFactory permissionFactory;
+    private final DomainRegistryService domainService;
+    private final DomainFactory domainFactory;
+    private Set<Domain> knownDomains;
 
     @Inject
     public NoGroupsClaimsFetcher(AuthorizationService authorizationService,
                                  PermissionFactory permissionFactory,
-                                 Set<Domain> knownDomains) {
+                                 DomainRegistryService domainService,
+                                 DomainFactory domainFactory) {
         this.authorizationServiceProvider = authorizationService;
         this.permissionFactory = permissionFactory;
-        this.knownDomains = knownDomains;
+        this.domainService = domainService;
+        this.domainFactory = domainFactory;
     }
 
     @Override
-    public Set<String> fetchUserClaims(KapuaId inScope) {
+    public Set<String> fetchUserClaims(KapuaId inScope) throws KapuaException {
+        if (this.knownDomains == null ) {
+            this.knownDomains = KapuaSecurityUtils.doPrivileged(() -> new HashSet<>(domainService.query(domainFactory.newQuery(null)).getItems()));
+        }
+
         final Set<String> claims = knownDomains.stream()
                 .flatMap(domain -> {
                     final Stream<String> domainClaims = domain.getActions()


### PR DESCRIPTION
The claimsFetcher implementation had a subtle bug where some knowDomains were not correctly imported due to missing depencensies on some modules defining them

I solved the issue refactoring how they are imported. Now a fetch from DB is performed. This guarantees to have all know domains since the varios containers align their definition on the DB accordingly at startup