### PR TITLE
 🐛 [Authorization] Changed permission needed to find a job step (maintaining old permssion check for compatibility) - errata

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -277,7 +277,6 @@ public class JobStepServiceImpl implements JobStepService {
         if (!authorizationService.isPermitted(permissionFactory.newPermission(Domains.JOB, Actions.read, scopeId))) {
             authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, scopeId)); //backward compatibility check
         }
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.JOB, Actions.write, scopeId));
         // Do find
         return txManager.execute(tx -> jobStepRepository.find(tx, scopeId, jobStepId))
                 .orElse(null);


### PR DESCRIPTION
This PR fixes a small bug on fix https://github.com/eclipse-kapua/kapua/pull/4328

**Related Issue**
#4328 

**Description of the solution adopted**
Removed the leftover checkAccess

**Screenshots**
_None_

**Any side note on the changes made**
_None_