### PR TITLE
⬆️  Upgraded netty to 4.1.130 final - CVE-2025-58056 CVE-2025-58057 CVE-2025-59419

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <liquibase.version>3.6.3</liquibase.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.124.Final</netty.version>
+        <netty.version>4.1.130.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <ow2-asm.version>9.4</ow2-asm.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>


### PR DESCRIPTION
Upgraded version to fix components CVEs:

- CVE-2025-58056 
- CVE-2025-58057 
- CVE-2025-59419