### PR TITLE
🐛 [REST API] API `GET /{scopeId}/jobs/{jobId}/steps/{stepId}` fails with 403 unauthorised when user has job:read permission

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -274,6 +274,9 @@ public class JobStepServiceImpl implements JobStepService {
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(jobStepId, "jobStepId");
         // Check Access
+        if (!authorizationService.isPermitted(permissionFactory.newPermission(Domains.JOB, Actions.read, scopeId))) {
+            authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, scopeId)); //backward compatibility check
+        }
         authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, scopeId));
         // Do find
         return txManager.execute(tx -> jobStepRepository.find(tx, scopeId, jobStepId))


### PR DESCRIPTION
The operation succeeds if the user has job:write permission, user with permission job:read should be able to get the details of a job target device (like methods query and count)

Removing the job:write in favour of job:read is a breaking change

To provide a back-ward compatible fix, this solution is implemented:

First check for job:read, if it is granted to the user allow retrieve the target

If job:read is not granted but job:write is granted to the user, allow reading the job step

Otherwise fail


NB: The old permission check is deprecated, hence it will be removed in the next minor release