### PR TITLE
🐛 [REST API] `POST /{scopeId}/devices/{deviceId}/keystore/items/csr` fails with 403 unauthorised when user has device_management:write permission

### DIFF
--- a/service/device/management/keystore/internal/src/main/java/org/eclipse/kapua/service/device/management/keystore/internal/DeviceKeystoreManagementServiceImpl.java
+++ b/service/device/management/keystore/internal/src/main/java/org/eclipse/kapua/service/device/management/keystore/internal/DeviceKeystoreManagementServiceImpl.java
@@ -430,7 +430,9 @@ public class DeviceKeystoreManagementServiceImpl extends AbstractDeviceManagemen
         ArgumentValidator.notNull(deviceId, DEVICE_ID);
         ArgumentValidator.notNull(keystoreCSRInfo, "keystoreCSRInfo");
         // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.DEVICE_MANAGEMENT, Actions.read, scopeId));
+        if (!authorizationService.isPermitted(permissionFactory.newPermission(Domains.DEVICE_MANAGEMENT, Actions.write, scopeId))) {
+            authorizationService.checkPermission(permissionFactory.newPermission(Domains.DEVICE_MANAGEMENT, Actions.read, scopeId)); //backward compatibility check
+        }
         // Prepare the request
         KeystoreRequestChannel keystoreRequestChannel = new KeystoreRequestChannel();
         keystoreRequestChannel.setAppName(DeviceKeystoreAppProperties.APP_NAME);


### PR DESCRIPTION
Additional information 

The operation succeeds if the user has device_management:read permission

Expected result:

User with permission device_management:read shouldn’t be able to create a CSR, instead device_management:write would be the correct permission needed.

Removing the device_management:read in favour of device_management:write is a breaking change that can impact integrations with existing deployments. 

To provide a back-ward compatible fix, this solution is implemented:

First check for device_management:write, if it is granted to the user allow create the csr

If device_management:write is not granted but device_management:read is granted to the user, allow creating the csr

Otherwise fail

NB: The old permission check is deprecated, hence it will be removed in the next minor release