### PR TITLE
:bug: [Device management] Wrong http error returned when containers resource is missing

### DIFF
--- a/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/DeviceManagementResponseNotFoundExceptionMapper.java
+++ b/commons-rest/errors/src/main/java/org/eclipse/kapua/commons/rest/errors/DeviceManagementResponseNotFoundExceptionMapper.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.rest.errors;
+
+import org.eclipse.kapua.commons.rest.model.errors.DeviceManagementResponseCodeExceptionInfo;
+import org.eclipse.kapua.service.device.management.exception.DeviceManagementResponseNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class DeviceManagementResponseNotFoundExceptionMapper implements ExceptionMapper<DeviceManagementResponseNotFoundException> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceManagementResponseNotFoundExceptionMapper.class);
+
+    private final boolean showStackTrace;
+
+    @Inject
+    public DeviceManagementResponseNotFoundExceptionMapper(ExceptionConfigurationProvider exceptionConfigurationProvider) {
+        this.showStackTrace = exceptionConfigurationProvider.showStackTrace();
+    }
+
+    @Override
+    public Response toResponse(DeviceManagementResponseNotFoundException deviceManagementResponseCodeException) {
+        LOG.error(deviceManagementResponseCodeException.getMessage(), deviceManagementResponseCodeException);
+
+        return Response
+                .status(Response.Status.NOT_FOUND)
+                .entity(new DeviceManagementResponseCodeExceptionInfo(404, deviceManagementResponseCodeException, showStackTrace))
+                .build();
+    }
+}

--- a/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/DeviceManagementResponseCodeExceptionInfo.java
+++ b/commons-rest/model/src/main/java/org/eclipse/kapua/commons/rest/model/errors/DeviceManagementResponseCodeExceptionInfo.java
@@ -50,7 +50,18 @@ public class DeviceManagementResponseCodeExceptionInfo extends ExceptionInfo {
      * @since 1.0.0
      */
     public DeviceManagementResponseCodeExceptionInfo(DeviceManagementResponseCodeException deviceManagementResponseCodeException, boolean showStackTrace) {
-        super(500/*Status.INTERNAL_SERVER_ERROR*/, deviceManagementResponseCodeException, showStackTrace);
+        this(500, deviceManagementResponseCodeException, showStackTrace);
+    }
+
+    /**
+     * Constructor with a custom http status code
+     *
+     * @param httpStatusCode the http status code we want to set in the response
+     * @param deviceManagementResponseCodeException The root exception.
+     * @since 2.0.0
+     */
+    public DeviceManagementResponseCodeExceptionInfo(int httpStatusCode, DeviceManagementResponseCodeException deviceManagementResponseCodeException, boolean showStackTrace) {
+        super(httpStatusCode, deviceManagementResponseCodeException, showStackTrace);
 
         this.responseCode = deviceManagementResponseCodeException.getResponseCode();
         this.errorMessage = deviceManagementResponseCodeException.getErrorMessage();


### PR DESCRIPTION
Assuming that a Device had no support for containers, a wrong http response code was returned when calling /{scopeId}/devices/{deviceId}/inventory/containers

In fact, the error returned was:

{
  "type": "deviceManagementResponseCodeExceptionInfo",
  "httpErrorCode": 500,
  "message": "The device has not found the requested resource. Error Code: NOT_FOUND - Error Message: null",
  "kapuaErrorCode": "RESPONSE_NOT_FOUND",
  "responseCode": "NOT_FOUND"
}

when the actual httpErrorCode should have been 404


To solve the issue I created an appropriate exception Mapper for the exception thrown during such case, which returns the 404 error code