### PR TITLE
:fix: review kapua message context content for internal and external connections and improve KapuaCamelFilter

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -258,14 +258,14 @@ public class ServerPlugin implements ActiveMQServerPlugin {
                         logger.info("Published message size over threshold. size: {} - destination: {} - account id: {} - username: {} - clientId: {}",
                                 messageSize, address, sessionContext.getAccountName(), sessionContext.getUsername(), sessionContext.getClientId());
                     }
-                    fillAdditionalMessagePropertiesExternal(message, sessionContext, address);
+                    fillAdditionalMessageProperties(message, sessionContext, address, false);
                     publishMetric.getMessageSizeAllowed().update(messageSize);
                 } else {
                     if (publishInfoMessageSizeLimit < messageSize) {
                         logger.info("Published message size over threshold. size: {} - destination: {}",
                                 messageSize, address);
                     }
-                    fillAdditionalMessagePropertiesInternal(message, sessionContext, address);
+                    fillAdditionalMessageProperties(message, sessionContext, address, true);
                     publishMetric.getMessageSizeAllowedInternal().update(messageSize);
                 }
                 serverContext.getAddressAccessTracker().update(address);
@@ -285,16 +285,6 @@ public class ServerPlugin implements ActiveMQServerPlugin {
         return originalTopic != null && originalTopic.endsWith(MISSING_TOPIC_SUFFIX);
     }
 
-    protected void fillAdditionalMessagePropertiesInternal(Message message, SessionContext sessionContext, String address) {
-        fillAdditionalMessageProperties(message, sessionContext, address, true);
-    }
-
-    protected void fillAdditionalMessagePropertiesExternal(Message message, SessionContext sessionContext, String address) {
-        fillAdditionalMessageProperties(message, sessionContext, address, false);
-        // FIX #164
-        message.putStringProperty(MessageConstants.HEADER_KAPUA_CONNECTION_ID, Base64.getEncoder().encodeToString(SerializationUtils.serialize(sessionContext.getKapuaConnectionId())));
-    }
-
     protected void fillAdditionalMessageProperties(Message message, SessionContext sessionContext, String address, boolean kapuaBrokerContext) {
         message.putStringProperty(MessageConstants.HEADER_KAPUA_CLIENT_ID, sessionContext.getClientId());
         message.putStringProperty(MessageConstants.HEADER_KAPUA_CONNECTOR_NAME, sessionContext.getConnectorName());
@@ -303,6 +293,13 @@ public class ServerPlugin implements ActiveMQServerPlugin {
         message.putStringProperty(MessageConstants.HEADER_KAPUA_MESSAGE_TYPE, getMessageType(address));
         message.putStringProperty(MessageConstants.PROPERTY_ORIGINAL_TOPIC, address);
         message.putBooleanProperty(MessageConstants.HEADER_KAPUA_BROKER_CONTEXT, kapuaBrokerContext);
+        // FIX #164
+        if (sessionContext.getKapuaConnectionId()==null) {
+            message.putStringProperty(MessageConstants.HEADER_KAPUA_CONNECTION_ID, Base64.getEncoder().encodeToString(SerializationUtils.serialize(KapuaId.ANY)));
+        }
+        else {
+            message.putStringProperty(MessageConstants.HEADER_KAPUA_CONNECTION_ID, Base64.getEncoder().encodeToString(SerializationUtils.serialize(sessionContext.getKapuaConnectionId())));
+        }
     }
 
     protected String getMessageType(String address) {

--- a/service/camel/src/main/java/org/eclipse/kapua/service/camel/application/MetricsCamel.java
+++ b/service/camel/src/main/java/org/eclipse/kapua/service/camel/application/MetricsCamel.java
@@ -34,9 +34,11 @@ public class MetricsCamel {
 
     //failure processor
     public static final String GENERIC = "generic";
+    public static final String RESTORE_CAMEL_SESSION = "restore_camel_session";
     public static final String UNAUTHENTICATED = "unauthenticated";
     private Counter unauthenticatedError;
     private Counter genericError;
+    private Counter restoreCamelSessionError;
 
     @Inject
     private MetricsCamel(MetricsService metricsService,
@@ -55,6 +57,7 @@ public class MetricsCamel {
 
         unauthenticatedError = metricsService.getCounter(metricModuleName, MetricsLabel.FAILURE, UNAUTHENTICATED);
         genericError = metricsService.getCounter(metricModuleName, MetricsLabel.FAILURE, GENERIC);
+        restoreCamelSessionError = metricsService.getCounter(metricModuleName, MetricsLabel.FAILURE, RESTORE_CAMEL_SESSION);
     }
 
     public Counter getErrorStoredToFileSuccess() {
@@ -79,5 +82,9 @@ public class MetricsCamel {
 
     public Counter getGenericError() {
         return genericError;
+    }
+
+    public Counter getRestoreCamelSessionError() {
+        return restoreCamelSessionError;
     }
 }

--- a/service/camel/src/main/java/org/eclipse/kapua/service/camel/converter/KapuaCamelFilter.java
+++ b/service/camel/src/main/java/org/eclipse/kapua/service/camel/converter/KapuaCamelFilter.java
@@ -13,12 +13,15 @@
 package org.eclipse.kapua.service.camel.converter;
 
 import org.apache.camel.Exchange;
+import org.apache.camel.TypeConversionException;
 import org.apache.commons.lang.SerializationException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.shiro.util.ThreadContext;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.camel.application.MetricsCamel;
 import org.eclipse.kapua.service.client.message.MessageConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +35,12 @@ public class KapuaCamelFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(KapuaCamelFilter.class);
 
+    private final MetricsCamel metricsCamel;
+
+    public KapuaCamelFilter() {
+        metricsCamel = KapuaLocator.getInstance().getComponent(MetricsCamel.class);
+    }
+
     /**
      * Bind the Kapua session retrieved from the message header (with key {@link MessageConstants#HEADER_KAPUA_SESSION}) to the current thread context.
      *
@@ -40,18 +49,23 @@ public class KapuaCamelFilter {
      * @throws KapuaException
      */
     public void bindSession(Exchange exchange, Object value) throws KapuaException {
-        logger.info("message from: {}", exchange.getIn().getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class));
         ThreadContext.unbindSubject();
-        if (Boolean.FALSE.equals(exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_BROKER_CONTEXT, boolean.class))) {
-            try {
-                // FIX #164
-                String kapuaSession = exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_SESSION, String.class);
-                //no null check (see telemetry consumer camel.xml - bind/unbind of the kapua session)
-                KapuaSecurityUtils.setSession((KapuaSession) SerializationUtils.deserialize(Base64.getDecoder().decode(kapuaSession)));
-            } catch (IllegalArgumentException | SerializationException e) {
-                // continue without session
-                logger.debug("Cannot restore Kapua session: {}", e.getMessage(), e);
-            }
+        try {
+            // FIX #164
+            //no null check (see telemetry consumer camel.xml - bind/unbind of the kapua session)
+            KapuaSecurityUtils.setSession(
+                (KapuaSession) SerializationUtils.deserialize(
+                    Base64.getDecoder().decode(
+                        exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_SESSION, String.class))));
+        } catch (
+                TypeConversionException | IllegalArgumentException | NullPointerException | SerializationException e) {
+            metricsCamel.getRestoreCamelSessionError().inc();
+            // continue without session
+            logger.warn("Cannot restore Kapua session for message from: '{}' - client id: '{}'. Error: {}",
+                exchange.getIn().getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class),
+                exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_CLIENT_ID, String.class),
+                e.getMessage());
+            logger.debug("", e);
         }
     }
 

--- a/service/client/src/main/java/org/eclipse/kapua/service/client/message/MessageConstants.java
+++ b/service/client/src/main/java/org/eclipse/kapua/service/client/message/MessageConstants.java
@@ -23,10 +23,6 @@ public class MessageConstants {
     }
 
     public static final String PROPERTY_ORIGINAL_TOPIC = "originalTopic";
-    public static final String PROPERTY_ENQUEUED_TIMESTAMP = "enqueuedTimestamp";
-    public static final String PROPERTY_BROKER_ID = "brokerId";
-    public static final String PROPERTY_CLIENT_ID = "clientId";
-    public static final String PROPERTY_SCOPE_ID = "scopeId";
 
     public static final String HEADER_KAPUA_CONNECTION_ID = "KAPUA_CONNECTION_ID";
     public static final String HEADER_KAPUA_RECEIVED_TIMESTAMP = "KAPUA_RECEIVED_TIMESTAMP";


### PR DESCRIPTION
Brief description of the PR.
There is an issue when a message, sent by an admin user, is processed on route side.
The KapuaCamelFilter is not able to restore the session (because the message is flagged as coming from a broker internal connection), so the massage is processed by the right consumer, but without a valid message context session.
The result is not predictable but, for sure, an exception is thrown somewhere along one of the route steps.

**Related Issue**
none

**Description of the solution adopted**
Add session context for all the connections type and try to deserialize it, in any case, in KapuaCamelFilter

**Screenshots**
none

**Any side note on the changes made**
none