### PR TITLE
:bug: [Device management] When defining permissions for domain device_management delete action is missing

### DIFF
--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceManagementBundleModule.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceManagementBundleModule.java
@@ -39,7 +39,7 @@ public class DeviceManagementBundleModule extends AbstractKapuaModule {
 
     @ProvidesIntoSet
     public Domain deviceManagementModule() {
-        return new DomainEntry(Domains.DEVICE_MANAGEMENT, DeviceManagementService.class.getName(), false, Actions.execute, Actions.read, Actions.write);
+        return new DomainEntry(Domains.DEVICE_MANAGEMENT, DeviceManagementService.class.getName(), false, Actions.execute, Actions.read, Actions.write, Actions.delete);
     }
 
     @Provides


### PR DESCRIPTION
Brief description of the PR.
This PR adds the action `delete` to the `device_management` domain. The action is required to configure certain type of permissions. For example,  `device_management:delete` is required to delete an item from the device Key Store service. 

**Related Issue**
None

**Description of the solution adopted**
The new action has been added in domain entry setup within DeviceManagementBundleModule.

**Screenshots**
None

**Any side note on the changes made**
None
