### PR TITLE
🐛 [Job] API to find job target device by id fails with unauthorised when user has job:read permission

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetServiceImpl.java
@@ -118,7 +118,9 @@ public class JobTargetServiceImpl implements JobTargetService {
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(jobTargetId, "jobTargetId");
         // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, scopeId));
+        if (!authorizationService.isPermitted(permissionFactory.newPermission(Domains.JOB, Actions.read, scopeId))) {
+            authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, scopeId)); //backward compatibility check
+        }
         // Do find
         return txManager.execute(tx -> jobTargetRepository.find(tx, scopeId, jobTargetId))
                 .orElse(null);


### PR DESCRIPTION
Expected result:

User with permission job:read should be able to get the details of a job target (like methods query and count)

Additional information 

The operation succeeds if the user has job:write permission

Expected result::

Removing the job:write in favour of job:read is a breaking change that can impact integrations with existing deployments. 

To provide a back-ward compatible fix, this solution is implemented:

First check for job:read, if it is granted to the user allow retrieve the target

If job:read is not granted but job:write is granted to the user, allow reading the target

Otherwise fail