### PR TITLE
⬆️  Upgraded jose4j to 0.9.6 - CVE-2024-29371 CVE-2023-31582 CVE-2023-51775

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <jetty.version>9.4.58.v20250814</jetty.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
-        <jose4j.version>0.7.10</jose4j.version>
+        <jose4j.version>0.9.6</jose4j.version>
         <junit.version>4.13.2</junit.version>
         <jupiter.version>5.9.2</jupiter.version>
         <liquibase.version>3.6.3</liquibase.version>


### PR DESCRIPTION
Upgraded jose4j version to 0.9.6 to address component CVEs:

- CVE-2024-29371 
- CVE-2023-31582 
- CVE-2023-51775