### PR TITLE
:bug: [Access Groups] Fixed Entity Groups handling of TagIds atttribute

### DIFF
--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/group/DeviceGroupCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/group/DeviceGroupCreator.java
@@ -14,11 +14,18 @@ package org.eclipse.kapua.service.device.registry.group;
 
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * {@link DeviceGroup} {@link KapuaEntityCreator} definition
@@ -29,4 +36,23 @@ import javax.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceGroupXmlRegistry.class, factoryMethod = "newCreator")
 public interface DeviceGroupCreator extends KapuaNamedEntityCreator<DeviceGroup> {
+
+    /**
+     * Gets the set of Tag id assigned to this entity.
+     *
+     * @return The set Tag id assigned to this entity.
+     * @since 2.1.0
+     */
+    @XmlElementWrapper(name = "tagIds")
+    @XmlElement(name = "tagId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    Set<KapuaId> getTagIds();
+
+    /**
+     * Sets the set of Tag id of this entity.
+     *
+     * @param tagIds The set Tag id to assign.
+     * @since 2.1.0
+     */
+    void setTagIds(Set<KapuaId> tagIds);
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/group/internal/DeviceGroupCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/group/internal/DeviceGroupCreatorImpl.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.group.internal;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.group.DeviceGroup;
@@ -24,6 +27,10 @@ import org.eclipse.kapua.service.device.registry.group.DeviceGroupCreator;
  */
 public class DeviceGroupCreatorImpl extends AbstractKapuaNamedEntityCreator<DeviceGroup> implements DeviceGroupCreator {
 
+    private static final long serialVersionUID = 2736033455537233881L;
+
+    private Set<KapuaId> tagIds;
+
     /**
      * Constructor.
      *
@@ -34,4 +41,18 @@ public class DeviceGroupCreatorImpl extends AbstractKapuaNamedEntityCreator<Devi
         super(scopeId);
     }
 
+
+    @Override
+    public Set<KapuaId> getTagIds() {
+        if (tagIds == null) {
+            tagIds = new HashSet<>();
+        }
+
+        return tagIds;
+    }
+
+    @Override
+    public void setTagIds(Set<KapuaId> tagIds) {
+        this.tagIds = tagIds;
+    }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/group/internal/DeviceGroupServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/group/internal/DeviceGroupServiceImpl.java
@@ -83,6 +83,7 @@ public class DeviceGroupServiceImpl implements DeviceGroupService {
         groupCreator.setName(deviceGroupCreator.getName());
         groupCreator.setDescription(deviceGroupCreator.getDescription());
         groupCreator.setDomain(Domains.DEVICE);
+        groupCreator.setTagIds(deviceGroupCreator.getTagIds());
 
         // Do create
         Group group = KapuaSecurityUtils.doPrivileged(() -> groupService.create(groupCreator));

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupCreator.java
@@ -13,11 +13,18 @@
 package org.eclipse.kapua.service.authorization.group;
 
 import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * {@link GroupCreator} definition.
@@ -46,4 +53,23 @@ public interface GroupCreator extends KapuaNamedEntityCreator<Group> {
      * @since 2.1.0
      */
     void setDomain(String domain);
+
+    /**
+     * Gets the set of Tag id assigned to this entity.
+     *
+     * @return The set Tag id assigned to this entity.
+     * @since 2.1.0
+     */
+    @XmlElementWrapper(name = "tagIds")
+    @XmlElement(name = "tagId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    Set<KapuaId> getTagIds();
+
+    /**
+     * Sets the set of Tag id of this entity.
+     *
+     * @param tagIds The set Tag id to assign.
+     * @since 2.1.0
+     */
+    void setTagIds(Set<KapuaId> tagIds);
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImpl.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group.shiro;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.domain.DomainCreator;
@@ -28,6 +31,7 @@ public class GroupCreatorImpl extends AbstractKapuaNamedEntityCreator<Group> imp
     private static final long serialVersionUID = -4676187845961673421L;
 
     private String domain;
+    private Set<KapuaId> tagIds;
 
     /**
      * Constructor
@@ -52,5 +56,19 @@ public class GroupCreatorImpl extends AbstractKapuaNamedEntityCreator<Group> imp
     @Override
     public void setDomain(String domain) {
         this.domain = domain;
+    }
+
+    @Override
+    public Set<KapuaId> getTagIds() {
+        if (tagIds == null) {
+            tagIds = new HashSet<>();
+        }
+
+        return tagIds;
+    }
+
+    @Override
+    public void setTagIds(Set<KapuaId> tagIds) {
+        this.tagIds = tagIds;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -100,6 +100,7 @@ public class GroupServiceImpl extends KapuaConfigurableServiceBase implements Gr
             group.setName(groupCreator.getName());
             group.setDescription(groupCreator.getDescription());
             group.setDomain(groupCreator.getDomain());
+            group.setTagIds(groupCreator.getTagIds());
 
             return groupRepository.create(tx, group);
         });

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/group/UserGroupCreator.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/group/UserGroupCreator.java
@@ -14,11 +14,18 @@ package org.eclipse.kapua.service.user.group;
 
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * {@link UserGroup} {@link KapuaEntityCreator} definition
@@ -29,4 +36,23 @@ import javax.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = UserGroupXmlRegistry.class, factoryMethod = "newCreator")
 public interface UserGroupCreator extends KapuaNamedEntityCreator<UserGroup> {
+
+    /**
+     * Gets the set of Tag id assigned to this entity.
+     *
+     * @return The set Tag id assigned to this entity.
+     * @since 2.1.0
+     */
+    @XmlElementWrapper(name = "tagIds")
+    @XmlElement(name = "tagId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    Set<KapuaId> getTagIds();
+
+    /**
+     * Sets the set of Tag id of this entity.
+     *
+     * @param tagIds The set Tag id to assign.
+     * @since 2.1.0
+     */
+    void setTagIds(Set<KapuaId> tagIds);
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupCreatorImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupCreatorImpl.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.group.internal;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.user.group.UserGroup;
@@ -24,6 +27,10 @@ import org.eclipse.kapua.service.user.group.UserGroupCreator;
  */
 public class UserGroupCreatorImpl extends AbstractKapuaNamedEntityCreator<UserGroup> implements UserGroupCreator {
 
+    private static final long serialVersionUID = 7080526107362000587L;
+
+    private Set<KapuaId> tagIds;
+
     /**
      * Constructor.
      *
@@ -34,4 +41,17 @@ public class UserGroupCreatorImpl extends AbstractKapuaNamedEntityCreator<UserGr
         super(scopeId);
     }
 
+    @Override
+    public Set<KapuaId> getTagIds() {
+        if (tagIds == null) {
+            tagIds = new HashSet<>();
+        }
+
+        return tagIds;
+    }
+
+    @Override
+    public void setTagIds(Set<KapuaId> tagIds) {
+        this.tagIds = tagIds;
+    }
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.service.user.group.internal;
 
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.group.Group;
 import org.eclipse.kapua.service.user.group.UserGroup;
@@ -55,17 +56,25 @@ public class UserGroupImpl extends AbstractKapuaNamedEntity implements UserGroup
     }
 
     @Override
-    public Set<KapuaId> getTagIds() {
-        if (tagIds == null) {
-            tagIds = new HashSet<>();
-        }
+    public void setTagIds(Set<KapuaId> tagIds) {
+        this.tagIds = new HashSet<>();
 
-        return tagIds;
+        for (KapuaId id : tagIds) {
+            this.tagIds.add(KapuaEid.parseKapuaId(id));
+        }
     }
 
     @Override
-    public void setTagIds(Set<KapuaId> tagIds) {
-        this.tagIds = tagIds;
+    public Set<KapuaId> getTagIds() {
+        Set<KapuaId> tagIds = new HashSet<>();
+
+        if (this.tagIds != null) {
+            for (KapuaId deviceTagId : this.tagIds) {
+                tagIds.add(new KapuaEid(deviceTagId));
+            }
+        }
+
+        return tagIds;
     }
 
     /**

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupServiceImpl.java
@@ -83,6 +83,7 @@ public class UserGroupServiceImpl implements UserGroupService {
         groupCreator.setName(userGroupCreator.getName());
         groupCreator.setDescription(userGroupCreator.getDescription());
         groupCreator.setDomain(Domains.USER);
+        groupCreator.setTagIds(userGroupCreator.getTagIds());
 
         // Do create
         Group group = KapuaSecurityUtils.doPrivileged(() -> groupService.create(groupCreator));


### PR DESCRIPTION
This PR fixes handling of TagIds field in:

- Access Groups
- Device Groups
- User Groups

**Related Issue**
_None_

**Description of the solution adopted**
Fixess handling of the field `tagIds`

**Screenshots**
_None_

**Any side note on the changes made**
_None_