### PR TITLE
:bug: [CI] Fixed permission on License Check GitHub Action

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -18,6 +18,8 @@ jobs:
   # Documentation: https://github.com/eclipse-dash/dash-licenses#reusable-github-workflow-for-automatic-license-check-and-ip-team-review-requests
   eclipse-dash-license-tool-run:
     name: Eclipse Dash License Tool
+    permissions:
+      pull-requests: write
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: iot.kapua


### PR DESCRIPTION
This PR fixes the Eclipse Dash Tool license check run on CI.
It was failing due to missing `pull_request:write` permission.

**Related Issue**
_None_

**Description of the solution adopted**
Added missing permission

**Screenshots**
_None_

**Any side note on the changes made**
_None_