### PR TITLE
🐛 [Authorization] Revoking a permission to a role now requires role:write in API 'DELETE {scope}/roles/{rileId}/permissions/{rolePermissionId}'

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
@@ -130,8 +130,9 @@ public class RolePermissionServiceImpl implements RolePermissionService {
         ArgumentValidator.notNull(scopeId, KapuaEntityAttributes.SCOPE_ID);
         ArgumentValidator.notNull(rolePermissionId, KapuaEntityAttributes.ENTITY_ID);
 
-        // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.ROLE, Actions.delete, scopeId));
+        if (!authorizationService.isPermitted(permissionFactory.newPermission(Domains.ROLE, Actions.write, scopeId))) {
+            authorizationService.checkPermission(permissionFactory.newPermission(Domains.ROLE, Actions.delete, scopeId)); //backward compatibility check
+        }
 
         if (KapuaId.ONE.equals(rolePermissionId)) {
             throw new KapuaException(KapuaErrorCodes.PERMISSION_DELETE_NOT_ALLOWED);


### PR DESCRIPTION
Mirror of https://github.com/eclipse-kapua/kapua/pull/4316 but with a backward-compatibility check on the previous permission for older releases