### PR TITLE
:sparkles: [Groups] Groups are now filtered based on the Groups that the user can view

### DIFF
--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/GroupQueryHelper.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/GroupQueryHelper.java
@@ -18,4 +18,6 @@ import org.eclipse.kapua.model.query.KapuaQuery;
 public interface GroupQueryHelper {
 
     void handleKapuaQueryGroupPredicate(KapuaQuery query, String domain, String groupPredicateName) throws KapuaException;
+
+    void handleGroupVisibility(KapuaQuery query) throws KapuaException;
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/GroupQueryHelperImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/GroupQueryHelperImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,10 @@ import org.eclipse.kapua.service.authorization.access.AccessRole;
 import org.eclipse.kapua.service.authorization.access.AccessRoleListResult;
 import org.eclipse.kapua.service.authorization.access.AccessRoleRepository;
 import org.eclipse.kapua.service.authorization.access.GroupQueryHelper;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.domain.DomainRepository;
+import org.eclipse.kapua.service.authorization.group.GroupAttributes;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupQueryImpl;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.role.Role;
 import org.eclipse.kapua.service.authorization.role.RolePermission;
@@ -45,18 +49,22 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class GroupQueryHelperImpl implements GroupQueryHelper {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final TxManager txManager;
     private final AccessInfoFactory accessInfoFactory;
     private final AccessInfoRepository accessInfoRepository;
     private final AccessPermissionRepository accessPermissionRepository;
     private final AccessRoleRepository accessRoleRepository;
+    private final DomainRepository domainRepository;
     private final RoleRepository roleRepository;
     private final RolePermissionRepository rolePermissionRepository;
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Inject
     public GroupQueryHelperImpl(
@@ -65,13 +73,16 @@ public class GroupQueryHelperImpl implements GroupQueryHelper {
             AccessInfoRepository accessInfoRepository,
             AccessPermissionRepository accessPermissionRepository,
             AccessRoleRepository accessRoleRepository,
+            DomainRepository domainRepository,
             RoleRepository roleRepository,
-            RolePermissionRepository rolePermissionRepository) {
+            RolePermissionRepository rolePermissionRepository
+    ) {
         this.txManager = txManager;
         this.accessInfoFactory = accessInfoFactory;
         this.accessInfoRepository = accessInfoRepository;
         this.accessPermissionRepository = accessPermissionRepository;
         this.accessRoleRepository = accessRoleRepository;
+        this.domainRepository = domainRepository;
         this.roleRepository = roleRepository;
         this.rolePermissionRepository = rolePermissionRepository;
     }
@@ -83,6 +94,21 @@ public class GroupQueryHelperImpl implements GroupQueryHelper {
             if (kapuaSession != null && !kapuaSession.isTrustedMode()) {
                 txManager.execute(tx -> {
                     handleKapuaQueryGroupPredicate(tx, kapuaSession, query, domain, groupPredicateName);
+                    return null;
+                });
+            }
+        } else {
+            logger.warn("'Access Group Permission' feature is disabled");
+        }
+    }
+
+    @Override
+    public void handleGroupVisibility(KapuaQuery query) throws KapuaException {
+        final KapuaSession kapuaSession = KapuaSecurityUtils.getSession();
+        if (accessInfoFactory != null) {
+            if (kapuaSession != null && !kapuaSession.isTrustedMode()) {
+                txManager.execute(tx -> {
+                    handleGroupVisibility(tx, kapuaSession, query);
                     return null;
                 });
             }
@@ -147,6 +173,87 @@ public class GroupQueryHelperImpl implements GroupQueryHelper {
             query.setPredicate(andPredicate);
         } catch (Exception e) {
             throw KapuaException.internalError(e, "Error while grouping!");
+        }
+    }
+
+    private void handleGroupVisibility(TxContext txContext, KapuaSession kapuaSession, KapuaQuery query) throws KapuaException{
+        try {
+            //
+            // Gather all groups that the user has access to
+            KapuaId userId = kapuaSession.getUserId();
+
+            Optional<AccessInfo> optionalAccessInfo = accessInfoRepository.findByUserId(txContext, kapuaSession.getScopeId(), userId);
+
+            Set<Permission> allPermissions = new HashSet<>();
+            if (optionalAccessInfo.isPresent()) {
+                AccessInfo accessInfo = optionalAccessInfo.get();
+
+                // Read from Permission granted to the User
+                AccessPermissionListResult accessPermissions = accessPermissionRepository.findByAccessInfoId(txContext, accessInfo.getScopeId(), accessInfo.getId());
+
+                for (AccessPermission accessPermission : accessPermissions.getItems()) {
+                    allPermissions.add(accessPermission.getPermission());
+                }
+
+                // Read from Roles granted to the User
+                AccessRoleListResult accessRoles = accessRoleRepository.findByAccessInfoId(txContext, accessInfo.getScopeId(), accessInfo.getId());
+                for (AccessRole ar : accessRoles.getItems()) {
+                    KapuaId roleId = ar.getRoleId();
+
+                    Role role = roleRepository
+                            .find(txContext, ar.getScopeId(), roleId)
+                            .orElseThrow(() -> new KapuaEntityNotFoundException(Role.TYPE, roleId));
+
+                    RolePermissionListResult rolePermissions = rolePermissionRepository.findByRoleId(txContext, role.getScopeId(), roleId);
+                    for (RolePermission rolePermission : rolePermissions.getItems()) {
+                        allPermissions.add(rolePermission.getPermission());
+                    }
+                }
+            }
+
+            //
+            // Extract list of Groups
+            // FIXME: make this load once
+            Map<String, Domain> allDomains =
+                this.domainRepository.query(
+                                txManager.getTxContext(),
+                                new GroupQueryImpl(KapuaId.ANY)
+                        )
+                        .getItemsAsMap(Domain::getName);
+
+            Set<KapuaId> groupIds = new HashSet<>();
+            for (Permission permission : allPermissions) {
+                Domain permissionDomain = allDomains.get(permission.getDomain());
+
+                if (permissionDomain == null || permissionDomain.getGroupable()) {
+                    if (permission.getGroupId() != null) {
+                        groupIds.add(permission.getGroupId());
+                    }
+                    else {
+                        groupIds.clear();
+                        break;
+                    }
+                }
+            }
+
+            //
+            // Create AttributePredicate on Group.id if there is a specific set of AccessGroup in Permissions
+            AndPredicate andPredicate = query.andPredicate();
+            if (!groupIds.isEmpty()) {
+                andPredicate.and(
+                        query.attributePredicate(GroupAttributes.ENTITY_ID, groupIds)
+                );
+            }
+
+            //
+            // Merge User-defined query predicates with the AttributePredicate on Groups
+            if (query.getPredicate() != null) {
+                andPredicate.and(query.getPredicate());
+            }
+
+            query.setPredicate(andPredicate);
+        } catch (Exception e) {
+            throw KapuaException.internalError(e, "Error filtering visible domains! Error: " + e.getMessage());
         }
     }
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -20,7 +20,9 @@ import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.access.GroupQueryHelper;
 import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.authorization.group.GroupAttributes;
 import org.eclipse.kapua.service.authorization.group.GroupCreator;
 import org.eclipse.kapua.service.authorization.group.GroupListResult;
 import org.eclipse.kapua.service.authorization.group.GroupQuery;
@@ -46,6 +48,8 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
 
     private final GroupServiceValidationUtils groupServiceValidationUtils;
 
+    private final GroupQueryHelper groupQueryHelper;
+
     private final GroupRepository groupRepository;
 
     /**
@@ -65,6 +69,7 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
             GroupServiceValidationUtils groupServiceValidationUtils,
+            GroupQueryHelper groupQueryHelper,
             GroupRepository groupRepository
     ) {
         super(
@@ -76,6 +81,7 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
         );
 
         this.groupServiceValidationUtils = groupServiceValidationUtils;
+        this.groupQueryHelper = groupQueryHelper;
         this.groupRepository = groupRepository;
     }
 
@@ -121,10 +127,32 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
         groupServiceValidationUtils.validateFindPreconditions(scopeId, groupId);
 
         // Do find
-        return txManager.execute(
-            tx -> groupRepository
-                .find(tx, scopeId, groupId))
-                .orElse(null);
+        // FIXME: make this use GroupRepository.find and then check on validateFindPostconditions access to the Group fpunt
+        // Group group = txManager.execute(
+        //     tx -> groupRepository
+        //         .find(tx, scopeId, groupId))
+        //         .orElse(null);
+
+        // FIXME: remove this once the GroupRepository.find is restored.
+        // Using GroupRepository.query because it supports the Group visibility filtering via GroupQueryHelper.handleGroupVisibility
+        GroupQuery groupQuery = new GroupQueryImpl(scopeId);
+        groupQuery.setPredicate(
+            groupQuery.attributePredicate(GroupAttributes.ENTITY_ID, groupId)
+        );
+
+        Group group = txManager.execute(
+            tx -> {
+                groupQueryHelper.handleGroupVisibility(groupQuery);
+
+                return groupRepository.query(tx, groupQuery);
+            }
+        ).getFirstItem();
+
+        // Validate postconditions
+        groupServiceValidationUtils.validateFindPostconditions(group);
+
+        // Return result
+        return group;
     }
 
     @Override
@@ -133,7 +161,13 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
         groupServiceValidationUtils.validateQueryPreconditions(query);
 
         // Do query
-        return txManager.execute(tx -> groupRepository.query(tx, query));
+        return txManager.execute(
+            tx -> {
+                groupQueryHelper.handleGroupVisibility(query);
+
+                return groupRepository.query(tx, query);
+            }
+        );
     }
 
     @Override
@@ -142,7 +176,13 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
         groupServiceValidationUtils.validateCountPreconditions(query);
 
         // Do count
-        return txManager.execute(tx -> groupRepository.count(tx, query));
+        return txManager.execute(
+            tx -> {
+                groupQueryHelper.handleGroupVisibility(query);
+
+                return groupRepository.count(tx, query);
+            }
+        );
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceValidationUtils.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceValidationUtils.java
@@ -78,6 +78,14 @@ public interface GroupServiceValidationUtils {
     void validateFindPreconditions(KapuaId scopeId, KapuaId groupId) throws KapuaException;
 
     /**
+     * Validates output for {@link GroupService#find(KapuaId, KapuaId)}
+
+     * @param group The {@link Group} to check
+     * @since 2.1.0
+     */
+    void validateFindPostconditions(Group group);
+
+    /**
      * Validates {@link KapuaQuery} for {@link GroupService#query(KapuaQuery)}
      *
      * @param query The {@link KapuaQuery} to validate
@@ -115,5 +123,6 @@ public interface GroupServiceValidationUtils {
      * @since 2.1.0
      */
     void validateDeleteInTransaction(TxContext txContext, KapuaId scopeId, KapuaId groupId) throws KapuaException;
+
 
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceValidationUtilsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceValidationUtilsImpl.java
@@ -144,6 +144,13 @@ public final class GroupServiceValidationUtilsImpl implements GroupServiceValida
     }
 
     @Override
+    public void validateFindPostconditions(Group group) {
+        if (group != null) {
+
+        }
+    }
+
+    @Override
     public void validateQueryPreconditions(KapuaQuery query) throws KapuaException {
         // Argument Validation
         ArgumentValidator.notNull(query, "query");

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
@@ -322,6 +322,7 @@ public class AuthorizationModule extends AbstractKapuaModule {
             Map<Class<?>, ServiceConfigurationManager> serviceConfigurationManagersByServiceClass,
             GroupServiceValidationUtils groupServiceValidationUtils,
             GroupRepository groupRepository,
+            GroupQueryHelper groupQueryHelper,
             KapuaJpaTxManagerFactory jpaTxManagerFactory
     ) {
         return new GroupServiceImpl(
@@ -330,6 +331,7 @@ public class AuthorizationModule extends AbstractKapuaModule {
             authorizationService,
             permissionFactory,
             groupServiceValidationUtils,
+            groupQueryHelper,
             groupRepository);
     }
 
@@ -461,6 +463,7 @@ public class AuthorizationModule extends AbstractKapuaModule {
             AccessInfoRepository accessInfoRepository,
             AccessPermissionRepository accessPermissionRepository,
             AccessRoleRepository accessRoleRepository,
+            DomainRepository domainRepository,
             RoleRepository roleRepository,
             RolePermissionRepository rolePermissionRepository) {
         return new GroupQueryHelperImpl(
@@ -469,6 +472,7 @@ public class AuthorizationModule extends AbstractKapuaModule {
                 accessInfoRepository,
                 accessPermissionRepository,
                 accessRoleRepository,
+                domainRepository,
                 roleRepository,
                 rolePermissionRepository);
     }

--- a/service/security/test/src/test/java/org/eclipse/kapua/service/security/test/SecurityLocatorConfiguration.java
+++ b/service/security/test/src/test/java/org/eclipse/kapua/service/security/test/SecurityLocatorConfiguration.java
@@ -191,6 +191,7 @@ public class SecurityLocatorConfiguration {
                             Mockito.mock(TagFactory.class),
                             groupRepository
                             ),
+                        mockGroupQueryHelper,
                         groupRepository
                     )
                 );


### PR DESCRIPTION
This PR makes visibility of Access Group based on the permission that a User has.

**Related Issue**
_None_

**Description of the solution adopted**
A user will be allowed to see only Access Group on which it has permissions on.

**Screenshots**
_None_

**Any side note on the changes made**
_None_