### PR TITLE
:sparkles: [Device Management] Extended device management to handle container images resources

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventory.java
@@ -46,6 +46,7 @@ public class DeviceTabInventory extends KapuaTabItem<GwtDevice> {
     private DeviceTabInventoryTabBundles inventoryBundlesTab;
     private DeviceTabInventoryTabContainer inventoryContainerTab;
     private DeviceTabInventoryTabSystemPackages inventorySystemPackagesTab;
+    private DeviceTabInventoryTabImage inventoryTabImage;
     private DeviceTabInventoryTabDeploymentPackages inventoryDeploymentPackageTab;
 
 
@@ -149,6 +150,19 @@ public class DeviceTabInventory extends KapuaTabItem<GwtDevice> {
             }
         });
         tabsPanel.add(inventoryContainerTab);
+        // Images Sub-tab
+        inventoryTabImage = new DeviceTabInventoryTabImage(this);
+        inventoryTabImage.setBorders(false);
+        inventoryTabImage.setLayout(new FitLayout());
+        inventoryTabImage.addListener(Events.Select, new Listener<ComponentEvent>() {
+
+            @Override
+            public void handleEvent(ComponentEvent be) {
+                setEntity(selectedEntity);
+                refresh();
+            }
+        });
+        tabsPanel.add(inventoryTabImage);
         // System Packages Sub-tab
         inventorySystemPackagesTab = new DeviceTabInventoryTabSystemPackages(this);
         inventorySystemPackagesTab.setBorders(false);
@@ -197,6 +211,10 @@ public class DeviceTabInventory extends KapuaTabItem<GwtDevice> {
 
             if (tabsPanel.getSelectedItem().equals(inventoryContainerTab)) {
                 inventoryContainerTab.refresh();
+            }
+
+            if (tabsPanel.getSelectedItem().equals(inventoryTabImage)) {
+                inventoryTabImage.refresh();
             }
 
             if (tabsPanel.getSelectedItem().equals(inventorySystemPackagesTab)) {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventoryTabImage.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventoryTabImage.java
@@ -1,0 +1,250 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.client.device.inventory;
+
+import com.extjs.gxt.ui.client.data.BaseListLoader;
+import com.extjs.gxt.ui.client.data.ListLoadResult;
+import com.extjs.gxt.ui.client.data.ListLoader;
+import com.extjs.gxt.ui.client.data.LoadEvent;
+import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
+import com.extjs.gxt.ui.client.event.SelectionChangedListener;
+import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.ContentPanel;
+import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
+import com.extjs.gxt.ui.client.widget.grid.ColumnModel;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.layout.FitLayout;
+import com.extjs.gxt.ui.client.widget.toolbar.ToolBar;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.extjs.gxt.ui.client.widget.button.Button;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog;
+import org.eclipse.kapua.app.console.module.api.client.ui.tab.TabItem;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaLoadListener;
+import org.eclipse.kapua.app.console.module.device.client.device.inventory.buttons.ImageDeleteButton;
+import org.eclipse.kapua.app.console.module.device.client.device.inventory.dialog.InventoryImageDeleteDialog;
+import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
+import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryImage;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceInventoryManagementService;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceInventoryManagementServiceAsync;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeviceTabInventoryTabImage extends TabItem {
+
+    private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
+    private static final ConsoleDeviceMessages DEVICE_MSGS = GWT.create(ConsoleDeviceMessages.class);
+
+    private static final GwtDeviceInventoryManagementServiceAsync GWT_DEVICE_INVENTORY_MANAGEMENT_SERVICE = GWT.create(GwtDeviceInventoryManagementService.class);
+
+    private boolean componentInitialized;
+    private boolean dirty = true;
+
+    private DeviceTabInventory parentTabPanel;
+    private Grid<GwtInventoryImage> grid;
+    private ListLoader<ListLoadResult<GwtInventoryImage>> storeLoader;
+
+    Button deleteButton;
+    Button refreshButton;
+
+    public DeviceTabInventoryTabImage(DeviceTabInventory parentTabPanel) {
+        super("Images", new KapuaIcon(IconSet.TH));
+
+        this.parentTabPanel = parentTabPanel;
+    }
+
+    private GwtDevice getSelectedDevice() {
+        return parentTabPanel.getSelectedDevice();
+    }
+
+    public void setDirty(boolean isDirty) {
+        dirty = isDirty;
+    }
+
+    @Override
+    protected void onRender(Element parent, int index) {
+        super.onRender(parent, index);
+        // Column Configuration
+        List<ColumnConfig> configs = new ArrayList<ColumnConfig>();
+
+        ColumnConfig column = new ColumnConfig();
+        column.setId("name");
+        column.setHeader("Name");
+        column.setWidth(100);
+        configs.add(column);
+
+        column = new ColumnConfig();
+        column.setId("version");
+        column.setHeader("Version");
+        column.setWidth(80);
+        configs.add(column);
+
+        column = new ColumnConfig();
+        column.setId("type");
+        column.setHeader("Type");
+        column.setWidth(80);
+        configs.add(column);
+
+        ColumnModel columnModel = new ColumnModel(configs);
+
+        RpcProxy<ListLoadResult<GwtInventoryImage>> proxy = new RpcProxy<ListLoadResult<GwtInventoryImage>>() {
+
+            @Override
+            protected void load(Object loadConfig, AsyncCallback<ListLoadResult<GwtInventoryImage>> callback) {
+                GWT_DEVICE_INVENTORY_MANAGEMENT_SERVICE.findDeviceImages(getSelectedDevice().getScopeId(),
+                        getSelectedDevice().getId(),
+                        callback);
+            }
+        };
+
+        storeLoader = new BaseListLoader<ListLoadResult<GwtInventoryImage>>(proxy);
+        storeLoader.addLoadListener(new DeviceTabInventoryTabImage.InventoryImagesLoadListener());
+
+        ListStore<GwtInventoryImage> store = new ListStore<GwtInventoryImage>(storeLoader);
+
+        grid = new Grid<GwtInventoryImage>(store, columnModel);
+        grid.setBorders(false);
+        grid.setStateful(false);
+        grid.setLoadMask(true);
+        grid.setStripeRows(true);
+        grid.setTrackMouseOver(false);
+        grid.disableTextSelection(false);
+        grid.setAutoExpandColumn("name");
+        grid.getView().setAutoFill(true);
+        grid.getView().setEmptyText("No images found...");
+
+        grid.getSelectionModel().addSelectionChangedListener(new SelectionChangedListener<GwtInventoryImage>() {
+            @Override
+            public void selectionChanged(SelectionChangedEvent<GwtInventoryImage> selectionChangedEvent) {
+                checkButtonEnablement();
+            }
+        });
+
+        // Delete Button
+        deleteButton = new ImageDeleteButton(new SelectionListener<ButtonEvent>() {
+            @Override
+            public void componentSelected(ButtonEvent buttonEvent) {
+                final InventoryImageDeleteDialog imageDeleteDialog = new InventoryImageDeleteDialog(getSelectedDevice(), grid.getSelectionModel().getSelectedItem());
+
+                imageDeleteDialog.addListener(Events.Hide, new Listener<BaseEvent>() {
+                    @Override
+                    public void handleEvent(BaseEvent baseEvent) {
+                        if (imageDeleteDialog.getExitStatus() != null) {
+                            String exitMessage = imageDeleteDialog.getExitMessage();
+                            ConsoleInfo.display(imageDeleteDialog.getExitStatus() ? MSGS.information() : MSGS.error(), exitMessage);
+                        }
+                        setDirty(true);
+                        refresh();
+                    }
+                });
+
+                imageDeleteDialog.show();
+            }
+        });
+
+        // Refresh Button
+        refreshButton = new RefreshButton(new SelectionListener<ButtonEvent>() {
+
+            @Override
+            public void componentSelected(ButtonEvent ce) {
+                if (getSelectedDevice() != null && getSelectedDevice().isOnline()) {
+                    setDirty(true);
+                    refresh();
+                } else {
+                    openDeviceOfflineAlertDialog();
+                }
+            }
+        });
+
+        ToolBar toolBar = new ToolBar();
+        toolBar.setBorders(true);
+        toolBar.add(deleteButton);
+        toolBar.add(refreshButton);
+
+        checkButtonEnablement();
+
+        ContentPanel rootContentPanel = new ContentPanel();
+        rootContentPanel.setLayout(new FitLayout());
+        rootContentPanel.setBorders(false);
+        rootContentPanel.setBodyBorder(false);
+        rootContentPanel.setHeaderVisible(false);
+        rootContentPanel.add(grid);
+        rootContentPanel.setTopComponent(toolBar);
+
+        add(rootContentPanel);
+
+        componentInitialized = true;
+    }
+
+    private void checkButtonEnablement() {
+        GwtInventoryImage selectedImage = grid.getSelectionModel().getSelectedItem();
+
+        deleteButton.setEnabled(getSelectedDevice() != null && getSelectedDevice().isOnline() && selectedImage != null);
+        refreshButton.setEnabled(getSelectedDevice() != null && getSelectedDevice().isOnline());
+    }
+
+    public void refresh() {
+        if (dirty && componentInitialized) {
+
+            if (getSelectedDevice() == null) {
+                grid.getView().setEmptyText(DEVICE_MSGS.deviceNoDeviceSelectedOrOffline());
+            } else {
+                storeLoader.load();
+            }
+
+            dirty = false;
+        }
+    }
+
+    public void openDeviceOfflineAlertDialog() {
+        InfoDialog errorDialog = new InfoDialog(InfoDialog.InfoDialogType.INFO, DEVICE_MSGS.deviceOffline());
+        errorDialog.show();
+    }
+
+    private class InventoryImagesLoadListener extends KapuaLoadListener {
+
+        @Override
+        public void loaderLoadException(LoadEvent le) {
+            grid.unmask();
+
+            Throwable loaderException = le.exception;
+
+            if (loaderException != null) {
+
+                if (loaderException instanceof GwtKapuaException &&
+                        ((GwtKapuaException) loaderException).getCode().equals(GwtKapuaErrorCode.DEVICE_MANAGEMENT_RESPONSE_NOT_FOUND)) {
+                    ConsoleInfo.display(MSGS.error(), "The 'images' resource is not supported by this device!");
+                } else {
+                    FailureHandler.handle(le.exception);
+                }
+            }
+        }
+    }
+}

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/buttons/ImageDeleteButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/buttons/ImageDeleteButton.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.client.device.inventory.buttons;
+
+import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.SelectionListener;
+import org.eclipse.kapua.app.console.module.api.client.ui.button.DeleteButton;
+
+public class ImageDeleteButton extends DeleteButton {
+
+    public ImageDeleteButton(SelectionListener<ButtonEvent> listener) {
+        super(listener);
+    }
+
+}

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/dialog/InventoryImageDeleteDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/dialog/InventoryImageDeleteDialog.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.client.device.inventory.dialog;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityDeleteDialog;
+import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryImage;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceInventoryManagementService;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceInventoryManagementServiceAsync;
+
+public class InventoryImageDeleteDialog extends EntityDeleteDialog {
+
+    private static final GwtDeviceInventoryManagementServiceAsync GWT_DEVICE_INVENTORY_MANAGEMENT_SERVICE = GWT.create(GwtDeviceInventoryManagementService.class);
+
+    private GwtDevice gwtDevice;
+    private GwtInventoryImage gwtInventoryImage;
+
+    public InventoryImageDeleteDialog(GwtDevice gwtDevice, GwtInventoryImage gwtInventoryImage) {
+        this.gwtDevice = gwtDevice;
+        this.gwtInventoryImage = gwtInventoryImage;
+
+        DialogUtils.resizeDialog(this, 300, 120);
+    }
+
+    @Override
+    public String getHeaderMessage() {
+        return "Delete inventory image: " + gwtInventoryImage.getName();
+    }
+
+    @Override
+    public String getInfoMessage() {
+        return "Are you sure to delete image item? If used by a container (even a stopped one) it will not be deleted on the device.";
+    }
+
+    @Override
+    public void submit() {
+        GWT_DEVICE_INVENTORY_MANAGEMENT_SERVICE.deleteDeviceImage(xsrfToken,
+                gwtDevice.getScopeId(),
+                gwtDevice.getId(),
+                gwtInventoryImage,
+                new AsyncCallback<Void>() {
+
+                    @Override
+                    public void onSuccess(Void arg0) {
+                        exitStatus = true;
+                        exitMessage = "Image deleted!";
+                        hide();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable cause) {
+                        exitStatus = false;
+                        exitMessage = "Error while deleting image: " + cause.getMessage();
+                        hide();
+                    }
+                });
+    }
+}

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceInventoryManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceInventoryManagementServiceImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryBundle;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryContainer;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryDeploymentPackage;
+import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryImage;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryItem;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventorySystemPackage;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceInventoryManagementService;
@@ -37,6 +38,8 @@ import org.eclipse.kapua.service.device.management.inventory.model.container.Dev
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerState;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackage;
@@ -161,6 +164,55 @@ public class GwtDeviceInventoryManagementServiceImpl extends KapuaRemoteServiceS
             }
 
             return new BaseListLoadResult<GwtInventoryContainer>(gwtInventoryContainers);
+        } catch (Exception exception) {
+            throw KapuaExceptionHandler.buildExceptionFromError(exception);
+        }
+    }
+
+    @Override
+    public ListLoadResult<GwtInventoryImage> findDeviceImages(String scopeIdString, String deviceIdString)
+            throws GwtKapuaException {
+        try {
+            KapuaId scopeId = KapuaEid.parseCompactId(scopeIdString);
+            KapuaId deviceId = KapuaEid.parseCompactId(deviceIdString);
+
+            DeviceInventoryImages inventoryImages = DEVICE_INVENTORY_MANAGEMENT_SERVICE.getImages(scopeId, deviceId, null);
+
+            List<GwtInventoryImage> gwtInventoryImages = new ArrayList<GwtInventoryImage>();
+            for (DeviceInventoryImage inventoryImage : inventoryImages.getInventoryImages()) {
+                GwtInventoryImage gwtInventoryImage = new GwtInventoryImage();
+                gwtInventoryImage.setName(inventoryImage.getName().isEmpty() ? "<none>" : inventoryImage.getName());
+                gwtInventoryImage.setVersion(inventoryImage.getVersion().isEmpty() ? "<none>" : inventoryImage.getVersion());
+                gwtInventoryImage.setType(inventoryImage.getImageType());
+
+                gwtInventoryImages.add(gwtInventoryImage);
+            }
+
+            return new BaseListLoadResult<GwtInventoryImage>(gwtInventoryImages);
+        } catch (Exception exception) {
+            throw KapuaExceptionHandler.buildExceptionFromError(exception);
+        }
+    }
+
+    public void deleteDeviceImage(GwtXSRFToken xsrfToken, String scopeIdString, String deviceIdString, GwtInventoryImage gwtInventoryImage)
+            throws GwtKapuaException {
+        checkXSRFToken(xsrfToken);
+
+        try {
+            KapuaId scopeId = KapuaEid.parseCompactId(scopeIdString);
+            KapuaId deviceId = KapuaEid.parseCompactId(deviceIdString);
+
+            DeviceInventoryImage deviceInventoryImage = DEVICE_INVENTORY_MANAGEMENT_FACTORY.newDeviceInventoryImage();
+            deviceInventoryImage.setName(gwtInventoryImage.getName().equals("&lt;none&gt;") ? "" : gwtInventoryImage.getName()); //I use "&lt;none&gt;" in the GWT model to represent the '<' and '>' characters
+            deviceInventoryImage.setVersion(gwtInventoryImage.getVersion().equals("&lt;none&gt;") ? "" : gwtInventoryImage.getVersion()); //I use "&lt;none&gt;" in the GWT model to represent the '<' and '>' characters
+            deviceInventoryImage.setImageType(gwtInventoryImage.getType());
+
+            DEVICE_INVENTORY_MANAGEMENT_SERVICE.deleteImage(
+                    scopeId,
+                    deviceId,
+                    deviceInventoryImage,
+                    null);
+
         } catch (Exception exception) {
             throw KapuaExceptionHandler.buildExceptionFromError(exception);
         }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/management/inventory/GwtInventoryImage.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/management/inventory/GwtInventoryImage.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.shared.model.management.inventory;
+
+import org.eclipse.kapua.app.console.module.api.shared.model.KapuaBaseModel;
+
+public class GwtInventoryImage extends KapuaBaseModel {
+
+    private static final long serialVersionUID = -4437969268565872654L;
+
+    public void setName(String name) {
+        set("name", name);
+    }
+
+    public String getName() {
+        return get("name");
+    }
+
+    public void setVersion(String version) {
+        set("version", version);
+    }
+
+    public String getVersion() {
+        return get("version");
+    }
+
+    public void setType(String type) {
+        set("type", type);
+    }
+
+    public String getType() {
+        return get("type");
+    }
+}

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceInventoryManagementService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceInventoryManagementService.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryBundle;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryContainer;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryDeploymentPackage;
+import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryImage;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventoryItem;
 import org.eclipse.kapua.app.console.module.device.shared.model.management.inventory.GwtInventorySystemPackage;
 
@@ -41,6 +42,12 @@ public interface GwtDeviceInventoryManagementService extends RemoteService {
             throws GwtKapuaException;
 
     ListLoadResult<GwtInventoryContainer> findDeviceContainers(String scopeIdString, String deviceIdString)
+            throws GwtKapuaException;
+
+    ListLoadResult<GwtInventoryImage> findDeviceImages(String scopeIdString, String deviceIdString)
+            throws GwtKapuaException;
+
+    void deleteDeviceImage(GwtXSRFToken xsrfToken, String scopeIdString, String deviceIdString, GwtInventoryImage gwtInventoryImage)
             throws GwtKapuaException;
 
     void execDeviceContainer(GwtXSRFToken xsrfToken, String scopeIdString, String deviceIdString, GwtInventoryContainer gwtInventoryContainer, boolean startOrStop)

--- a/console/web/src/main/java/org/eclipse/kapua/app/console/ConsoleJAXBContextProvider.java
+++ b/console/web/src/main/java/org/eclipse/kapua/app/console/ConsoleJAXBContextProvider.java
@@ -60,6 +60,8 @@ import org.eclipse.kapua.service.device.call.kura.model.inventory.bundles.KuraIn
 import org.eclipse.kapua.service.device.call.kura.model.inventory.bundles.KuraInventoryBundles;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.containers.KuraInventoryContainer;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.containers.KuraInventoryContainers;
+import org.eclipse.kapua.service.device.call.kura.model.inventory.images.KuraInventoryImage;
+import org.eclipse.kapua.service.device.call.kura.model.inventory.images.KuraInventoryImages;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.packages.KuraInventoryPackage;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.packages.KuraInventoryPackages;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.system.KuraInventorySystemPackage;
@@ -77,6 +79,8 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundles;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryXmlRegistry;
@@ -167,6 +171,10 @@ public class ConsoleJAXBContextProvider implements JAXBContextProvider {
                         DeviceInventoryContainer.class,
                         KuraInventoryContainers.class,
                         KuraInventoryContainer.class,
+                        DeviceInventoryImages.class,
+                        DeviceInventoryImage.class,
+                        KuraInventoryImages.class,
+                        KuraInventoryImage.class,
                         DeviceInventoryPackages.class,
                         DeviceInventoryPackage.class,
                         KuraInventoryPackages.class,

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestJAXBContextProvider.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestJAXBContextProvider.java
@@ -59,6 +59,8 @@ import org.eclipse.kapua.service.device.call.kura.model.inventory.bundles.KuraIn
 import org.eclipse.kapua.service.device.call.kura.model.inventory.bundles.KuraInventoryBundles;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.containers.KuraInventoryContainer;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.containers.KuraInventoryContainers;
+import org.eclipse.kapua.service.device.call.kura.model.inventory.images.KuraInventoryImage;
+import org.eclipse.kapua.service.device.call.kura.model.inventory.images.KuraInventoryImages;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.packages.KuraInventoryPackage;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.packages.KuraInventoryPackages;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.system.KuraInventorySystemPackage;
@@ -75,6 +77,8 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundles;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryXmlRegistry;
@@ -172,6 +176,10 @@ public class TestJAXBContextProvider implements JAXBContextProvider {
                     DeviceInventoryContainer.class,
                     KuraInventoryContainers.class,
                     KuraInventoryContainer.class,
+                    DeviceInventoryImages.class,
+                    DeviceInventoryImage.class,
+                    KuraInventoryImage.class,
+                    KuraInventoryImages.class,
                     DeviceInventoryPackages.class,
                     DeviceInventoryPackage.class,
                     KuraInventoryPackages.class,

--- a/qa/integration/src/test/resources/features/deviceManagement/DeviceManagementInventoryI9n.feature
+++ b/qa/integration/src/test/resources/features/deviceManagement/DeviceManagementInventoryI9n.feature
@@ -197,6 +197,28 @@ Feature: Device Management Inventory Service Tests
     Then KuraMock is disconnected
     And I logout
 
+  Scenario: Request Inventory Images to a Device
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I start the Kura Mock
+    And Device is connected within 10 seconds
+    And Device status is "CONNECTED" within 10 seconds
+    And I select account "kapua-sys"
+    And I get the KuraMock device after 5 seconds
+    And Inventory Images are requested
+    And Inventory Images are received
+    And Inventory Images are 3
+    And Inventory Images has Image named "nginx" is present
+    And Inventory Images has Image named "nginx" has version "latest"
+    And Inventory Images has Image named "nginx" has type "CONTAINER_IMAGE"
+    And Inventory Images has Image named "alpine" is present
+    And Inventory Images has Image named "alpine" has version "latest"
+    And Inventory Images has Image named "alpine" has type "CONTAINER_IMAGE"
+    Then I delete Inventory Image named "nginx"
+    And No exception was thrown
+    Then KuraMock is disconnected
+    And I logout
+
   Scenario: Request Inventory System Packages to a Device
 
     Given I login as user with name "kapua-sys" and password "kapua-password"

--- a/qa/integration/src/test/resources/mqtt/INVENTORY-V1_GET_inventory_images_reply.json
+++ b/qa/integration/src/test/resources/mqtt/INVENTORY-V1_GET_inventory_images_reply.json
@@ -1,0 +1,19 @@
+{
+  "images": [
+    {
+      "name": "nginx",
+      "version": "latest",
+      "type": "CONTAINER_IMAGE"
+    },
+    {
+      "name": "alpine",
+      "version": "latest",
+      "type": "CONTAINER_IMAGE"
+    },
+    {
+      "name": "redis",
+      "version": "latest",
+      "type": "CONTAINER_IMAGE"
+    }
+  ]
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementInventory.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementInventory.java
@@ -24,6 +24,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
 import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackages;
@@ -31,6 +32,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.system.Device
 import org.eclipse.kapua.service.device.registry.Device;
 
 import javax.inject.Inject;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -174,6 +176,30 @@ public class DeviceManagementInventory extends AbstractKapuaResource {
             @PathParam("deviceId") EntityId deviceId,
             @QueryParam("timeout") @DefaultValue("30000") Long timeout) throws KapuaException {
         return deviceInventoryManagementService.getImages(scopeId, deviceId, timeout);
+    }
+
+    /**
+     * Deletes a {@link DeviceInventoryImage} present on the {@link Device}.
+     *
+     * @param scopeId                  The {@link Device#getScopeId()}.
+     * @param deviceId                 The {@link Device#getId()}.
+     * @param deviceInventoryImage The {@link DeviceInventoryContainer} to delete.
+     * @param timeout                  The timeout of the operation in milliseconds
+     * @return The {@link Response#noContent()} if succeeded.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 2.0.0
+     */
+    @DELETE
+    @Path("images/_delete")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public Response deleteInventoryImage(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("deviceId") EntityId deviceId,
+            @QueryParam("timeout") @DefaultValue("30000") Long timeout,
+            DeviceInventoryImage deviceInventoryImage) throws KapuaException {
+        deviceInventoryManagementService.deleteImage(scopeId, deviceId, deviceInventoryImage, timeout);
+
+        return returnNoContent();
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementInventory.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementInventory.java
@@ -24,6 +24,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackages;
 import org.eclipse.kapua.service.device.management.inventory.model.system.DeviceInventorySystemPackages;
@@ -153,6 +154,26 @@ public class DeviceManagementInventory extends AbstractKapuaResource {
             @PathParam("deviceId") EntityId deviceId,
             @QueryParam("timeout") @DefaultValue("30000") Long timeout) throws KapuaException {
         return deviceInventoryManagementService.getContainers(scopeId, deviceId, timeout);
+    }
+
+    /**
+     * Gets the {@link DeviceInventoryImages} present on the {@link Device}.
+     *
+     * @param scopeId  The {@link Device#getScopeId()}.
+     * @param deviceId The {@link Device#getId()}.
+     * @param timeout  The timeout of the operation in milliseconds
+     * @return The {@link DeviceInventoryImages}.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 2.0.0
+     */
+    @GET
+    @Path("images")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public DeviceInventoryImages getInventoryImages(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("deviceId") EntityId deviceId,
+            @QueryParam("timeout") @DefaultValue("30000") Long timeout) throws KapuaException {
+        return deviceInventoryManagementService.getImages(scopeId, deviceId, timeout);
     }
 
     /**

--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
@@ -149,6 +149,34 @@ paths:
           $ref: '../openapi.yaml#/components/responses/entityNotFound'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
+  /{scopeId}/devices/{deviceId}/inventory/images/_delete:
+    delete:
+      tags:
+        - Device Management - Inventory
+      summary: Delete an image in a Device
+      operationId: deviceInventoryImageDelete
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../device/device.yaml#/components/parameters/timeout'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: './deviceInventory.yaml#/components/schemas/deviceInventoryImage'
+      responses:
+        204:
+          description: The inventory image has been removed
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
   /{scopeId}/devices/{deviceId}/inventory/containers:
     get:
       tags:

--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
@@ -122,6 +122,33 @@ paths:
           $ref: '../openapi.yaml#/components/responses/entityNotFound'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
+  /{scopeId}/devices/{deviceId}/inventory/images:
+    get:
+      tags:
+        - Device Management - Inventory
+      summary: Get the inventory images from a single Device
+      operationId: deviceInventoryImageGet
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../device/device.yaml#/components/parameters/timeout'
+      responses:
+        200:
+          description: The inventory image from the Device
+          content:
+            application/json:
+              schema:
+                $ref: './deviceInventory.yaml#/components/schemas/deviceInventoryImages'
+        400:
+          $ref: '../openapi.yaml#/components/responses/illegalArgument'
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
   /{scopeId}/devices/{deviceId}/inventory/containers:
     get:
       tags:

--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory.yaml
@@ -123,6 +123,35 @@ components:
             version: haproxy:latest
             containerType: DOCKER
             state: INSTALLED
+    deviceInventoryImage:
+      type: object
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+        imageType:
+          type: string
+      example:
+        name: nginx
+        version: latest
+        imageType: CONTAINER_IMAGE
+    deviceInventoryImages:
+      type: object
+      properties:
+        inventoryImages:
+          type: array
+          items:
+            $ref: '#/components/schemas/deviceInventoryImage'
+      example:
+        type: deviceInventoryImages
+        inventoryImages:
+          - name: nginx
+            version: latest
+            imageType: CONTAINER_IMAGE
+          - name: alpine
+            version: latest
+            imageType: CONTAINER_IMAGE
     deviceInventorySystemPackage:
       type: object
       properties:

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -197,6 +197,8 @@ paths:
     $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory~1containers'
   /{scopeId}/devices/{deviceId}/inventory/images:
     $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory~1images'
+  /{scopeId}/devices/{deviceId}/inventory/images/_delete:
+    $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory~1images~1_delete'
   /{scopeId}/devices/{deviceId}/inventory/containers/_start:
     $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory~1containers~1_start'
   /{scopeId}/devices/{deviceId}/inventory/containers/_stop:

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -195,6 +195,8 @@ paths:
     $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory~1bundles~1_stop'
   /{scopeId}/devices/{deviceId}/inventory/containers:
     $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory~1containers'
+  /{scopeId}/devices/{deviceId}/inventory/images:
+    $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory~1images'
   /{scopeId}/devices/{deviceId}/inventory/containers/_start:
     $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory~1containers~1_start'
   /{scopeId}/devices/{deviceId}/inventory/containers/_stop:
@@ -996,6 +998,10 @@ components:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryContainer'
     deviceInventoryContainers:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryContainers'
+    deviceInventoryImage:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryImage'
+    deviceInventoryImages:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryImages'
     deviceInventoryPackage:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventorySystemPackage'
     deviceInventoryPackages:

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/inventory/images/KuraInventoryImage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/inventory/images/KuraInventoryImage.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.call.kura.model.inventory.images;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+/**
+ * {@link KuraInventoryImage} definition.
+ *
+ * @since 2.0.0
+ */
+@JsonRootName("image")
+public class KuraInventoryImage {
+
+    @JsonProperty("name")
+    public String name;
+
+    @JsonProperty("version")
+    public String version;
+
+    @JsonProperty("type")
+    public String type;
+
+    /**
+     * Gets the name.
+     *
+     * @return The name.
+     * @since 2.0.0
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name.
+     *
+     * @param name The name.
+     * @since 2.0.0
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the version.
+     *
+     * @return The version.
+     * @since 2.0.0
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Gets the version.
+     *
+     * @param version The version.
+     * @since 2.0.0
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Gets the type.
+     *
+     * @return The type.
+     * @since 2.0.0
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets the type.
+     *
+     * @param type The type.
+     * @since 2.0.0
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/inventory/images/KuraInventoryImages.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/inventory/images/KuraInventoryImages.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.call.kura.model.inventory.images;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link KuraInventoryImages} definition.
+ *
+ * @since 2.0.0
+ */
+@JsonRootName("inventoryImages")
+public class KuraInventoryImages {
+
+    @JsonProperty("images")
+    public List<KuraInventoryImage> inventoryImages;
+
+    /**
+     * Gets the {@link KuraInventoryImage}s {@link List}.
+     *
+     * @return The {@link KuraInventoryImage}s {@link List}.
+     * @since 2.0.0
+     */
+    public List<KuraInventoryImage> getInventoryImages() {
+        if (inventoryImages == null) {
+            inventoryImages = new ArrayList<>();
+        }
+
+        return inventoryImages;
+    }
+
+    /**
+     * Adds a {@link KuraInventoryImage} to the {@link List}
+     *
+     * @param inventoryImage The {@link KuraInventoryImage} to add.
+     * @since 2.0.0
+     */
+    public void addInventoryImage(@NotNull KuraInventoryImage inventoryImage) {
+        getInventoryImages().add(inventoryImage);
+    }
+
+    /**
+     * Sets the {@link KuraInventoryImage}s {@link List}.
+     *
+     * @param inventoryImages The {@link KuraInventoryImage}s {@link List}.
+     * @since 2.0.0
+     */
+    public void setInventoryImages(@Nullable List<KuraInventoryImage> inventoryImages) {
+        this.inventoryImages = inventoryImages;
+    }
+}

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/DeviceInventoryManagementFactory.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/DeviceInventoryManagementFactory.java
@@ -17,6 +17,8 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundles;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackage;
@@ -113,5 +115,20 @@ public interface DeviceInventoryManagementFactory extends KapuaObjectFactory {
      */
     DeviceInventoryPackages newDeviceInventoryPackages();
 
+    /**
+     * Instantiates a new {@link DeviceInventoryImage}.
+     *
+     * @return The newly instantiated {@link DeviceInventoryImage}
+     * @since 2.0.0
+     */
+    DeviceInventoryImage newDeviceInventoryImage();
+
+    /**
+     * Instantiates a new {@link DeviceInventoryImages}.
+     *
+     * @return The newly instantiated {@link DeviceInventoryImages}
+     * @since 2.0.0
+     */
+    DeviceInventoryImages newDeviceInventoryImages();
 
 }

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/DeviceInventoryManagementService.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/DeviceInventoryManagementService.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
 import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
@@ -134,4 +135,16 @@ public interface DeviceInventoryManagementService extends DeviceManagementServic
      * @since 2.0.0
      */
     DeviceInventoryImages getImages(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
+
+    /**
+     * Delete the {@link DeviceInventoryImage}
+     *
+     * @param scopeId  The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId The {@link Device#getId()}
+     * @param image    The {@link DeviceInventoryImage} to delete
+     * @param timeout  The timeout waiting for the device response
+     * @throws KapuaException
+     * @since 2.0.0
+     */
+    void deleteImage(KapuaId scopeId, KapuaId deviceId, DeviceInventoryImage image, Long timeout) throws KapuaException;
 }

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/DeviceInventoryManagementService.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/DeviceInventoryManagementService.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackages;
@@ -121,4 +122,16 @@ public interface DeviceInventoryManagementService extends DeviceManagementServic
      * @since 1.5.0
      */
     DeviceInventoryPackages getDeploymentPackages(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
+
+    /**
+     * Gets the {@link DeviceInventoryImages}
+     *
+     * @param scopeId  The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId The {@link Device#getId()}
+     * @param timeout  The timeout waiting for the device response
+     * @return The {@link DeviceInventoryImages} retrieved from the {@link Device}
+     * @throws KapuaException
+     * @since 2.0.0
+     */
+    DeviceInventoryImages getImages(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 }

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/DeviceInventoryImage.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/DeviceInventoryImage.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory.model.image;
+
+import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * {@link DeviceInventoryContainer} definition.
+ * <p>
+ * It represents an image (usually, a docker one) present on a device.
+ *
+ * @since 2.0.0
+ */
+@XmlRootElement(name = "deviceInventoryImage")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = DeviceInventoryImagesXmlRegistry.class, factoryMethod = "newDeviceInventoryImage")
+public interface DeviceInventoryImage {
+    /**
+     * Gets the name.
+     *
+     * @return The name.
+     * @since 2.0.0
+     */
+    @XmlElement(name = "name")
+    String getName();
+
+    /**
+     * Sets the name.
+     *
+     * @param name The name.
+     * @since 2.0.0
+     */
+    void setName(String name);
+
+    /**
+     * Gets the container version.
+     *
+     * @return The version.
+     * @since 2.0.0
+     */
+    @XmlElement(name = "version")
+    String getVersion();
+
+    /**
+     * Sets the version.
+     *
+     * @param version The version.
+     * @since 2.0.0
+     */
+    void setVersion(String version);
+
+    /**
+     * Gets the type.
+     *
+     * @return The type.
+     * @since 2.0.0
+     */
+    @XmlElement(name = "imageType")
+    String getImageType();
+
+    /**
+     * Sets the image type.
+     *
+     * @param imageType The container type.
+     * @since 2.0.0
+     */
+    void setImageType(String imageType);
+}

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/DeviceInventoryImages.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/DeviceInventoryImages.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory.model.image;
+
+import org.eclipse.kapua.KapuaSerializable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+import java.util.List;
+
+/**
+ * {@link DeviceInventoryImages} definition.
+ *
+ * @since 2.0.0
+ */
+@XmlRootElement(name = "deviceInventoryImages")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = DeviceInventoryImagesXmlRegistry.class, factoryMethod = "newDeviceInventoryImages")
+public interface DeviceInventoryImages extends KapuaSerializable {
+
+    /**
+     * Gets the {@link List} of {@link DeviceInventoryImage}s
+     *
+     * @return The {@link List} of {@link DeviceInventoryImage}s
+     * @since 2.0.0
+     */
+    @XmlElement(name = "inventoryImages")
+    List<DeviceInventoryImage> getInventoryImages();
+
+    /**
+     * Adds a {@link DeviceInventoryImage} to the {@link List}
+     *
+     * @param inventoryImage The {@link DeviceInventoryImage} to add.
+     * @since 2.0.0
+     */
+    @XmlTransient
+    void addInventoryImage(DeviceInventoryImage inventoryImage);
+
+    /**
+     * Sets the {@link List} of {@link DeviceInventoryImage}s
+     *
+     * @param inventoryImage The {@link List} of {@link DeviceInventoryImage}s
+     * @since 2.0.0
+     */
+    void setInventoryImage(List<DeviceInventoryImage> inventoryImage);
+
+}

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/DeviceInventoryImagesXmlRegistry.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/DeviceInventoryImagesXmlRegistry.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory.model.image;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementFactory;
+
+public class DeviceInventoryImagesXmlRegistry {
+
+    private final DeviceInventoryManagementFactory factory = KapuaLocator.getInstance().getFactory(DeviceInventoryManagementFactory.class);
+
+    /**
+     * Instantiates a new {@link DeviceInventoryImages}.
+     *
+     * @return The newly instantiated {@link DeviceInventoryImages}
+     * @since 2.0.0
+     */
+    public DeviceInventoryImages newDeviceInventoryImages() {
+        return factory.newDeviceInventoryImages();
+    }
+
+    /**
+     * Instantiates a new {@link DeviceInventoryImage}.
+     *
+     * @return The newly instantiated {@link DeviceInventoryImage}
+     * @since 2.0.0
+     */
+    public DeviceInventoryImage newDeviceInventoryImage() {
+        return factory.newDeviceInventoryImage();
+    }
+}

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementFactoryImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementFactoryImpl.java
@@ -21,6 +21,10 @@ import org.eclipse.kapua.service.device.management.inventory.model.container.Dev
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
 import org.eclipse.kapua.service.device.management.inventory.model.container.internal.DeviceInventoryContainerImpl;
 import org.eclipse.kapua.service.device.management.inventory.model.container.internal.DeviceInventoryContainersImpl;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
+import org.eclipse.kapua.service.device.management.inventory.model.image.internal.DeviceInventoryImageImpl;
+import org.eclipse.kapua.service.device.management.inventory.model.image.internal.DeviceInventoryImagesImpl;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.internal.DeviceInventoryImpl;
@@ -92,5 +96,15 @@ public class DeviceInventoryManagementFactoryImpl implements DeviceInventoryMana
     @Override
     public DeviceInventoryPackages newDeviceInventoryPackages() {
         return new DeviceInventoryPackagesImpl();
+    }
+
+    @Override
+    public DeviceInventoryImage newDeviceInventoryImage() {
+        return new DeviceInventoryImageImpl();
+    }
+
+    @Override
+    public DeviceInventoryImages newDeviceInventoryImages() {
+        return new DeviceInventoryImagesImpl();
     }
 }

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.kapua.service.device.management.inventory.internal.message.In
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryContainerExecRequestMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryContainersResponseMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryEmptyRequestMessage;
+import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryImageDeleteRequestMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryImagesResponseMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryListResponseMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryNoContentResponseMessage;
@@ -43,6 +44,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
 import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackages;
@@ -524,6 +526,65 @@ public class DeviceInventoryManagementServiceImpl extends AbstractDeviceManageme
         createDeviceEvent(scopeId, deviceId, inventoryRequestMessage, responseMessage);
         // Check response
         return checkResponseAcceptedOrThrowError(responseMessage, () -> responseMessage.getPayload().getDeviceInventoryImages().orElse(deviceInventoryManagementFactory.newDeviceInventoryImages()));
+    }
+
+    public void deleteImage(KapuaId scopeId, KapuaId deviceId, DeviceInventoryImage image, Long timeout) throws KapuaException {
+        // Argument Validation
+        ArgumentValidator.notNull(scopeId, SCOPE_ID);
+        ArgumentValidator.notNull(deviceId, DEVICE_ID);
+        ArgumentValidator.notNull(image, "deviceInventoryContainer");
+        ArgumentValidator.notNull(image.getName(), "deviceInventoryContainer.name");
+        ArgumentValidator.notNull(image.getVersion(), "deviceInventoryContainer.version");
+        // Check Access
+        authorizationService.checkPermission(permissionFactory.newPermission(Domains.DEVICE_MANAGEMENT, Actions.write, scopeId));
+        // Prepare the request
+        InventoryRequestChannel inventoryRequestChannel = new InventoryRequestChannel();
+        inventoryRequestChannel.setAppName(DeviceInventoryAppProperties.APP_NAME);
+        inventoryRequestChannel.setVersion(DeviceInventoryAppProperties.APP_VERSION);
+        inventoryRequestChannel.setMethod(KapuaMethod.EXECUTE);
+        inventoryRequestChannel.setResource("images/_delete");
+
+        InventoryRequestPayload inventoryRequestPayload = new InventoryRequestPayload();
+        try {
+            inventoryRequestPayload.setDeviceInventoryImage(image);
+        } catch (Exception e) {
+            throw new DeviceManagementRequestContentException(e, image);
+        }
+
+        InventoryImageDeleteRequestMessage inventoryRequestMessage = new InventoryImageDeleteRequestMessage() {
+            @Override
+            public Class<InventoryNoContentResponseMessage> getResponseClass() {
+                return InventoryNoContentResponseMessage.class;
+            }
+        };
+
+        inventoryRequestMessage.setScopeId(scopeId);
+        inventoryRequestMessage.setDeviceId(deviceId);
+        inventoryRequestMessage.setCapturedOn(new Date());
+        inventoryRequestMessage.setPayload(inventoryRequestPayload);
+        inventoryRequestMessage.setChannel(inventoryRequestChannel);
+
+        // Build request
+        DeviceCallBuilder<InventoryRequestChannel, InventoryRequestPayload, InventoryImageDeleteRequestMessage, InventoryNoContentResponseMessage> inventoryDeviceCallBuilder =
+                DeviceCallBuilder
+                        .newBuilder()
+                        .withRequestMessage(inventoryRequestMessage)
+                        .withTimeoutOrDefault(timeout);
+
+        // Do exec
+        InventoryNoContentResponseMessage responseMessage;
+        try {
+            responseMessage = inventoryDeviceCallBuilder.send();
+        } catch (Exception e) {
+            LOG.error("Error while deleting image {} on Device {}. Error: {}", image, deviceId, e);
+            throw e;
+        }
+
+        // Create event
+        createDeviceEvent(scopeId, deviceId, inventoryRequestMessage, responseMessage);
+        // Check response
+        checkResponseAcceptedOrThrowError(responseMessage);
+
     }
 
 

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.kapua.service.device.management.inventory.internal.message.In
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryContainerExecRequestMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryContainersResponseMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryEmptyRequestMessage;
+import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryImagesResponseMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryListResponseMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryNoContentResponseMessage;
 import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryPackagesResponseMessage;
@@ -42,6 +43,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackages;
 import org.eclipse.kapua.service.device.management.inventory.model.system.DeviceInventorySystemPackages;
@@ -470,6 +472,58 @@ public class DeviceInventoryManagementServiceImpl extends AbstractDeviceManageme
         createDeviceEvent(scopeId, deviceId, inventoryRequestMessage, responseMessage);
         // Check response
         return checkResponseAcceptedOrThrowError(responseMessage, () -> responseMessage.getPayload().getDeviceInventoryPackages().orElse(deviceInventoryManagementFactory.newDeviceInventoryPackages()));
+    }
+
+    @Override
+    public DeviceInventoryImages getImages(KapuaId scopeId, KapuaId deviceId, Long timeout)
+            throws KapuaException {
+        // Argument Validation
+        ArgumentValidator.notNull(scopeId, SCOPE_ID);
+        ArgumentValidator.notNull(deviceId, DEVICE_ID);
+        // Check Access
+        authorizationService.checkPermission(permissionFactory.newPermission(Domains.DEVICE_MANAGEMENT, Actions.read, scopeId));
+        // Prepare the request
+        InventoryRequestChannel inventoryRequestChannel = new InventoryRequestChannel();
+        inventoryRequestChannel.setAppName(DeviceInventoryAppProperties.APP_NAME);
+        inventoryRequestChannel.setVersion(DeviceInventoryAppProperties.APP_VERSION);
+        inventoryRequestChannel.setMethod(KapuaMethod.READ);
+        inventoryRequestChannel.setResource("images");
+
+        InventoryRequestPayload inventoryRequestPayload = new InventoryRequestPayload();
+
+        InventoryEmptyRequestMessage inventoryRequestMessage = new InventoryEmptyRequestMessage() {
+            @Override
+            public Class<InventoryImagesResponseMessage> getResponseClass() {
+                return InventoryImagesResponseMessage.class;
+            }
+        };
+
+        inventoryRequestMessage.setScopeId(scopeId);
+        inventoryRequestMessage.setDeviceId(deviceId);
+        inventoryRequestMessage.setCapturedOn(new Date());
+        inventoryRequestMessage.setPayload(inventoryRequestPayload);
+        inventoryRequestMessage.setChannel(inventoryRequestChannel);
+
+        // Build request
+        DeviceCallBuilder<InventoryRequestChannel, InventoryRequestPayload, InventoryEmptyRequestMessage, InventoryImagesResponseMessage> inventoryDeviceCallBuilder =
+                DeviceCallBuilder
+                        .newBuilder()
+                        .withRequestMessage(inventoryRequestMessage)
+                        .withTimeoutOrDefault(timeout);
+
+        // Do get
+        InventoryImagesResponseMessage responseMessage;
+        try {
+            responseMessage = inventoryDeviceCallBuilder.send();
+        } catch (Exception e) {
+            LOG.error("Error while getting DeviceInventoryImages for Device {}. Error: {}", deviceId, e.getMessage(), e);
+            throw e;
+        }
+
+        // Create event
+        createDeviceEvent(scopeId, deviceId, inventoryRequestMessage, responseMessage);
+        // Check response
+        return checkResponseAcceptedOrThrowError(responseMessage, () -> responseMessage.getPayload().getDeviceInventoryImages().orElse(deviceInventoryManagementFactory.newDeviceInventoryImages()));
     }
 
 

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/message/InventoryImageDeleteRequestMessage.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/message/InventoryImageDeleteRequestMessage.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory.internal.message;
+
+public abstract class InventoryImageDeleteRequestMessage extends InventoryRequestMessage<InventoryImageDeleteRequestMessage> {
+
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    public InventoryImageDeleteRequestMessage() {
+        super(InventoryImageDeleteRequestMessage.class);
+    }
+}

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/message/InventoryImagesResponseMessage.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/message/InventoryImagesResponseMessage.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory.internal.message;
+
+import org.eclipse.kapua.service.device.management.message.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
+
+/**
+ * {@link DeviceInventoryImages} {@link KapuaResponseMessage} implementation.
+ *
+ * @since 2.0.0
+ */
+public class InventoryImagesResponseMessage extends InventoryResponseMessage {
+}

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/message/InventoryRequestPayload.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/message/InventoryRequestPayload.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagem
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundle;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestPayload;
 
@@ -98,5 +99,36 @@ public class InventoryRequestPayload extends KapuaPayloadImpl implements KapuaRe
     public void setDeviceInventoryContainer(@NotNull DeviceInventoryContainer deviceInventoryContainer) throws Exception {
         String bodyString = xmlUtil.marshal(deviceInventoryContainer);
         setBody(bodyString.getBytes(charEncoding));
+    }
+
+    /**
+     * Sets the {@link DeviceInventoryImage} in the {@link #getBody()}.
+     *
+     * @param deviceInventoryImage
+     *         The {@link DeviceInventoryImage} in the {@link #getBody()}.
+     * @throws Exception
+     *         if writing errors.
+     * @since 2.0.0
+     */
+    public void setDeviceInventoryImage(@NotNull DeviceInventoryImage deviceInventoryImage) throws Exception {
+        String bodyString = xmlUtil.marshal(deviceInventoryImage);
+        setBody(bodyString.getBytes(charEncoding));
+    }
+
+    /**
+     * Gets the {@link DeviceInventoryImage} from the {@link #getBody()}.
+     *
+     * @return The {@link DeviceInventoryImage} from the {@link #getBody()}.
+     * @throws Exception
+     *         if reading {@link #getBody()} errors.
+     * @since 2.0.0
+     */
+    public Optional<DeviceInventoryImage> getDeviceInventoryImage() throws Exception {
+        if (!hasBody()) {
+            return Optional.empty();
+        }
+
+        String bodyString = new String(getBody(), charEncoding);
+        return Optional.ofNullable(xmlUtil.unmarshal(bodyString, DeviceInventoryImage.class));
     }
 }

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/message/InventoryResponsePayload.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/message/InventoryResponsePayload.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagem
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundles;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackages;
 import org.eclipse.kapua.service.device.management.inventory.model.system.DeviceInventorySystemPackages;
@@ -134,6 +135,20 @@ public class InventoryResponsePayload extends KapuaResponsePayloadImpl implement
     }
 
     /**
+     * Sets the {@link DeviceInventoryImages} in the {@link #getBody()}.
+     *
+     * @param inventoryImages
+     *         The {@link DeviceInventoryImages} in the {@link #getBody()}.
+     * @throws Exception
+     *         if writing errors.
+     * @since 2.0.0
+     */
+    public void setDeviceInventoryImages(@NotNull DeviceInventoryImages inventoryImages) throws Exception {
+        String bodyString = xmlUtil.marshal(inventoryImages);
+        setBody(bodyString.getBytes(charEncoding));
+    }
+
+    /**
      * Gets the {@link DeviceInventorySystemPackages} from the {@link #getBody()}.
      *
      * @return The {@link DeviceInventorySystemPackages} from the {@link #getBody()}.
@@ -179,6 +194,23 @@ public class InventoryResponsePayload extends KapuaResponsePayloadImpl implement
 
         String bodyString = new String(getBody(), charEncoding);
         return Optional.ofNullable(xmlUtil.unmarshal(bodyString, DeviceInventoryPackages.class));
+    }
+
+    /**
+     * Gets the {@link DeviceInventoryImages} from the {@link #getBody()}.
+     *
+     * @return The {@link DeviceInventoryImages} from the {@link #getBody()}.
+     * @throws Exception
+     *         if reading {@link #getBody()} errors.
+     * @since 2.0.0
+     */
+    public Optional<DeviceInventoryImages> getDeviceInventoryImages() throws Exception {
+        if (!hasBody()) {
+            return Optional.empty();
+        }
+
+        String bodyString = new String(getBody(), charEncoding);
+        return Optional.ofNullable(xmlUtil.unmarshal(bodyString, DeviceInventoryImages.class));
     }
 
     /**

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/internal/DeviceInventoryImageImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/internal/DeviceInventoryImageImpl.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory.model.image.internal;
+
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+
+/**
+ * {@link DeviceInventoryImage} implementation.
+ *
+ * @since 2.0.0
+ */
+public class DeviceInventoryImageImpl implements DeviceInventoryImage {
+
+    private String name;
+    private String version;
+    private String imageType;
+
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    public DeviceInventoryImageImpl() {
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String getImageType() {
+        return imageType;
+    }
+
+    @Override
+    public void setImageType(String imageType) {
+        this.imageType = imageType;
+    }
+}

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/internal/DeviceInventoryImagesImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/image/internal/DeviceInventoryImagesImpl.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory.model.image.internal;
+
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link DeviceInventoryImages} implementation.
+ *
+ * @since 2.0.0
+ */
+public class DeviceInventoryImagesImpl implements DeviceInventoryImages {
+
+    private List<DeviceInventoryImage> inventoryImages;
+
+    @Override
+    public List<DeviceInventoryImage> getInventoryImages() {
+        if (inventoryImages == null) {
+            inventoryImages = new ArrayList<>();
+        }
+
+        return inventoryImages;
+    }
+
+    @Override
+    public void addInventoryImage(DeviceInventoryImage inventoryImage) {
+        getInventoryImages().add(inventoryImage);
+    }
+
+    @Override
+    public void setInventoryImage(List<DeviceInventoryImage> inventoryImages) {
+        this.inventoryImages = inventoryImages;
+    }
+}

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceManagementInventorySteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceManagementInventorySteps.java
@@ -30,6 +30,8 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerAction;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackage;
@@ -49,6 +51,7 @@ public class DeviceManagementInventorySteps extends TestBase {
     private static final String INVENTORY_ITEMS = "inventory_inventory";
     private static final String INVENTORY_BUNDLES = "inventory_bundles";
     private static final String INVENTORY_CONTAINERS = "inventory_container";
+    private static final String INVENTORY_IMAGES = "inventory_images";
     private static final String INVENTORY_SYSTEM_PACKAGES = "inventory_system_packages";
     private static final String INVENTORY_DEPLOYMENT_PACKAGES = "inventory_deployment_packages";
 
@@ -295,6 +298,70 @@ public class DeviceManagementInventorySteps extends TestBase {
             Device device = deviceRegistryService.findByClientId(SYS_SCOPE_ID, kuraDevice.getClientId());
             if (device != null) {
                 deviceInventoryManagementService.execContainer(device.getScopeId(), device.getId(), inventoryContainer, DeviceInventoryContainerAction.STOP, null);
+            }
+        }
+    }
+
+    // /images
+    @When("Inventory Images are requested")
+    public void inventoryImagesRequested() throws Exception {
+        List<KuraDevice> kuraDevices = (List<KuraDevice>) stepData.get(KURA_DEVICES);
+        for (KuraDevice kuraDevice : kuraDevices) {
+            Device device = deviceRegistryService.findByClientId(SYS_SCOPE_ID, kuraDevice.getClientId());
+            if (device != null) {
+                DeviceInventoryImages deviceInventoryImages = deviceInventoryManagementService.getImages(device.getScopeId(), device.getId(), null);
+                List<DeviceInventoryImage> inventoryImages = deviceInventoryImages.getInventoryImages();
+                stepData.put(INVENTORY_IMAGES, inventoryImages);
+            }
+        }
+    }
+
+    @Then("Inventory Images are received")
+    public void inventoryImagesReceived() {
+        List<DeviceInventoryImage> inventoryImages = (List<DeviceInventoryImage>) stepData.get(INVENTORY_IMAGES);
+        Assert.assertNotNull(inventoryImages);
+    }
+
+    @Then("Inventory Images are {long}")
+    public void inventoryImagesAreSize(long size) {
+        List<DeviceInventoryImage> inventoryImages = (List<DeviceInventoryImage>) stepData.get(INVENTORY_IMAGES);
+        Assert.assertEquals(size, inventoryImages.size());
+    }
+
+    @Then("Inventory Images has Image named {string} is present")
+    public void inventoryImageNamedIsPresent(String inventoryImageName) {
+        List<DeviceInventoryImage> inventoryImages = (List<DeviceInventoryImage>) stepData.get(INVENTORY_IMAGES);
+        DeviceInventoryImage inventoryImage = inventoryImages.stream().filter(i -> i.getName().equals(inventoryImageName)).findAny().orElse(null);
+        Assert.assertNotNull(inventoryImage);
+    }
+
+    @Then("Inventory Images has Image named {string} has version {string}")
+    public void inventoryImageNamedHasVersion(String inventoryImageName, String inventoryImageVersion) {
+        List<DeviceInventoryImage> inventoryImages = (List<DeviceInventoryImage>) stepData.get(INVENTORY_IMAGES);
+        DeviceInventoryImage inventoryImage = inventoryImages.stream().filter(i -> i.getName().equals(inventoryImageName)).findAny().orElse(null);
+        Assert.assertNotNull(inventoryImage);
+        Assert.assertEquals(inventoryImageVersion, inventoryImage.getVersion());
+    }
+
+    @Then("Inventory Images has Image named {string} has type {string}")
+    public void inventoryImageNamedHasType(String inventoryImageName, String inventoryImageType) {
+        List<DeviceInventoryImage> inventoryImages = (List<DeviceInventoryImage>) stepData.get(INVENTORY_IMAGES);
+        DeviceInventoryImage inventoryImage = inventoryImages.stream().filter(i -> i.getName().equals(inventoryImageName)).findAny().orElse(null);
+        Assert.assertNotNull(inventoryImage);
+        Assert.assertEquals(inventoryImageType, inventoryImage.getImageType());
+    }
+
+    @Then("I delete Inventory Image named {string}")
+    public void inventoryImagedNamedDelete(String inventoryImageName) throws KapuaException {
+        List<DeviceInventoryImage> inventoryImages = (List<DeviceInventoryImage>) stepData.get(INVENTORY_IMAGES);
+        DeviceInventoryImage inventoryImage = inventoryImages.stream().filter(b -> b.getName().equals(inventoryImageName)).findAny().orElse(null);
+        Assert.assertNotNull(inventoryImage);
+
+        List<KuraDevice> kuraDevices = (List<KuraDevice>) stepData.get(KURA_DEVICES);
+        for (KuraDevice kuraDevice : kuraDevices) {
+            Device device = deviceRegistryService.findByClientId(SYS_SCOPE_ID, kuraDevice.getClientId());
+            if (device != null) {
+                deviceInventoryManagementService.deleteImage(device.getScopeId(), device.getId(), inventoryImage, null);
             }
         }
     }

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/KuraDevice.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/KuraDevice.java
@@ -74,7 +74,9 @@ public class KuraDevice implements MqttCallback {
     private String inventoryExecInventoryBundleStop;
     private String inventoryGetInventoryContainerEntries;
     private String inventoryExecInventoryContainerStart;
+    private String inventoryGetInventoryImagesEntries;
     private String inventoryExecInventoryContainerStop;
+    private String inventoryDeleteInventoryImage;
     private String inventoryGetInventorySystemPackagesEntries;
     private String inventoryGetInventoryPackagesEntries;
 
@@ -209,8 +211,10 @@ public class KuraDevice implements MqttCallback {
         inventoryExecInventoryBundleStart = "$EDC/kapua-sys/rpione3/INVENTORY-V1/EXEC/bundles/_start";
         inventoryExecInventoryBundleStop = "$EDC/kapua-sys/rpione3/INVENTORY-V1/EXEC/bundles/_stop";
         inventoryGetInventoryContainerEntries = "$EDC/kapua-sys/rpione3/INVENTORY-V1/GET/containers";
+        inventoryGetInventoryImagesEntries = "$EDC/kapua-sys/rpione3/INVENTORY-V1/GET/images";
         inventoryExecInventoryContainerStart = "$EDC/kapua-sys/rpione3/INVENTORY-V1/EXEC/containers/_start";
         inventoryExecInventoryContainerStop = "$EDC/kapua-sys/rpione3/INVENTORY-V1/EXEC/containers/_stop";
+        inventoryDeleteInventoryImage = "$EDC/kapua-sys/rpione3/INVENTORY-V1/EXEC/images/_delete";
         inventoryGetInventorySystemPackagesEntries = "$EDC/kapua-sys/rpione3/INVENTORY-V1/GET/systemPackages";
         inventoryGetInventoryPackagesEntries = "$EDC/kapua-sys/rpione3/INVENTORY-V1/GET/deploymentPackages";
 
@@ -755,6 +759,39 @@ public class KuraDevice implements MqttCallback {
 
                         mqttClient.publish(responseTopic, responsePayload, 0, false);
                     }
+                } else if (topic.equals(inventoryDeleteInventoryImage)) {
+                    callbackParam = extractCallback(requestPayload);
+
+                    KuraPayload kuraRequestPayload = new KuraPayload();
+                    kuraRequestPayload.readFromByteArray(requestPayload);
+
+                    String jsonRequestBody = new String(kuraRequestPayload.getBody());
+
+                    if (jsonRequestBody.contains("nginx")) {
+                        responseTopic = $EDC + clientAccount + "/" + callbackParam.getClientId() + INVENTORY_V1_REPLY + callbackParam.getRequestId();
+
+                        KuraPayload kuraResponsePayload = new KuraPayload();
+                        kuraResponsePayload.getMetrics().put("response.code", 200);
+
+                        responsePayload = kuraResponsePayload.toByteArray();
+
+                        mqttClient.publish(responseTopic, responsePayload, 0, false);
+                    }
+                } else if (topic.equals(inventoryGetInventoryImagesEntries)) {
+                    callbackParam = extractCallback(requestPayload);
+
+                    responseTopic = $EDC + clientAccount + "/" + callbackParam.getClientId() + INVENTORY_V1_REPLY + callbackParam.getRequestId();
+
+                    byte[] responseBody = Files.readAllBytes(Paths.get(getClass().getResource("/mqtt/INVENTORY-V1_GET_inventory_images_reply.json").toURI()));
+
+                    KuraPayload kuraResponsePayload = new KuraPayload();
+                    kuraResponsePayload.setBody(responseBody);
+                    kuraResponsePayload.getMetrics().put("response.code", 200);
+
+                    responsePayload = kuraResponsePayload.toByteArray();
+
+                    mqttClient.publish(responseTopic, responsePayload, 0, false);
+
                 } else if (topic.equals(inventoryGetInventorySystemPackagesEntries)) {
                     callbackParam = extractCallback(requestPayload);
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/KapuaKuraTranslatorsModule.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/KapuaKuraTranslatorsModule.java
@@ -33,6 +33,7 @@ import org.eclipse.kapua.translator.kapua.kura.TranslatorDataKapuaKura;
 import org.eclipse.kapua.translator.kapua.kura.inventory.TranslatorAppInventoryBundleExecKapuaKura;
 import org.eclipse.kapua.translator.kapua.kura.inventory.TranslatorAppInventoryContainerExecKapuaKura;
 import org.eclipse.kapua.translator.kapua.kura.inventory.TranslatorAppInventoryEmptyKapuaKura;
+import org.eclipse.kapua.translator.kapua.kura.inventory.TranslatorAppInventoryImageDeleteKapuaKura;
 import org.eclipse.kapua.translator.kapua.kura.keystore.TranslatorAppKeystoreCertificateKapuaKura;
 import org.eclipse.kapua.translator.kapua.kura.keystore.TranslatorAppKeystoreCsrKapuaKura;
 import org.eclipse.kapua.translator.kapua.kura.keystore.TranslatorAppKeystoreKeypairKapuaKura;
@@ -84,6 +85,7 @@ public class KapuaKuraTranslatorsModule extends AbstractKapuaModule {
         translatorMultibinder.addBinding().to(TranslatorAppInventoryBundleExecKapuaKura.class);
         translatorMultibinder.addBinding().to(TranslatorAppInventoryContainerExecKapuaKura.class);
         translatorMultibinder.addBinding().to(TranslatorAppInventoryEmptyKapuaKura.class);
+        translatorMultibinder.addBinding().to(TranslatorAppInventoryImageDeleteKapuaKura.class);
         //org.eclipse.kapua.translator.kapua.kura.keystore
         translatorMultibinder.addBinding().to(TranslatorAppKeystoreCertificateKapuaKura.class);
         translatorMultibinder.addBinding().to(TranslatorAppKeystoreCsrKapuaKura.class);

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/KapuaKuraTranslatorsModule.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/KapuaKuraTranslatorsModule.java
@@ -55,6 +55,7 @@ import org.eclipse.kapua.translator.kura.kapua.TranslatorLifeMissingKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.event.TranslatorEventConfigurationKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.inventory.TranslatorAppInventoryBundlesKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.inventory.TranslatorAppInventoryContainersKuraKapua;
+import org.eclipse.kapua.translator.kura.kapua.inventory.TranslatorAppInventoryImagesKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.inventory.TranslatorAppInventoryListKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.inventory.TranslatorAppInventoryNoContentKuraKapua;
 import org.eclipse.kapua.translator.kura.kapua.inventory.TranslatorAppInventoryPackagesKuraKapua;
@@ -111,6 +112,7 @@ public class KapuaKuraTranslatorsModule extends AbstractKapuaModule {
         translatorMultibinder.addBinding().to(TranslatorAppInventoryNoContentKuraKapua.class);
         translatorMultibinder.addBinding().to(TranslatorAppInventoryPackagesKuraKapua.class);
         translatorMultibinder.addBinding().to(TranslatorAppInventorySystemPackagesKuraKapua.class);
+        translatorMultibinder.addBinding().to(TranslatorAppInventoryImagesKuraKapua.class);
         //org.eclipse.kapua.translator.kura.kapua.keystore
         translatorMultibinder.addBinding().to(TranslatorAppKeystoreItemKuraKapua.class);
         translatorMultibinder.addBinding().to(TranslatorAppKeystoreItemsKuraKapua.class);

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/inventory/TranslatorAppInventoryImageDeleteKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/inventory/TranslatorAppInventoryImageDeleteKapuaKura.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kapua.kura.inventory;
+
+import org.eclipse.kapua.service.device.call.kura.model.inventory.InventoryMetrics;
+import org.eclipse.kapua.service.device.call.kura.model.inventory.images.KuraInventoryImage;
+import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestChannel;
+import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestMessage;
+import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestPayload;
+import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
+import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
+import org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementFactory;
+import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryImageDeleteRequestMessage;
+import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryRequestChannel;
+import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryRequestPayload;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.translator.exception.InvalidChannelException;
+import org.eclipse.kapua.translator.exception.InvalidPayloadException;
+import org.eclipse.kapua.translator.kapua.kura.AbstractTranslatorKapuaKura;
+import org.eclipse.kapua.translator.kapua.kura.TranslatorKapuaKuraUtils;
+
+import javax.inject.Inject;
+
+public class TranslatorAppInventoryImageDeleteKapuaKura extends AbstractTranslatorKapuaKura<InventoryRequestChannel, InventoryRequestPayload, InventoryImageDeleteRequestMessage> {
+
+    private final String charEncoding;
+    private final DeviceInventoryManagementFactory deviceInventoryManagementFactory;
+
+    @Inject
+    public TranslatorAppInventoryImageDeleteKapuaKura(DeviceManagementSetting deviceManagementSetting, DeviceInventoryManagementFactory deviceInventoryManagementFactory) {
+        this.deviceInventoryManagementFactory = deviceInventoryManagementFactory;
+        this.charEncoding = deviceManagementSetting.getString(DeviceManagementSettingKey.CHAR_ENCODING);
+    }
+
+    @Override
+    protected KuraRequestChannel translateChannel(InventoryRequestChannel inventoryRequestChannel) throws InvalidChannelException {
+        try {
+            KuraRequestChannel kuraRequestChannel = TranslatorKapuaKuraUtils.buildBaseRequestChannel(InventoryMetrics.APP_ID, InventoryMetrics.APP_VERSION, inventoryRequestChannel.getMethod());
+            kuraRequestChannel.setResources(new String[]{inventoryRequestChannel.getResource()});
+            // Return Kura Channel
+            return kuraRequestChannel;
+        } catch (Exception e) {
+            throw new InvalidChannelException(e, inventoryRequestChannel);
+        }
+    }
+
+    @Override
+    protected KuraRequestPayload translatePayload(InventoryRequestPayload inventoryRequestPayload) throws InvalidPayloadException {
+        try {
+            KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
+
+            if (inventoryRequestPayload.hasBody()) {
+                DeviceInventoryImage deviceInventoryImage = inventoryRequestPayload.getDeviceInventoryImage().orElse(deviceInventoryManagementFactory.newDeviceInventoryImage());
+
+                KuraInventoryImage kuraInventoryImage = new KuraInventoryImage();
+                kuraInventoryImage.setName(deviceInventoryImage.getName());
+                kuraInventoryImage.setVersion(deviceInventoryImage.getVersion());
+                kuraInventoryImage.setType(deviceInventoryImage.getImageType());
+
+                kuraRequestPayload.setBody(getJsonMapper().writeValueAsString(kuraInventoryImage).getBytes(charEncoding));
+            }
+
+            return kuraRequestPayload;
+        } catch (Exception e) {
+            throw new InvalidPayloadException(e, inventoryRequestPayload);
+        }
+    }
+
+    @Override
+    public Class<InventoryImageDeleteRequestMessage> getClassFrom() {
+        return InventoryImageDeleteRequestMessage.class;
+    }
+
+    @Override
+    public Class<KuraRequestMessage> getClassTo() {
+        return KuraRequestMessage.class;
+    }
+
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/AbstractTranslatorAppInventoryKuraKapua.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.service.device.call.kura.model.inventory.InventoryMetri
 import org.eclipse.kapua.service.device.call.kura.model.inventory.KuraInventoryItems;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.bundles.KuraInventoryBundles;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.containers.KuraInventoryContainers;
+import org.eclipse.kapua.service.device.call.kura.model.inventory.images.KuraInventoryImages;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.packages.KuraInventoryPackages;
 import org.eclipse.kapua.service.device.call.kura.model.inventory.system.KuraInventorySystemPackages;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseChannel;
@@ -30,6 +31,8 @@ import org.eclipse.kapua.service.device.management.inventory.model.bundle.Device
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainer;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainerState;
 import org.eclipse.kapua.service.device.management.inventory.model.container.DeviceInventoryContainers;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImage;
+import org.eclipse.kapua.service.device.management.inventory.model.image.DeviceInventoryImages;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventory;
 import org.eclipse.kapua.service.device.management.inventory.model.inventory.DeviceInventoryItem;
 import org.eclipse.kapua.service.device.management.inventory.model.packages.DeviceInventoryPackage;
@@ -122,6 +125,28 @@ public class AbstractTranslatorAppInventoryKuraKapua<M extends InventoryResponse
         });
 
         return deviceInventoryBundles;
+    }
+
+    /**
+     * Translates {@link KuraInventoryImages} to {@link DeviceInventoryImages}
+     *
+     * @param kuraInventoryImages The {@link KuraInventoryImages} to translate.
+     * @return The translated {@link DeviceInventoryImages}.
+     * @since 2.0.0
+     */
+    protected DeviceInventoryImages translate(KuraInventoryImages kuraInventoryImages) {
+        DeviceInventoryImages deviceInventoryImages = deviceInventoryFactory.newDeviceInventoryImages();
+
+        kuraInventoryImages.getInventoryImages().forEach(kuraInventoryImage -> {
+            DeviceInventoryImage deviceInventoryImage = deviceInventoryFactory.newDeviceInventoryImage();
+            deviceInventoryImage.setName(kuraInventoryImage.getName());
+            deviceInventoryImage.setVersion(kuraInventoryImage.getVersion());
+            deviceInventoryImage.setImageType(kuraInventoryImage.getType());
+
+            deviceInventoryImages.addInventoryImage(deviceInventoryImage);
+        });
+
+        return deviceInventoryImages;
     }
 
     /**

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/TranslatorAppInventoryImagesKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/inventory/TranslatorAppInventoryImagesKuraKapua.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kura.kapua.inventory;
+
+import org.eclipse.kapua.service.device.call.kura.model.inventory.images.KuraInventoryImages;
+import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponsePayload;
+import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
+import org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementFactory;
+import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryImagesResponseMessage;
+import org.eclipse.kapua.service.device.management.inventory.internal.message.InventoryResponsePayload;
+import org.eclipse.kapua.translator.exception.InvalidPayloadException;
+
+import javax.inject.Inject;
+
+public class TranslatorAppInventoryImagesKuraKapua extends AbstractTranslatorAppInventoryKuraKapua<InventoryImagesResponseMessage> {
+
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    @Inject
+    public TranslatorAppInventoryImagesKuraKapua(DeviceManagementSetting deviceManagementSetting, DeviceInventoryManagementFactory deviceInventoryManagementFactory) {
+        super(deviceManagementSetting, deviceInventoryManagementFactory, InventoryImagesResponseMessage.class);
+    }
+
+    @Override
+    protected InventoryResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
+        try {
+            InventoryResponsePayload inventoryResponsePayload = super.translatePayload(kuraResponsePayload);
+
+            if (kuraResponsePayload.hasBody()) {
+                KuraInventoryImages inventoryContainers = readJsonBodyAs(kuraResponsePayload.getBody(), KuraInventoryImages.class);
+
+                if (!inventoryContainers.getInventoryImages().isEmpty()) {
+                    inventoryResponsePayload.setDeviceInventoryImages(translate(inventoryContainers));
+                }
+            }
+
+            return inventoryResponsePayload;
+        } catch (Exception e) {
+            throw new InvalidPayloadException(e, kuraResponsePayload);
+        }
+    }
+}


### PR DESCRIPTION
Brief description of the PR.
Management of container images is backed by Kura with a resource in the INVENTORY-V1 application handler. 
The resource allows a user to:

1) lists all the container images visible by the Kura instance
2) delete a specific container image

With this PR, DeviceInventoryManagementService jas been extended to support such resource. Furthermore, proper API has been added in the rest-API layer, and proper gwt code has been provided to render such resource in the UI
