### PR TITLE
:recycle: [Group] Refactored GroupService to rely on GroupServiceValidationUtils

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -12,15 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group.shiro;
 
-import org.eclipse.kapua.KapuaDuplicateNameException;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceBase;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.model.domains.Domains;
-import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
-import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
@@ -47,6 +43,9 @@ import javax.inject.Singleton;
 public class GroupServiceImpl extends KapuaConfigurableServiceBase implements GroupService {
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupServiceImpl.class);
+
+    private final GroupServiceValidationUtils groupServiceValidationUtils;
+
     private final GroupRepository groupRepository;
 
     /**
@@ -65,6 +64,7 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
             ServiceConfigurationManager serviceConfigurationManager,
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
+            GroupServiceValidationUtils groupServiceValidationUtils,
             GroupRepository groupRepository
     ) {
         super(
@@ -75,95 +75,62 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
             permissionFactory
         );
 
+        this.groupServiceValidationUtils = groupServiceValidationUtils;
         this.groupRepository = groupRepository;
     }
 
     @Override
     public Group create(GroupCreator groupCreator) throws KapuaException {
-        // Argument validation
-        ArgumentValidator.notNull(groupCreator, "groupCreator");
-        ArgumentValidator.notNull(groupCreator.getScopeId(), "roleCreator.scopeId");
-        ArgumentValidator.validateEntityName(groupCreator.getName(), "groupCreator.name");
+        // Validate preconditions
+        groupServiceValidationUtils.validateCreatePreconditions(groupCreator);
 
-        // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.write, groupCreator.getScopeId()));
-
+        // Do create
         return txManager.execute(tx -> {
-            // Check entity limit
-            serviceConfigurationManager.checkAllowedEntities(tx, groupCreator.getScopeId(), "Groups");
+            // Validate in-transaction conditions
+            groupServiceValidationUtils.validateCreateInTransaction(tx, groupCreator);
 
             // Do create
             Group group = new GroupImpl(groupCreator.getScopeId());
             group.setName(groupCreator.getName());
             group.setDescription(groupCreator.getDescription());
 
-            // Check duplicate name
-            if (groupRepository.countEntitiesWithNameInScope(tx, group.getScopeId(), group.getName()) > 0) {
-                throw new KapuaDuplicateNameException(group.getName());
-            }
             return groupRepository.create(tx, group);
         });
     }
 
     @Override
     public Group update(Group group) throws KapuaException {
-        // Argument validator
-        ArgumentValidator.notNull(group, "group");
-        ArgumentValidator.notNull(group.getId(), "group.id");
-        ArgumentValidator.notNull(group.getScopeId(), "group.scopeId");
-        ArgumentValidator.validateEntityName(group.getName(), "group.name");
+        // Validate preconditions
+        groupServiceValidationUtils.validateUpdatePreconditions(group);
 
-        // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.write, group.getScopeId()));
-
+        // Do update
         return txManager.execute(tx -> {
-            // Check existence
-            if (!groupRepository.find(tx, group.getScopeId(), group.getId()).isPresent()) {
-                throw new KapuaEntityNotFoundException(Group.TYPE, group.getId());
-            }
+            // Validate in-transaction conditions
+            groupServiceValidationUtils.validateUpdateInTransaction(tx, group);
 
-            // Do update
-            // Check duplicate name
-            if (groupRepository.countOtherEntitiesWithNameInScope(tx, group.getScopeId(), group.getId(), group.getName()) > 0) {
-                throw new KapuaDuplicateNameException(group.getName());
-            }
+            // Update
             return groupRepository.update(tx, group);
         });
     }
 
-    @Override
-    public void delete(KapuaId scopeId, KapuaId groupId) throws KapuaException {
-        // Argument validation
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(groupId, "groupId");
 
-        // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.delete, scopeId));
-
-        txManager.execute(tx -> groupRepository.delete(tx, scopeId, groupId));
-    }
 
     @Override
     public Group find(KapuaId scopeId, KapuaId groupId) throws KapuaException {
-        // Argument validation
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(groupId, "groupId");
-
-        // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.read, scopeId));
+        // Validate preconditions
+        groupServiceValidationUtils.validateFindPreconditions(scopeId, groupId);
 
         // Do find
-        return txManager.execute(tx -> groupRepository.find(tx, scopeId, groupId))
+        return txManager.execute(
+            tx -> groupRepository
+                .find(tx, scopeId, groupId))
                 .orElse(null);
     }
 
     @Override
     public GroupListResult query(KapuaQuery query) throws KapuaException {
-        // Argument validation
-        ArgumentValidator.notNull(query, "query");
-
-        // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.read, query.getScopeId()));
+        // Validate preconditions
+        groupServiceValidationUtils.validateQueryPreconditions(query);
 
         // Do query
         return txManager.execute(tx -> groupRepository.query(tx, query));
@@ -171,14 +138,29 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
 
     @Override
     public long count(KapuaQuery query) throws KapuaException {
-        // Argument validation
-        ArgumentValidator.notNull(query, "query");
-
-        // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.read, query.getScopeId()));
+        // Validate preconditions
+        groupServiceValidationUtils.validateCountPreconditions(query);
 
         // Do count
         return txManager.execute(tx -> groupRepository.count(tx, query));
+    }
+
+    @Override
+    public void delete(KapuaId scopeId, KapuaId groupId) throws KapuaException {
+        // Validate preconditions
+        groupServiceValidationUtils.validateDeletePreconditions(scopeId, groupId);
+
+        // Do delete
+        txManager.execute(
+            tx -> {
+                // Validate in-transaction conditions
+                groupServiceValidationUtils.validateDeleteInTransaction(tx, scopeId, groupId);
+
+                // Delete
+                groupRepository.delete(tx, scopeId, groupId);
+                return null;
+            }
+        );
     }
 
     //@ListenServiceEvent(fromAddress="account")

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceValidationUtils.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceValidationUtils.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.group.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.authorization.group.GroupCreator;
+import org.eclipse.kapua.service.authorization.group.GroupService;
+import org.eclipse.kapua.storage.TxContext;
+
+/**
+ * {@link GroupService} validation utilities.
+ *
+ * @since 2.1.0
+ */
+public interface GroupServiceValidationUtils {
+
+    /**
+     * Validates a {@link GroupCreator} on {@link GroupService#create(GroupCreator)}
+     *
+     * @param groupCreator The {@link GroupCreator} to validate
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    void validateCreatePreconditions(GroupCreator groupCreator) throws KapuaException;
+
+    /**
+     * Validates a {@link Group} on {@link GroupService#create(GroupCreator)} in a {@link TxContext}
+     *
+     * @param txContext The {@link TxContext} to use
+     * @param groupCreator The {@link GroupCreator} to validate
+     * @throws KapuaException
+     *
+     * @since 2.1.0
+     */
+    void validateCreateInTransaction(TxContext txContext, GroupCreator groupCreator) throws KapuaException;
+
+    /**
+     * Validates a {@link Group} on {@link GroupService#update(Group)}
+     *
+     * @param group The {@link Group} to validate
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    void validateUpdatePreconditions(Group group) throws KapuaException;
+
+    /**
+     * Validates a {@link Group} on {@link GroupService#update(Group)} in a {@link TxContext}
+     *
+     * @param txContext The {@link TxContext} to use
+     * @param group The {@link Group} to validate
+     * @throws KapuaException
+     *
+     * @since 2.1.0
+     */
+    void validateUpdateInTransaction(TxContext txContext, Group group) throws KapuaException;
+
+    /**
+     * Validates inputs for {@link GroupService#find(KapuaId, KapuaId)}
+     *
+     * @param scopeId The {@link Group#getScopeId()}
+     * @param groupId The {@link Group#getId()}
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    void validateFindPreconditions(KapuaId scopeId, KapuaId groupId) throws KapuaException;
+
+    /**
+     * Validates {@link KapuaQuery} for {@link GroupService#query(KapuaQuery)}
+     *
+     * @param query The {@link KapuaQuery} to validate
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    void validateQueryPreconditions(KapuaQuery query) throws KapuaException;
+
+    /**
+     * Validates {@link KapuaQuery} for {@link GroupService#count(KapuaQuery)}
+     *
+     * @param query The {@link KapuaQuery} to validate
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    void validateCountPreconditions(KapuaQuery query) throws KapuaException;
+
+    /**
+     * Validates a {@link Group} on {@link GroupService#delete(KapuaId, KapuaId)}
+     *
+     * @param scopeId The {@link Group#getScopeId()}
+     * @param groupId The {@link Group#getId()}
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    void validateDeletePreconditions(KapuaId scopeId, KapuaId groupId) throws KapuaException;
+
+    /**
+     * Validates a {@link Group} on {@link GroupService#delete(KapuaId, KapuaId)} in a {@link TxContext}
+     *
+     * @param txContext The {@link TxContext} to use
+     * @param scopeId The {@link Group#getScopeId()}
+     * @param groupId The {@link Group#getId()}
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    void validateDeleteInTransaction(TxContext txContext, KapuaId scopeId, KapuaId groupId) throws KapuaException;
+
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceValidationUtilsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceValidationUtilsImpl.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.group.shiro;
+
+import org.eclipse.kapua.KapuaDuplicateNameException;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
+import org.eclipse.kapua.commons.model.domains.Domains;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.authorization.group.GroupCreator;
+import org.eclipse.kapua.service.authorization.group.GroupRepository;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.tag.Tag;
+import org.eclipse.kapua.service.tag.TagAttributes;
+import org.eclipse.kapua.service.tag.TagFactory;
+import org.eclipse.kapua.service.tag.TagListResult;
+import org.eclipse.kapua.service.tag.TagQuery;
+import org.eclipse.kapua.service.tag.TagService;
+import org.eclipse.kapua.storage.TxContext;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * {@link GroupServiceValidationUtils} implementation.
+ *
+ * @since 2.1.0
+ */
+public final class GroupServiceValidationUtilsImpl implements GroupServiceValidationUtils {
+
+    private final AuthorizationService authorizationService;
+    private final PermissionFactory permissionFactory;
+
+    protected final ServiceConfigurationManager serviceConfigurationManager;
+    private final TagService tagService;
+    private final TagFactory tagFactory;
+
+    private final GroupRepository groupRepository;
+
+    public GroupServiceValidationUtilsImpl(
+            AuthorizationService authorizationService,
+            PermissionFactory permissionFactory,
+            ServiceConfigurationManager serviceConfigurationManager,
+            TagService tagService,
+            TagFactory tagFactory,
+            GroupRepository groupRepository
+    ) {
+        this.authorizationService = authorizationService;
+        this.permissionFactory = permissionFactory;
+        this.serviceConfigurationManager = serviceConfigurationManager;
+        this.tagService = tagService;
+        this.tagFactory = tagFactory;
+        this.groupRepository = groupRepository;
+    }
+
+    @Override
+    public void validateCreatePreconditions(GroupCreator groupCreator) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(groupCreator.getScopeId().getId(), "groupCreator.scopeId");
+        ArgumentValidator.notEmptyOrNull(groupCreator.getName(), "groupCreator.name");
+        ArgumentValidator.validateEntityName(groupCreator.getName(), "groupCreator.name");
+
+        //
+        // Check Access
+        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.write, groupCreator.getScopeId()));
+    }
+
+    @Override
+    public void validateCreateInTransaction(TxContext txContext, GroupCreator groupCreator) throws KapuaException {
+        // Check entity limit
+        serviceConfigurationManager.checkAllowedEntities(txContext, groupCreator.getScopeId(), "Groups");
+
+        //
+        // Check duplicates
+
+        // .name
+        if (groupRepository.countEntitiesWithNameInScope(txContext, groupCreator.getScopeId(), groupCreator.getName()) > 0) {
+            throw new KapuaDuplicateNameException(groupCreator.getName());
+        }
+    }
+
+    @Override
+    public void validateUpdatePreconditions(Group group) throws KapuaException {
+        //
+        // Argument validation
+        ArgumentValidator.notNull(group, "group");
+        ArgumentValidator.notNull(group.getId(), "group.id");
+        ArgumentValidator.notNull(group.getScopeId(), "group.scopeId");
+        ArgumentValidator.validateEntityName(group.getName(), "group.name");
+
+        // .tagIds
+        validateTagIds(group.getScopeId(), group.getTagIds());
+
+        //
+        // Check Access
+        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.write, group.getScopeId()));
+    }
+
+    @Override
+    public void validateUpdateInTransaction(TxContext txContext, Group group) throws KapuaException {
+        //
+        // Check existence
+        groupRepository
+                .find(txContext, group.getScopeId(), group.getId())
+                .orElseThrow(() -> new KapuaEntityNotFoundException(Group.TYPE, group.getId()));
+
+        //
+        // Check duplicates
+
+        // .name
+        if (groupRepository.countOtherEntitiesWithNameInScope(txContext, group.getScopeId(), group.getId(), group.getName()) > 0) {
+            throw new KapuaDuplicateNameException(group.getName());
+        }
+    }
+
+    @Override
+    public void validateFindPreconditions(KapuaId scopeId, KapuaId groupId) throws KapuaException {
+        // Argument validation
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(groupId, "groupId");
+
+        // Check access
+        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.read, scopeId));
+    }
+
+    @Override
+    public void validateQueryPreconditions(KapuaQuery query) throws KapuaException {
+        // Argument Validation
+        ArgumentValidator.notNull(query, "query");
+
+        // Check Access
+        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.read, query.getScopeId()));
+    }
+
+    @Override
+    public void validateCountPreconditions(KapuaQuery query) throws KapuaException {
+        // Argument Validation
+        ArgumentValidator.notNull(query, "query");
+
+        // Check Access
+        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.read, query.getScopeId()));
+    }
+
+    @Override
+    public void validateDeletePreconditions(KapuaId scopeId, KapuaId groupId) throws KapuaException {
+        // Argument validation
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(groupId, "id");
+
+        // Check Access
+        authorizationService.checkPermission(permissionFactory.newPermission(Domains.GROUP, Actions.delete, scopeId, Group.ANY));
+    }
+
+    @Override
+    public void validateDeleteInTransaction(TxContext txContext, KapuaId scopeId, KapuaId groupId) throws KapuaException {
+        // Check existence
+        Group group = groupRepository
+                .find(txContext, scopeId, groupId)
+                .orElseThrow(() -> new KapuaEntityNotFoundException(Group.TYPE, groupId));
+    }
+
+
+    //
+    // Private methods
+    //
+
+    /**
+     * Applies validation logics to {@link Group#getTagIds()} attribute.
+     * <p>
+     * Requirements are:
+     * <ul>
+     *     <li>The Tags defined must exists</li>
+     * </ul>
+     *
+     * @param tagIds The {@link Group} to check
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    private void validateTagIds(KapuaId scopeId, @NotNull Collection<KapuaId> tagIds) throws KapuaException {
+        if (tagIds.isEmpty()) {
+            return;
+        }
+
+        // Look for Tags
+        TagQuery tagQuery = tagFactory.newQuery(scopeId);
+        tagQuery.setPredicate(tagQuery.attributePredicate(TagAttributes.ENTITY_ID, tagIds));
+        TagListResult dbTags = KapuaSecurityUtils.doPrivileged(() -> tagService.query(tagQuery));
+
+        // Match Tags found with given Tag IDs
+        if (tagIds.size() != dbTags.getSize()) {
+            // Some tags have not been found
+            Set<KapuaId> dbTagsIds =
+                    dbTags.getItems()
+                            .stream()
+                            .map(Tag::getId)
+                            .collect(Collectors.toSet());
+
+            for (KapuaId tagId : tagIds) {
+                if (!dbTagsIds.contains(tagId)) {
+                    throw new KapuaEntityNotFoundException(Tag.TYPE, tagId);
+                }
+            }
+        }
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -76,6 +76,8 @@ import org.eclipse.kapua.service.authorization.group.GroupService;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupFactoryImpl;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupImplJpaRepository;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupServiceImpl;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupServiceValidationUtils;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupServiceValidationUtilsImpl;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.authorization.permission.shiro.PermissionFactoryImpl;
 import org.eclipse.kapua.service.authorization.permission.shiro.PermissionValidator;
@@ -96,6 +98,8 @@ import org.eclipse.kapua.service.authorization.role.shiro.RoleServiceImpl;
 import org.eclipse.kapua.service.authorization.shiro.claims.ClaimsFetcher;
 import org.eclipse.kapua.service.authorization.shiro.claims.ClaimsFetcherImpl;
 import org.eclipse.kapua.service.authorization.shiro.setting.KapuaAuthorizationSetting;
+import org.eclipse.kapua.service.tag.TagFactory;
+import org.eclipse.kapua.service.tag.TagService;
 import org.eclipse.kapua.storage.TxManager;
 
 import com.google.inject.Provides;
@@ -316,15 +320,37 @@ public class AuthorizationModule extends AbstractKapuaModule {
             PermissionFactory permissionFactory,
             AuthorizationService authorizationService,
             Map<Class<?>, ServiceConfigurationManager> serviceConfigurationManagersByServiceClass,
+            GroupServiceValidationUtils groupServiceValidationUtils,
             GroupRepository groupRepository,
             KapuaJpaTxManagerFactory jpaTxManagerFactory
     ) {
         return new GroupServiceImpl(
             jpaTxManagerFactory.create("kapua-authorization"),
             serviceConfigurationManagersByServiceClass.get(GroupService.class),
+            authorizationService,
+            permissionFactory,
+            groupServiceValidationUtils,
+            groupRepository);
+    }
+
+    @Provides
+    @Singleton
+    public GroupServiceValidationUtils groupServiceValidationUtils(
+            AuthorizationService authorizationService,
+            PermissionFactory permissionFactory,
+            Map<Class<?>, ServiceConfigurationManager> serviceConfigurationManagersByServiceClass,
+            TagService tagService,
+            TagFactory tagFactory,
+            GroupRepository userRepository
+    ) {
+        return new GroupServiceValidationUtilsImpl(
                 authorizationService,
                 permissionFactory,
-                groupRepository);
+                serviceConfigurationManagersByServiceClass.get(GroupService.class),
+                tagService,
+                tagFactory,
+                userRepository
+        );
     }
 
     @Provides

--- a/service/security/test/src/test/java/org/eclipse/kapua/service/security/test/SecurityLocatorConfiguration.java
+++ b/service/security/test/src/test/java/org/eclipse/kapua/service/security/test/SecurityLocatorConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -70,10 +70,12 @@ import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoFactoryImp
 import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleFactoryImpl;
 import org.eclipse.kapua.service.authorization.domain.DomainRegistryService;
 import org.eclipse.kapua.service.authorization.group.GroupFactory;
+import org.eclipse.kapua.service.authorization.group.GroupRepository;
 import org.eclipse.kapua.service.authorization.group.GroupService;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupFactoryImpl;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupImplJpaRepository;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupServiceImpl;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupServiceValidationUtilsImpl;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.authorization.permission.shiro.PermissionValidator;
@@ -173,13 +175,23 @@ public class SecurityLocatorConfiguration {
                 bind(RoleFactory.class).toInstance(new RoleFactoryImpl());
                 bind(RolePermissionFactory.class).toInstance(new RolePermissionFactoryImpl());
 
+                GroupRepository groupRepository = new GroupImplJpaRepository(jpaRepoConfig);
+
                 bind(GroupService.class).toInstance(
                     new GroupServiceImpl(
                         txManager,
                         Mockito.mock(ServiceConfigurationManager.class),
                         mockedAuthorization,
                         mockPermissionFactory,
-                        new GroupImplJpaRepository(jpaRepoConfig)
+                        new GroupServiceValidationUtilsImpl(
+                            mockedAuthorization,
+                            mockPermissionFactory,
+                            Mockito.mock(ServiceConfigurationManager.class),
+                            Mockito.mock(TagService.class),
+                            Mockito.mock(TagFactory.class),
+                            groupRepository
+                            ),
+                        groupRepository
                     )
                 );
 


### PR DESCRIPTION
This PR refactors the validation logics of the Group in the Group service.

**Related Issue**
_None_

**Description of the solution adopted**
This PR improves the validation and moves all the validation into a `GroupServiceValidationUtils` class to better readability of the GroupServiceImpl

**Screenshots**
_None_

**Any side note on the changes made**
_None_