### PR TITLE
⬆️  Upgraded Logback to 1.3.15

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -50,6 +50,9 @@
                 <exclude>lib/geronimo-jta_1.0.1B_spec*</exclude>
                 <exclude>lib/geronimo-jms*</exclude>
                 <exclude>lib/slf4j*</exclude> <!-- pull in version 1.7.24 -->
+                <exclude>lib/log4j-over-slf4j-*.jar</exclude>
+                <exclude>lib/log4j-core-*.jar</exclude>
+                <exclude>lib/log4j-slf4j2-impl-*.jar</exclude>
 
                 <exclude>lib/optional/activeio-core-*</exclude>
                 <exclude>lib/optional/activemq-amqp-*</exclude>
@@ -142,6 +145,7 @@
             <includes>
                 <include>ch.qos.logback:logback-core</include>
                 <include>ch.qos.logback:logback-classic</include>
+                <include>org.apache.logging.log4j:log4j-to-slf4j</include>
             </includes>
         </dependencySet>
 
@@ -154,6 +158,7 @@
             <fileMode>0644</fileMode>
             <includes>
                 <include>aopalliance:aopalliance</include>
+                <include>org.apache.logging.log4j:log4j-to-slf4j</include>
 
                 <include>com.carrotsearch:hppc</include>
                 <include>com.fasterxml.jackson.core:*</include>
@@ -205,8 +210,6 @@
                 <include>org.apache.httpcomponents:httpclient</include>
                 <include>org.apache.httpcomponents:httpcore-nio</include>
                 <include>org.apache.httpcomponents:httpcore</include>
-                <include>org.apache.logging.log4j:log4j-api</include>
-                <include>org.apache.logging.log4j:log4j-to-slf4j</include>
                 <include>org.apache.lucene:*</include>
                 <include>org.apache.qpid:proton-j</include>
                 <include>org.apache.qpid:qpid-jms-client</include>
@@ -241,8 +244,6 @@
                 <include>org.liquibase:liquibase-core</include>
                 <include>org.quartz-scheduler:quartz</include>
                 <include>org.reflections:reflections</include>
-                <include>org.slf4j:log4j-over-slf4j</include>
-                <include>org.slf4j:slf4j-api</include>
                 <include>org.springframework.security:spring-security-core</include>
                 <include>org.yaml:snakeyaml</include>
                 <include>javax.cache:cache-api</include>

--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -146,6 +146,7 @@
                 <include>ch.qos.logback:logback-core</include>
                 <include>ch.qos.logback:logback-classic</include>
                 <include>org.apache.logging.log4j:log4j-to-slf4j</include>
+                <include>org.slf4j:slf4j-api</include>
             </includes>
         </dependencySet>
 
@@ -159,6 +160,7 @@
             <includes>
                 <include>aopalliance:aopalliance</include>
                 <include>org.apache.logging.log4j:log4j-to-slf4j</include>
+                <include>org.slf4j:slf4j-api</include>
 
                 <include>com.carrotsearch:hppc</include>
                 <include>com.fasterxml.jackson.core:*</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -251,6 +251,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -247,6 +247,10 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.activemq</groupId>
@@ -429,16 +433,8 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.checkerframework</groupId>

--- a/client/gateway/pom.xml
+++ b/client/gateway/pom.xml
@@ -40,7 +40,7 @@
 
         <!-- feature packages -->
 
-        <module>features</module>
+<!--        <module>features</module>-->
 
     </modules>
 

--- a/client/gateway/pom.xml
+++ b/client/gateway/pom.xml
@@ -40,9 +40,31 @@
 
         <!-- feature packages -->
 
-<!--        <module>features</module>-->
+        <module>features</module>
 
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <scope>test</scope>
+                <version>1.2.13</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <scope>test</scope>
+                <version>1.2.13</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.36</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <junit.version>4.13.2</junit.version>
         <liquibase.version>3.6.3</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
+        <log4j-to-slf4j.version>2.24.1</log4j-to-slf4j.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
         <logback.version>1.3.15</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
         <mockito.version>1.10.19</mockito.version>
@@ -2053,7 +2054,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-to-slf4j</artifactId>
-                <version>2.24.1</version>
+                <version>${log4j-to-slf4j.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <liquibase.version>3.6.3</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
-        <logback.version>1.2.13</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
+        <logback.version>1.3.15</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
         <mockito.version>1.10.19</mockito.version>
         <netty.version>4.1.124.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
@@ -105,7 +105,7 @@
         <reflections.version>0.9.12</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.13.0</shiro.version>
-        <slf4j.version>1.7.33</slf4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <spring.version>4.3.30.RELEASE</spring.version>
@@ -2053,7 +2053,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-to-slf4j</artifactId>
-                <version>${log4j-api.version}</version>
+                <version>2.24.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Due to a conflict with Karaf dependencies it was not possible to upgrade the whole project to 1.3.x

Hence, This PR  upgraded Logback and related dependencies to 1.3.x, while keeping 1.2.x on kapua-client modules. 