### PR TITLE
✨ [Datastore] Remove uniqueness check on store call

### DIFF
--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -21,6 +21,42 @@ Feature: Datastore tests
     Given Init Security Context
     And Start full docker environment
 
+  Scenario: Test message store call with fixed document id
+  Do few inserts (even after waiting a index refresh time) with the same document id and verify that only one message is returned by the search.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-client"
+    And I set the database to device timestamp indexing
+
+    Given System property "datastore.index.prefix" with value ""
+    And I set the datastore indexing window to "week"
+
+    When I prepare a number of messages in the specified ranges and remember the list as "multipleStoreCall"
+      | clientId    | topic     | count | startDate                | endDate                  |
+      | test-client | messageId | 1     | 2025-12-01T12:00:00.000Z | 2025-12-02T12:00:00.000Z |
+    And Store messages "multipleStoreCall" for 8 times with message id "id-no-wait" and wait time 0
+    #wait to have message indexed
+    And I wait 5 seconds
+    And I query for messages and I found 1 message, 0 of them with UUID as id, and store the result as "multipleStoreCallFoundMessages"
+    Then I found a message with id "id-no-wait" and version 8 from stored search "multipleStoreCallFoundMessages"
+
+    When I prepare a number of messages in the specified ranges and remember the list as "multipleStoreCallWait"
+      | clientId         | topic         | count | startDate                | endDate                  |
+      | test-client-wait | messageIdWait | 1     | 2025-12-01T12:00:00.000Z | 2025-12-02T12:00:00.000Z |
+    And Store messages "multipleStoreCallWait" for 4 times with message id "id-wait" and wait time 5
+    And Store messages "multipleStoreCall" for 1 times with message id "other-id" and wait time 0
+    And Store messages "multipleStoreCall" for 6 times with message id "" and wait time 0
+    And I wait 5 seconds
+    And I query for messages and I found 9 messages, 6 of them with UUID as id, and store the result as "multipleStoreCallFoundMessages"
+    Then I found a message with id "id-no-wait" and version 8 from stored search "multipleStoreCallFoundMessages"
+    Then I found a message with id "id-wait" and version 4 from stored search "multipleStoreCallFoundMessages"
+    Then I found a message with id "other-id" and version 1 from stored search "multipleStoreCallFoundMessages"
+
+    Then I delete all indices
+
+    Then I logout
+
   Scenario: Delete items by date ranges
   Delete previously stored messages based on a time interval. The number of deleted items should
   depend on the index window. Only the items in whole hours/days/weeks of th einterval should be deleted.

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -26,7 +26,7 @@ import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.id.StorableId;
 
 public interface MessageStoreFacade {
-    StorableId store(KapuaMessage<?, ?> message, String messageId, boolean newInsert)
+    StorableId store(KapuaMessage<?, ?> message, String messageId)
             throws KapuaIllegalArgumentException,
             DatastoreDisabledException,
             ConfigurationException,

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacadeImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.datastore.internal;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
-import org.eclipse.kapua.commons.cache.LocalCache;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.message.KapuaMessage;
@@ -25,9 +24,7 @@ import org.eclipse.kapua.service.datastore.exception.DatastoreDisabledException;
 import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.ClientInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.ConfigurationException;
-import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreChannel;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
-import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageInfo;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfiguration;
 import org.eclipse.kapua.service.datastore.internal.mediator.Metric;
@@ -37,17 +34,9 @@ import org.eclipse.kapua.service.datastore.internal.model.ClientInfoImpl;
 import org.eclipse.kapua.service.datastore.internal.model.DataIndexBy;
 import org.eclipse.kapua.service.datastore.internal.model.DatastoreMessageImpl;
 import org.eclipse.kapua.service.datastore.internal.model.MessageListResultImpl;
-import org.eclipse.kapua.service.datastore.internal.model.MessageUniquenessCheck;
 import org.eclipse.kapua.service.datastore.internal.model.MetricInfoImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.ChannelInfoQueryImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.ClientInfoQueryImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.MetricInfoQueryImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.predicate.ChannelMatchPredicateImpl;
-import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
-import org.eclipse.kapua.service.datastore.model.ClientInfoListResult;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
-import org.eclipse.kapua.service.datastore.model.MetricInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.elasticsearch.client.exception.ClientException;
 import org.eclipse.kapua.service.elasticsearch.client.exception.QueryMappingException;
@@ -80,9 +69,7 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
     private final MetricInfoRepository metricInfoRepository;
     private final ChannelInfoRepository channelInfoRepository;
     private final ClientInfoRepository clientInfoRepository;
-    private final MetricsDatastore metrics;
     private final DatastoreUtils datastoreUtils;
-    private final DatastoreCacheManager datastoreCacheManager;
 
     private static final String QUERY = "query";
     private static final String QUERY_SCOPE_ID = "query.scopeId";
@@ -99,9 +86,7 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
             MetricInfoRepository metricInfoRepository,
             ChannelInfoRepository channelInfoRepository,
             ClientInfoRepository clientInfoRepository,
-            MetricsDatastore metricsDatastore,
-            DatastoreUtils datastoreUtils,
-            DatastoreCacheManager datastoreCacheManager) {
+            DatastoreUtils datastoreUtils) {
         super(configProvider);
         this.storableIdFactory = storableIdFactory;
         this.clientInfoRegistryFacade = clientInfoRegistryFacade;
@@ -111,9 +96,7 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
         this.metricInfoRepository = metricInfoRepository;
         this.channelInfoRepository = channelInfoRepository;
         this.clientInfoRepository = clientInfoRepository;
-        this.metrics = metricsDatastore;
         this.datastoreUtils = datastoreUtils;
-        this.datastoreCacheManager = datastoreCacheManager;
     }
 
     /**
@@ -126,7 +109,7 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
      * @throws ClientException
      */
     @Override
-    public StorableId store(KapuaMessage<?, ?> message, String messageId, boolean newInsert) throws KapuaIllegalArgumentException, DatastoreDisabledException, ConfigurationException, ClientException, MappingException {
+    public StorableId store(KapuaMessage<?, ?> message, String messageId) throws KapuaIllegalArgumentException, DatastoreDisabledException, ConfigurationException, ClientException, MappingException {
         ArgumentValidator.notNull(message, "message");
         ArgumentValidator.notNull(message.getScopeId(), SCOPE_ID);
         ArgumentValidator.notNull(message.getReceivedOn(), "receivedOn");
@@ -152,17 +135,6 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
         }
         // Extract schema metadata
         Date indexedOnDate = new Date(indexedOn);
-
-        if (!newInsert && !MessageUniquenessCheck.NONE.equals(accountServicePlan.getMessageUniquenessCheck())) {
-            DatastoreMessage datastoreMessage = MessageUniquenessCheck.FULL.equals(accountServicePlan.getMessageUniquenessCheck()) ?
-                    messageRepository.find(message.getScopeId(), storableIdFactory.newStorableId(messageId)) :
-                    messageRepository.find(message.getScopeId(), storableIdFactory.newStorableId(messageId), indexedOnDate.getTime());
-            if (datastoreMessage != null) {
-                LOG.debug("Message with datastore id '{}' already found", messageId);
-                metrics.getAlreadyInTheDatastore().inc();
-                return storableIdFactory.newStorableId(messageId);
-            }
-        }
 
         // Save message (the big one)
         final DatastoreMessage messageToStore = convertTo(message, messageId);
@@ -359,143 +331,7 @@ public final class MessageStoreFacadeImpl extends AbstractDatastoreFacade implem
         return messageRepository.query(query);
     }
 
-
-    // TODO cache will not be reset from the client code it should be automatically reset
-    // after some time.
-    private void resetCache(KapuaId scopeId, KapuaId deviceId, String channel, String clientId) throws Exception {
-
-        boolean isAnyClientId;
-        boolean isClientToDelete = false;
-        String semTopic;
-
-        if (channel != null) {
-
-            // determine if we should delete an client if topic = account/clientId/#
-            isAnyClientId = isAnyClientId(channel);
-            semTopic = channel;
-
-            if (semTopic.isEmpty() && !isAnyClientId) {
-                isClientToDelete = true;
-            }
-        } else {
-            isClientToDelete = true;
-        }
-
-        // Find all topics
-        int pageSize = 1000;
-        int offset = 0;
-        long totalHits = 1;
-
-        MetricInfoQueryImpl metricQuery = new MetricInfoQueryImpl(scopeId);
-        metricQuery.setLimit(pageSize + 1);
-        metricQuery.setOffset(offset);
-
-        ChannelMatchPredicateImpl channelPredicate = new ChannelMatchPredicateImpl(MessageField.CHANNEL, channel);
-        metricQuery.setPredicate(channelPredicate);
-
-        // Remove metrics
-        while (totalHits > 0) {
-            MetricInfoListResult metrics = metricInfoRepository.query(metricQuery);
-
-            totalHits = metrics.getTotalCount();
-            LocalCache<String, Boolean> metricsCache = datastoreCacheManager.getMetricsCache();
-            long toBeProcessed = totalHits > pageSize ? pageSize : totalHits;
-
-            for (int i = 0; i < toBeProcessed; i++) {
-                String id = metrics.getItem(i).getId().toString();
-                if (metricsCache.get(id)) {
-                    metricsCache.remove(id);
-                }
-            }
-
-            if (totalHits > pageSize) {
-                offset += pageSize + 1;
-            }
-        }
-        LOG.debug("Removed cached channel metrics for: {}", channel);
-        metricInfoRepository.delete(metricQuery);
-        LOG.debug("Removed channel metrics for: {}", channel);
-        ChannelInfoQueryImpl channelQuery = new ChannelInfoQueryImpl(scopeId);
-        channelQuery.setLimit(pageSize + 1);
-        channelQuery.setOffset(offset);
-
-        channelPredicate = new ChannelMatchPredicateImpl(MessageField.CHANNEL, channel);
-        channelQuery.setPredicate(channelPredicate);
-
-        // Remove channel
-        offset = 0;
-        totalHits = 1;
-        while (totalHits > 0) {
-            final ChannelInfoListResult channels = channelInfoRepository.query(channelQuery);
-
-            totalHits = channels.getTotalCount();
-            LocalCache<String, Boolean> channelsCache = datastoreCacheManager.getChannelsCache();
-            long toBeProcessed = totalHits > pageSize ? pageSize : totalHits;
-
-            for (int i = 0; i < toBeProcessed; i++) {
-                String id = channels.getFirstItem().getId().toString();
-                if (channelsCache.get(id)) {
-                    channelsCache.remove(id);
-                }
-            }
-            if (totalHits > pageSize) {
-                offset += pageSize + 1;
-            }
-        }
-
-        LOG.debug("Removed cached channels for: {}", channel);
-        channelInfoRepository.delete(channelQuery);
-
-        LOG.debug("Removed channels for: {}", channel);
-        // Remove client
-        if (isClientToDelete) {
-            ClientInfoQueryImpl clientInfoQuery = new ClientInfoQueryImpl(scopeId);
-            clientInfoQuery.setLimit(pageSize + 1);
-            clientInfoQuery.setOffset(offset);
-
-            channelPredicate = new ChannelMatchPredicateImpl(MessageField.CHANNEL, channel);
-            clientInfoQuery.setPredicate(channelPredicate);
-            offset = 0;
-            totalHits = 1;
-            while (totalHits > 0) {
-                ClientInfoListResult clients = clientInfoRepository.query(clientInfoQuery);
-                totalHits = clients.getTotalCount();
-                LocalCache<String, Boolean> clientsCache = datastoreCacheManager.getClientsCache();
-                long toBeProcessed = totalHits > pageSize ? pageSize : totalHits;
-
-                for (int i = 0; i < toBeProcessed; i++) {
-                    String id = clients.getItem(i).getId().toString();
-                    if (clientsCache.get(id)) {
-                        clientsCache.remove(id);
-                    }
-                }
-                if (totalHits > pageSize) {
-                    offset += pageSize + 1;
-                }
-            }
-
-            LOG.debug("Removed cached clients for: {}", channel);
-            clientInfoRepository.delete(clientInfoQuery);
-
-            LOG.debug("Removed clients for: {}", channel);
-        }
-    }
-
     // Utility methods
-
-    /**
-     * Check if the channel admit any client identifier (so if the channel has a specific wildcard in the second topic level).<br>
-     * In the MQTT word this method return true if the topic starts with 'account/+/'.
-     *
-     * @param clientId
-     * @return
-     * @since 1.0.0
-     */
-    private boolean isAnyClientId(String clientId) {
-        return DatastoreChannel.SINGLE_LEVEL_WCARD.equals(clientId);
-    }
-
-
     @Override
     public void refreshAllIndexes() throws ClientException {
         messageRepository.refreshAllIndexes();

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -88,28 +88,7 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
     @Override
     public StorableId store(KapuaMessage<?, ?> message)
             throws KapuaException {
-        String datastoreId = UUID.randomUUID().toString();
-        Context metricDataSaveTimeContext = metrics.getDataSaveTime().time();
-        try {
-            checkDataAccess(message.getScopeId(), Actions.write);
-            metrics.getMessage().inc();
-            return messageStoreFacade.store(message, datastoreId, true);
-        } catch (ConfigurationException e) {
-            metrics.getConfigurationError().inc();
-            throw e;
-        } catch (KapuaIllegalArgumentException e) {
-            metrics.getValidationError().inc();
-            throw e;
-        } catch (ClientCommunicationException e) {
-            metrics.getCommunicationError().inc();
-            throw new DatastoreCommunicationException(datastoreId, e);
-        } catch (Exception e) {
-            metrics.getGenericError().inc();
-            logException(e);
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getMessage());
-        } finally {
-            metricDataSaveTimeContext.stop();
-        }
+        return store(message, UUID.randomUUID().toString());
     }
 
     @Override
@@ -120,7 +99,7 @@ public class MessageStoreServiceImpl extends KapuaConfigurableServiceBase implem
         try {
             checkDataAccess(message.getScopeId(), Actions.write);
             metrics.getMessage().inc();
-            return messageStoreFacade.store(message, datastoreId, false);
+            return messageStoreFacade.store(message, datastoreId);
         } catch (ConfigurationException e) {
             metrics.getConfigurationError().inc();
             throw e;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricsDatastore.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricsDatastore.java
@@ -26,9 +26,6 @@ public class MetricsDatastore {
     private static final String CONSUMER_TELEMETRY = "consumer_telemetry";
     private static final String STORE = "store";
     private static final String PROCESSED = "processed";
-    private static final String DUPLICATED_STORE = "duplicated_store";
-
-    private Counter alreadyInTheDatastore;
 
     private final Counter message;
     private final Counter communicationError;
@@ -44,8 +41,6 @@ public class MetricsDatastore {
 
     @Inject
     public MetricsDatastore(MetricsService metricsService) {
-        alreadyInTheDatastore = metricsService.getCounter(CONSUMER_TELEMETRY, STORE, DUPLICATED_STORE);
-
         // data message
         message = metricsService.getCounter(CONSUMER_TELEMETRY, STORE, MetricsLabel.ATTEMPT);
         communicationError = metricsService.getCounter(CONSUMER_TELEMETRY, STORE, MetricsLabel.COMMUNICATION, MetricsLabel.ERROR);
@@ -60,10 +55,6 @@ public class MetricsDatastore {
 
         // store timers
         dataSaveTime = metricsService.getTimer(CONSUMER_TELEMETRY, STORE, MetricsLabel.TIME, MetricsLabel.SECONDS);
-    }
-
-    public Counter getAlreadyInTheDatastore() {
-        return alreadyInTheDatastore;
     }
 
     public Counter getMessage() {

--- a/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
@@ -56,18 +56,6 @@
             <Option label="SERVER_TIMESTAMP" value="SERVER_TIMESTAMP" />
         </AD>
 
-        <AD id="messageUniquenessCheck"
-            name="messageUniquenessCheck"
-            type="String"
-            cardinality="0"
-            required="true"
-            default="FULL"
-            description="Message uniqueness check type (on telemetry message datastore insert)">
-            <Option label="NONE" value="NONE" />
-            <Option label="BOUND" value="BOUND" />
-            <Option label="FULL" value="FULL" />
-        </AD>
-
     </OCD>
 
     <Designate pid="org.eclipse.kapua.service.datastore.MessageStoreService">

--- a/service/datastore/test-steps/pom.xml
+++ b/service/datastore/test-steps/pom.xml
@@ -52,6 +52,11 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-qa-markers</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -22,6 +22,7 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.http.HttpHost;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -102,8 +103,15 @@ import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
 import org.eclipse.kapua.service.storable.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.service.storable.model.query.predicate.RangePredicate;
 import org.eclipse.kapua.service.storable.model.query.predicate.TermPredicate;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,6 +134,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -495,7 +504,9 @@ public class DatastoreSteps extends TestBase {
         for (CucMessageRange tmpMessage : messages) {
             Date startDate = KapuaDateUtils.parseDate(tmpMessage.getStartDate());
             Date endDate = KapuaDateUtils.parseDate(tmpMessage.getEndDate());
-            long stepSeconds = (endDate.getTime() - startDate.getTime()) / (1000L * (tmpMessage.getCount().longValue() - 1));
+            long stepSeconds = tmpMessage.getCount() > 1 ?
+                    (endDate.getTime() - startDate.getTime()) / (1000L * (tmpMessage.getCount().longValue() - 1)) :
+                    0;
             tmpCal.setTime(startDate);
             for (int cnt = 0; cnt < tmpMessage.getCount(); cnt++) {
                 tmpMsg = createTestMessage(
@@ -510,6 +521,78 @@ public class DatastoreSteps extends TestBase {
         }
 
         stepData.put(listKey, tmpList);
+    }
+
+    @And("Store messages {string} for {int} time(s) with message id {string} and wait time {int}")
+    public void storeMessagesWithMessageId(String listKey, int insertCount, String msgId, int waitTime) throws Exception {
+        List<KapuaDataMessage> tmpList = (List<KapuaDataMessage>)stepData.get(listKey);
+        for (KapuaDataMessage msg : tmpList) {
+            for (int i=0; i<insertCount; i++) {
+                logger.info("Store attempt {} for message with id {}", i, msgId);
+                if ("".equals(msgId)) {
+                    messageStoreService.store(msg);
+                }
+                else {
+                    messageStoreService.store(msg, msgId);
+                }
+                if (waitTime>0) {
+                    synchronized (this) {
+                        this.wait(waitTime * 1000);
+                    }
+                }
+            }
+        }
+    }
+
+    @Then("I query for messages and I found {int} message(s), {int} of them with UUID as id, and store the result as {string}")
+    public void foundMessagesAndStoreAs(int messageCount, int messageUUIDCount, String messageListName) throws Exception {
+        Map<String, Integer> messages = new HashMap<>();
+        RestHighLevelClient client = null;
+        try {
+            client = new RestHighLevelClient(
+                    RestClient.builder(new HttpHost("localhost", 9200, "http")));
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().
+                    query(QueryBuilders.matchAllQuery()).
+                    size(100).
+                    version(true);
+            SearchRequest searchRequest = new SearchRequest("*-message-*").source(searchSourceBuilder);
+            SearchResponse searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
+            int messageFound = 0;
+            int messageUUIDFound = 0;
+            for (SearchHit hit : searchResponse.getHits()) {
+                if (messages.put(hit.getId(), new Integer((int)hit.getVersion())) != null) {
+                    Assert.fail("More than one message found for message id " + hit.getId());
+                }
+                messageFound++;
+                try {
+                    UUID.fromString(hit.getId());
+                    messageUUIDFound++;
+                }
+                catch (IllegalArgumentException e) {
+                    //message with id set before store call, nothing to do
+                }
+            }
+            Assert.assertEquals("Wrong total message count", messageCount, messageFound);
+            Assert.assertEquals("Wrong total message count", messageUUIDCount, messageUUIDFound);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        finally {
+            if (client!=null) {
+                client.close();
+            }
+        }
+        stepData.put(messageListName, messages);
+    }
+
+    @Then("I found a message with id {string} and version {int} from stored search {string}")
+    public void foundMessagesWithMessageIdAndVersion(String messageId, int version, String messageListName) throws Exception {
+        Map<String, Integer> messages = (Map<String, Integer>)stepData.get(messageListName);
+        messages.forEach((key, value) -> {
+            if (key.equals(messageId)) {
+                Assert.assertEquals("Wrong message version for message id " + messageId, version, value.intValue());
+            }
+        });
     }
 
     @And("I set the following metrics to the message {int} from the list {string}")


### PR DESCRIPTION
Brief description of the PR.
Remove the uniqueness check while storing telemetry message

**Related Issue**
fix https://github.com/eclipse-kapua/kapua/issues/4323

**Description of the solution adopted**
Remove the uniqueness check, add test to verify that no more than one copy with the same message id is present.
Check also the version number to verify that matches the expected message store call count

**Screenshots**
none

**Any side note on the changes made**
NO BACKPORT
