### PR TITLE
:bug: [Datastore] Set uniqueness check to NONE by default

### DIFF
--- a/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
@@ -61,7 +61,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="FULL"
+            default="NONE"
             description="Message uniqueness check type (on telemetry message datastore insert)">
             <Option label="NONE" value="NONE" />
             <Option label="BOUND" value="BOUND" />


### PR DESCRIPTION
Brief description of the PR.
Set the default from FULL to NONE

**Related Issue**
fix https://github.com/eclipse-kapua/kapua/issues/4323

**Description of the solution adopted**
See brief description

**Screenshots**
none

**Any side note on the changes made**
none
