### PR TITLE
:bug: [Broker] Review in memory blocking queue events layer and metrics

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/MetricsSecurityPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/MetricsSecurityPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.artemis.plugin.security;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.eclipse.kapua.KapuaException;
@@ -33,9 +34,14 @@ public class MetricsSecurityPlugin {
     private static final String TOTAL_MESSAGE = "total_message";
     private static final String TOTAL_MESSAGE_ACKNOWLEDGED = "total_message_acknowledged";
     private static final String TOTAL_MESSAGE_ADDED = "total_message_added";
+    private static final String SECURITY_PLUGIN_EVENT = "security_plugin_event";
 
     private final MetricsService metricsService;
     private final String metricModuleName;
+
+    private Counter processedEvent;
+    private Counter dequeuedEvent;
+    private Counter enqueuedEvent;
 
     @Inject
     public MetricsSecurityPlugin(
@@ -55,6 +61,21 @@ public class MetricsSecurityPlugin {
         metricsService.registerGauge(() -> server.getTotalMessageCount(), metricModuleName, LoginMetric.COMPONENT_LOGIN, TOTAL_MESSAGE, MetricsLabel.SIZE);
         metricsService.registerGauge(() -> server.getTotalMessagesAcknowledged(), metricModuleName, LoginMetric.COMPONENT_LOGIN, TOTAL_MESSAGE_ACKNOWLEDGED, MetricsLabel.SIZE);
         metricsService.registerGauge(() -> server.getTotalMessagesAdded(), metricModuleName, LoginMetric.COMPONENT_LOGIN, TOTAL_MESSAGE_ADDED, MetricsLabel.SIZE);
+
+        processedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "processed");
+        dequeuedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "dequeued");
+        enqueuedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "enqueued");
     }
 
+    public Counter getProcessedEvent() {
+        return processedEvent;
+    }
+
+    public Counter getDequeuedEvent() {
+        return dequeuedEvent;
+    }
+
+    public Counter getEnqueuedEvent() {
+        return enqueuedEvent;
+    }
 }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,7 +41,6 @@ import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSettingKey
 import org.eclipse.kapua.client.security.context.SessionContext;
 import org.eclipse.kapua.client.security.context.Utils;
 import org.eclipse.kapua.commons.core.ServiceModuleBundle;
-import org.eclipse.kapua.commons.metric.CommonsMetric;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
@@ -117,9 +116,6 @@ public class ServerPlugin implements ActiveMQServerPlugin {
         this.publishInfoMessageSizeLimit = brokerSetting.getInt(BrokerSettingKey.PUBLISHED_MESSAGE_SIZE_LOG_THRESHOLD, DEFAULT_PUBLISHED_MESSAGE_SIZE_LOG_THRESHOLD);
         serverContext = kapuaLocator.getComponent(ServerContext.class);
         deviceConnectionEventListenerService = kapuaLocator.getComponent(DeviceConnectionEventListenerService.class);
-        brokerEventHandler = new BrokerEventHandler(kapuaLocator.getComponent(CommonsMetric.class));
-        brokerEventHandler.registerConsumer((brokerEvent) -> disconnectClient(brokerEvent));
-        brokerEventHandler.start();
     }
 
     @Override
@@ -128,6 +124,11 @@ public class ServerPlugin implements ActiveMQServerPlugin {
         try {
             String clusterName = SystemSetting.getInstance().getString(SystemSettingKey.CLUSTER_NAME);
             serverContext.init(server);
+            KapuaLocator kapuaLocator = KapuaLocator.getInstance();
+            //metricsSecurityPlugin (singleton) initialized by serverContext.init(server)
+            brokerEventHandler = new BrokerEventHandler("ServerPlugin", 0l, 10000l, kapuaLocator.getComponent(MetricsSecurityPlugin.class));
+            brokerEventHandler.registerConsumer((brokerEvent) -> disconnectClient(brokerEvent));
+            brokerEventHandler.start();
             acceptorHandler = new AcceptorHandler(server,
                     brokerSetting.getMap(String.class, BrokerSettingKey.ACCEPTORS));
             //init activateCallback to handle acceptor initialization instead of calling it from here

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/event/BrokerEventHandler.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/event/BrokerEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,74 +12,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.artemis.plugin.security.event;
 
+import org.eclipse.kapua.broker.artemis.plugin.security.MetricsSecurityPlugin;
 import org.eclipse.kapua.commons.localevent.EventHandler;
-import org.eclipse.kapua.commons.localevent.EventProcessor;
-import org.eclipse.kapua.commons.localevent.ExecutorWrapper;
-import org.eclipse.kapua.commons.metric.CommonsMetric;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.TimeUnit;
+public class BrokerEventHandler extends EventHandler<BrokerEvent> {
 
-public class BrokerEventHandler {
-    private static Logger logger = LoggerFactory.getLogger(EventHandler.class);
-    private final CommonsMetric commonsMetric;
-
-    private boolean running;
-    private ExecutorWrapper executorWrapper;
-    private static final int MAX_ONGOING_OPERATION = 10;
-    private static final int POLL_TIMEOUT = 10000;
-
-    private BlockingQueue<BrokerEvent> eventQueue = new LinkedBlockingDeque<>(MAX_ONGOING_OPERATION);
-    private EventProcessor<BrokerEvent> eventProcessor;
-
-    @Inject
-    public BrokerEventHandler(CommonsMetric commonsMetric) {
-        this.commonsMetric = commonsMetric;
-        executorWrapper = new ExecutorWrapper(BrokerEventHandler.class.getName(), () -> {
-            while (isRunning()) {
-                try {
-                    final BrokerEvent eventBean = eventQueue.poll(POLL_TIMEOUT, TimeUnit.MILLISECONDS);
-                    if (eventBean != null) {
-                        commonsMetric.getDequeuedEvent().inc();
-                        eventProcessor.processEvent(eventBean);
-                        commonsMetric.getProcessedEvent().inc();
-                    }
-                } catch (InterruptedException e) {
-                    //do nothing...
-                    this.stop();
-                    Thread.currentThread().interrupt();
-                } catch (Exception e) {
-                    //do nothing
-                    logger.error("Error while processing event: {}", e.getMessage(), e);
-                    //TODO add metric?
-                }
-            }
-        }, 10, TimeUnit.SECONDS);
-    }
-
-    public void enqueueEvent(BrokerEvent eventBean) {
-        eventQueue.add(eventBean);
-        commonsMetric.getEnqueuedEvent().inc();
-    }
-
-    public void registerConsumer(EventProcessor<BrokerEvent> eventProcessor) {
-        this.eventProcessor = eventProcessor;
-    }
-
-    public void start() {
-        running = true;
-        executorWrapper.start();
-    }
-
-    public void stop() {
-        running = false;
-    }
-
-    public boolean isRunning() {
-        return running;
+    public BrokerEventHandler(String name, long initialDelay, long pollTimeout,
+            MetricsSecurityPlugin metricsSecurityPlugin) {
+        super(name, initialDelay, pollTimeout,
+                metricsSecurityPlugin.getEnqueuedEvent(),
+                metricsSecurityPlugin.getDequeuedEvent(),
+                metricsSecurityPlugin.getProcessedEvent());
     }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/localevent/EventHandler.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/localevent/EventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,43 +12,54 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.localevent;
 
-import org.eclipse.kapua.commons.metric.CommonsMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Counter;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @param <O> Who knows?
- * @deprecated since 2.0.0 - this was probably intended to be part of a larger abstraction that never came to fruition - as it is now it just creates confusion.
- * Do not use, will be removed in future releases
+ * Generic class to allow different component to interact with a blocking queue.
+ * This is usable to distribute internal events without involving brokers.
+ * This class provide a consumer that polling for new messages in the queue and a producer method to put new messages in that queue.
+ * O generic object
  */
-@Deprecated
 public abstract class EventHandler<O> {
 
     private static Logger logger = LoggerFactory.getLogger(EventHandler.class);
-    private final CommonsMetric commonsMetric;
 
     private boolean running;
     private ExecutorWrapper executorWrapper;
     private static final int MAX_ONGOING_OPERATION = 10;
-    private static final int POLL_TIMEOUT = 10000;
 
     private BlockingQueue<O> eventQueue = new LinkedBlockingDeque<>(MAX_ONGOING_OPERATION);
     private EventProcessor<O> eventProcessor;
 
-    protected EventHandler(CommonsMetric commonsMetric, String name, long initialDelay, long pollTimeout) {
-        this.commonsMetric = commonsMetric;
+    private Counter enqueuedEvent;
+
+    /**
+     * Default constructor. Warn: doesn't start without start() is called
+     * @param name Event handler name useful to distinguish between multiple instances (and used while logging information)
+     * @param initialDelay initial delay before executor start, after start() is called (in seconds!)
+     * @param pollTimeout poll timeout (in milliseconds!)
+     * @param enqueuedEvent counter for enqueued events
+     * @param dequeuedEvent counter for dequeued events
+     * @param processedEvent counter for processed events
+     */
+    public EventHandler(String name, long initialDelay, long pollTimeout,
+            Counter enqueuedEvent, Counter dequeuedEvent, Counter processedEvent) {
+        this.enqueuedEvent = enqueuedEvent;
         executorWrapper = new ExecutorWrapper(name, () -> {
             while (isRunning()) {
                 try {
-                    O eventBean = eventQueue.poll(POLL_TIMEOUT, TimeUnit.MILLISECONDS);
+                    O eventBean = eventQueue.poll(pollTimeout, TimeUnit.MILLISECONDS);
                     if (eventBean != null) {
-                        commonsMetric.getDequeuedEvent().inc();
+                        dequeuedEvent.inc();
                         eventProcessor.processEvent(eventBean);
-                        commonsMetric.getProcessedEvent().inc();
+                        processedEvent.inc();
                     }
                 } catch (InterruptedException e) {
                     //do nothing...
@@ -64,7 +75,7 @@ public abstract class EventHandler<O> {
 
     public void enqueueEvent(O eventBean) {
         eventQueue.add(eventBean);
-        commonsMetric.getEnqueuedEvent().inc();
+        enqueuedEvent.inc();
     }
 
     public void registerConsumer(EventProcessor<O> eventProcessor) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/CommonsMetric.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/CommonsMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,8 +14,6 @@ package org.eclipse.kapua.commons.metric;
 
 import com.codahale.metrics.Counter;
 import org.eclipse.kapua.KapuaException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -26,8 +24,6 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class CommonsMetric {
-
-    private static final Logger logger = LoggerFactory.getLogger(CommonsMetric.class);
 
     private final String module;
     //cache
@@ -52,12 +48,6 @@ public class CommonsMetric {
     private Counter cacheRemoval;
     private Counter cacheError;
 
-    //events
-    public static final String EVENT = "event";
-    private Counter processedEvent;
-    private Counter enqueuedEvent;
-    private Counter dequeuedEvent;
-
     @Inject
     public CommonsMetric(MetricsService metricsService,
                          @Named("metricModuleName") String metricModuleName) throws KapuaException {
@@ -75,10 +65,6 @@ public class CommonsMetric {
         cacheHit = metricsService.getCounter(module, CACHE_ENTITY, "hit");
         cacheRemoval = metricsService.getCounter(module, CACHE_ENTITY, "removed");
         cacheError = metricsService.getCounter(module, CACHE_ENTITY, "error");
-
-        processedEvent = metricsService.getCounter(module, EVENT, "processed");
-        dequeuedEvent = metricsService.getCounter(module, EVENT, "dequeued");
-        enqueuedEvent = metricsService.getCounter(module, EVENT, "enqueued");
     }
 
     public String getModule() {
@@ -124,18 +110,6 @@ public class CommonsMetric {
 
     public Counter getCacheError() {
         return cacheError;
-    }
-
-    public Counter getProcessedEvent() {
-        return processedEvent;
-    }
-
-    public Counter getDequeuedEvent() {
-        return dequeuedEvent;
-    }
-
-    public Counter getEnqueuedEvent() {
-        return enqueuedEvent;
     }
 
 }


### PR DESCRIPTION
Brief description of the PR.
This pr reviews the internal in memory blocking queue layer.

**Related Issue**
none

**Description of the solution adopted**
This pr reviews the internal in memory blocking queue layer, removing duplicated code (the broker-plugin module had the same code of the generic class used to handle message dispatch and sending) and move the related metrics out of commons metrics. In this way these metrics are not repetead in the containers that are not using this feature.
This feature is useful when an event doesn't need to be persisted, so even if lost there is no issue, and have to be used only internally to the JVM. Otherwise, obviously, we have the broker to achive this task.

**Screenshots**
none

**Any side note on the changes made**
none