### PR TITLE
🐛 [Authorization] Added check to ensure uniqueness of AccessInfo for a User

### DIFF
--- a/qa/integration/src/test/resources/features/authorization/AccessInfoService.feature
+++ b/qa/integration/src/test/resources/features/authorization/AccessInfoService.feature
@@ -281,7 +281,7 @@ Feature: Access Info Service CRUD tests
       | name     | displayName  | email              | phoneNumber     |
       | kapua-u1 | Kapua User 1 | kapua_u1@kapua.com | +386 31 323 555 |
     Then I create the access info entity
-    Then I create the access info entity
+    And I expect the exception "KapuaEntityUniquenessException" with the text "Duplicate accessInfo entry for values"
     Then I create the access info entity
     Given Scope with ID 20
     When I configure the user service for the account with the id 20
@@ -289,6 +289,7 @@ Feature: Access Info Service CRUD tests
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities | 5     |
     Then I create the access info entity
+    And I expect the exception "KapuaEntityUniquenessException" with the text "Duplicate accessInfo entry for values"
     Then I create the access info entity
     Given Scope with ID 30
     When I configure the user service for the account with the id 30
@@ -297,9 +298,9 @@ Feature: Access Info Service CRUD tests
       | integer | maxNumberChildEntities | 5     |
     Then I create the access info entity
     When I count the access info entities for scope 10
-    Then I count 3
+    Then I count 1
     When I count the access info entities for scope 20
-    Then I count 2
+    Then I count 1
     When I count the access info entities for scope 30
     Then I count 1
     When I count the access info entities for scope 42
@@ -307,8 +308,7 @@ Feature: Access Info Service CRUD tests
     Then I logout
 
   Scenario: Query for all the access info entities of a specific user
-  It must be possible to find all the access info entities that belong
-  to a specific user.
+  It only be possible to create one access info for a User.
 
     When I login as user with name "kapua-sys" and password "kapua-password"
     Given Scope with ID 1
@@ -320,19 +320,10 @@ Feature: Access Info Service CRUD tests
       | name     | displayName  | email              | phoneNumber     |
       | kapua-u1 | Kapua User 1 | kapua_u1@kapua.com | +386 31 323 555 |
     And I create the access info entity
-    And I create the access info entity
-    And I create the access info entity
-    And I create the access info entity
-    When I query for the access info entities for the last user
-    Then I count 4
-    Given I have the following user
-      | name     | displayName  | email              | phoneNumber     |
-      | kapua-u2 | Kapua User 2 | kapua_u2@kapua.com | +386 31 323 555 |
-    And I create the access info entity
-    And I create the access info entity
+    And I expect the exception "KapuaEntityUniquenessException" with the text "Duplicate accessInfo entry for values"
     And I create the access info entity
     When I query for the access info entities for the last user
-    Then I count 3
+    Then I count 1
     Then I logout
 
   Scenario: Query for all the access info entities of an invalid user

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.service.authorization.access.shiro;
 
 import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.domains.Domains;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
@@ -47,6 +48,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * {@link AccessInfoService} implementation based on JPA.
@@ -96,9 +102,16 @@ public class AccessInfoServiceImpl implements AccessInfoService {
     @Override
     public AccessInfo create(AccessInfoCreator accessInfoCreator)
             throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(accessInfoCreator, "accessInfoCreator");
-        // Check Access
+        ArgumentValidator.notNull(accessInfoCreator.getScopeId(), "accessInfoCreator.scopeId");
+        ArgumentValidator.notNull(accessInfoCreator.getUserId(), "accessInfoCreator.userId");
+
+        //
+        // Check access
         authorizationService.checkPermission(permissionFactory.newPermission(Domains.ACCESS_INFO, Actions.write, accessInfoCreator.getScopeId()));
+
         // If permission are created out of the access info scope, check that the current user has the permission on the external scopeId.
         if (accessInfoCreator.getPermissions() != null) {
             for (Permission p : accessInfoCreator.getPermissions()) {
@@ -109,13 +122,25 @@ public class AccessInfoServiceImpl implements AccessInfoService {
         }
 
         permissionValidator.validatePermissions(accessInfoCreator.getPermissions());
+
         return txManager.execute(tx -> {
+            Optional<AccessInfo> optionalAccessInfo = accessInfoRepository.findByUserId(tx, accessInfoCreator.getScopeId(), accessInfoCreator.getUserId());
+
+            if (optionalAccessInfo.isPresent()) {
+                List<Map.Entry<String, Object>> uniquesFieldValues = new ArrayList<>();
+
+                uniquesFieldValues.add(new AbstractMap.SimpleEntry<>(AccessInfoAttributes.SCOPE_ID, accessInfoCreator.getScopeId()));
+                uniquesFieldValues.add(new AbstractMap.SimpleEntry<>(AccessInfoAttributes.USER_ID, accessInfoCreator.getUserId()));
+
+                throw new KapuaEntityUniquenessException(AccessInfo.TYPE, uniquesFieldValues);
+            }
+
             if (accessInfoCreator.getRoleIds() != null) {
                 for (KapuaId roleId : accessInfoCreator.getRoleIds()) {
                     // This checks also that the role belong to the same scopeId in which the access info is created
-                    Role role = roleRepository.find(tx, accessInfoCreator.getScopeId(), roleId)
-                            // If role is not present then roleId does not exist, or it is in another Account scope.
-                            .orElseThrow(() -> new KapuaEntityNotFoundException(Role.TYPE, roleId));
+                    roleRepository.find(tx, accessInfoCreator.getScopeId(), roleId)
+                        // If role is not present then roleId does not exist, or it is in another Account scope.
+                        .orElseThrow(() -> new KapuaEntityNotFoundException(Role.TYPE, roleId));
                 }
             }
 

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.steps;
 
+import com.google.common.base.MoreObjects;
 import com.google.inject.Singleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
@@ -25,7 +26,6 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
-import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdImpl;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -55,11 +55,14 @@ import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService;
 import org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaOptionFactoryImpl;
 import org.eclipse.kapua.service.authentication.credential.shiro.CredentialQueryImpl;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
 import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
 import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
 import org.eclipse.kapua.service.authorization.access.AccessInfoService;
 import org.eclipse.kapua.service.authorization.access.AccessPermission;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionAttributes;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionCreator;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionFactory;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionQuery;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionService;
 import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionQueryImpl;
@@ -128,6 +131,7 @@ public class UserServiceSteps extends TestBase {
     private CredentialFactory credentialFactory;
     private CredentialsFactory credentialsFactory;
     private AccessPermissionService accessPermissionService;
+    private AccessPermissionFactory accessPermissionFactory;
 
     @Inject
     public UserServiceSteps(StepData stepData) {
@@ -151,6 +155,7 @@ public class UserServiceSteps extends TestBase {
         credentialFactory = locator.getFactory(CredentialFactory.class);
         credentialsFactory = locator.getFactory(CredentialsFactory.class);
         accessPermissionService = locator.getService(AccessPermissionService.class);
+        accessPermissionFactory = locator.getFactory(AccessPermissionFactory.class);
     }
 
     @Before
@@ -845,7 +850,29 @@ public class UserServiceSteps extends TestBase {
         KapuaSecurityUtils.doPrivileged(() -> {
             primeException();
             try {
-                accessInfoService.create(accessInfoCreatorCreator(permissionList, user, account));
+                AccessInfo accessInfo = accessInfoService.findByUserId(user.getUser().getScopeId(), user.getUser().getId());
+
+                // If AccessInfo does not exist, create a new one.
+                if (accessInfo == null) {
+                    accessInfoService.create(accessInfoCreatorCreator(permissionList, user, account));
+                }
+                // If Access info exists, add to the existing one.
+                else {
+                    for (CucPermission cucPermission : permissionList) {
+
+                        AccessPermissionCreator accessPermissionCreator = accessPermissionFactory.newCreator(accessInfo.getScopeId());
+                        accessPermissionCreator.setAccessInfoId(accessInfo.getId());
+                        accessPermissionCreator.setPermission(
+                            permissionFactory.newPermission(
+                                cucPermission.getDomain(),
+                                cucPermission.getAction(),
+                                MoreObjects.firstNonNull(cucPermission.getTargetScopeId(), account.getId())
+                            )
+                        );
+
+                        accessPermissionService.create(accessPermissionCreator);
+                    }
+                }
             } catch (KapuaException ke) {
                 verifyException(ke);
             }
@@ -864,28 +891,32 @@ public class UserServiceSteps extends TestBase {
      * @return AccessInfoCreator instance for creating user permissions
      */
     private AccessInfoCreator accessInfoCreatorCreator(List<CucPermission> permissionList, ComparableUser user, Account account) throws KapuaException {
-        AccessInfoCreator accessInfoCreator = accessInfoFactory.newCreator(account.getId());
-        accessInfoCreator.setUserId(user.getUser().getId());
-        accessInfoCreator.setScopeId(user.getUser().getScopeId());
         Set<Permission> permissions = new HashSet<>();
         if (permissionList != null) {
             for (CucPermission cucPermission : permissionList) {
                 stepData.remove(LAST_PERMISSION_ADDED_TO_USER);
-                Actions action = cucPermission.getAction();
-                KapuaId targetScopeId = cucPermission.getTargetScopeId();
-                if (targetScopeId == null) {
-                    targetScopeId = (KapuaEid) account.getId();
-                }
-                Permission permission = permissionFactory.newPermission(cucPermission.getDomain(),
-                        action, targetScopeId);
+
+                Permission permission =
+                    permissionFactory.newPermission(
+                        cucPermission.getDomain(),
+                        cucPermission.getAction(),
+                        MoreObjects.firstNonNull(cucPermission.getTargetScopeId(), account.getId())
+                );
                 permissions.add(permission);
+
                 stepData.put(LAST_PERMISSION_ADDED_TO_USER, permission);
             }
         } else {
-            Permission permission = permissionFactory.newPermission((String) null, null, null);
-            permissions.add(permission);
+            permissions.add(
+                permissionFactory.newPermission(null, null, null)
+            );
         }
+
+        AccessInfoCreator accessInfoCreator = accessInfoFactory.newCreator(account.getId());
+        accessInfoCreator.setUserId(user.getUser().getId());
+        accessInfoCreator.setScopeId(user.getUser().getScopeId());
         accessInfoCreator.setPermissions(permissions);
+
         return accessInfoCreator;
     }
 


### PR DESCRIPTION
This PR fixes an issue where a User was allowed to have more than one AccessInfo

**Related Issue**
_None_

**Description of the solution adopted**
Added a check to prevent duplicate creation of an AccessInfo for the same User.

**Screenshots**
_None_

**Any side note on the changes made**
Fixed and adapted relates tests