### PR TITLE
:bug: [Groups] Fixed missing audit fields in UserGroup and DeviceGroup

### DIFF
--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/group/DeviceGroup.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/group/DeviceGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/group/internal/DeviceGroupImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/group/internal/DeviceGroupImpl.java
@@ -54,6 +54,27 @@ public class DeviceGroupImpl extends AbstractKapuaNamedEntity implements DeviceG
         setTagIds(deviceGroup.getTagIds());
     }
 
+    /**
+     * Map constructor
+     *
+     * @param group The {@link Group} to map
+     * @since 2.1.0
+     */
+    public DeviceGroupImpl(Group group) {
+        setScopeId(group.getScopeId());
+        setId(group.getId());
+        setCreatedBy(group.getCreatedBy());
+        setCreatedOn(group.getCreatedOn());
+        setModifiedBy(group.getModifiedBy());
+        setModifiedOn(group.getModifiedOn());
+        setTagIds(group.getTagIds());
+        setName(group.getName());
+        setDescription(group.getDescription());
+        setEntityAttributes(group.getEntityAttributes());
+        setEntityProperties(group.getEntityProperties());
+        setOptlock(group.getOptlock());
+    }
+
     @Override
     public Set<KapuaId> getTagIds() {
         if (tagIds == null) {

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/group/internal/DeviceGroupServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/group/internal/DeviceGroupServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,18 +88,8 @@ public class DeviceGroupServiceImpl implements DeviceGroupService {
         // Do create
         Group group = KapuaSecurityUtils.doPrivileged(() -> groupService.create(groupCreator));
 
-        // Convert
-        DeviceGroup deviceGroup = new DeviceGroupImpl(group.getScopeId());
-        deviceGroup.setId(group.getId());
-        deviceGroup.setTagIds(group.getTagIds());
-        deviceGroup.setName(group.getName());
-        deviceGroup.setDescription(group.getDescription());
-        deviceGroup.setEntityAttributes(group.getEntityAttributes());
-        deviceGroup.setEntityProperties(group.getEntityProperties());
-        deviceGroup.setOptlock(group.getOptlock());
-
         // Return result
-        return deviceGroup;
+        return new DeviceGroupImpl(group);
     }
 
     @Override
@@ -121,18 +111,8 @@ public class DeviceGroupServiceImpl implements DeviceGroupService {
         // Do update
         Group updatedGroup = KapuaSecurityUtils.doPrivileged(() -> groupService.update(group));
 
-        // Convert
-        DeviceGroup updatedDeviceGroup = new DeviceGroupImpl(updatedGroup.getScopeId());
-        updatedDeviceGroup.setId(updatedGroup.getId());
-        updatedDeviceGroup.setTagIds(updatedGroup.getTagIds());
-        updatedDeviceGroup.setName(updatedGroup.getName());
-        updatedDeviceGroup.setDescription(updatedGroup.getDescription());
-        updatedDeviceGroup.setEntityAttributes(updatedGroup.getEntityAttributes());
-        updatedDeviceGroup.setEntityProperties(updatedGroup.getEntityProperties());
-        updatedDeviceGroup.setOptlock(updatedGroup.getOptlock());
-
         // Return result
-        return updatedDeviceGroup;
+        return new DeviceGroupImpl(updatedGroup);
     }
 
     @Override
@@ -148,14 +128,7 @@ public class DeviceGroupServiceImpl implements DeviceGroupService {
         }
 
         // Convert
-        DeviceGroup deviceGroup = new DeviceGroupImpl(group.getScopeId());
-        deviceGroup.setId(group.getId());
-        deviceGroup.setTagIds(group.getTagIds());
-        deviceGroup.setName(group.getName());
-        deviceGroup.setDescription(group.getDescription());
-        deviceGroup.setEntityAttributes(group.getEntityAttributes());
-        deviceGroup.setEntityProperties(group.getEntityProperties());
-        deviceGroup.setOptlock(group.getOptlock());
+        DeviceGroup deviceGroup = new DeviceGroupImpl(group);
 
         // Validate post-conditions
         deviceGroupServiceValidationUtils.validateFindPostConditions(deviceGroup);
@@ -205,19 +178,8 @@ public class DeviceGroupServiceImpl implements DeviceGroupService {
         deviceGroups.addItems(
             groups.getItems()
                   .stream()
-                  .map((group)-> {
-                      DeviceGroup deviceGroup = new DeviceGroupImpl(group.getScopeId());
-                      deviceGroup.setId(group.getId());
-                      deviceGroup.setTagIds(group.getTagIds());
-                      deviceGroup.setName(group.getName());
-                      deviceGroup.setDescription(group.getDescription());
-                      deviceGroup.setEntityAttributes(group.getEntityAttributes());
-                      deviceGroup.setEntityProperties(group.getEntityProperties());
-                      deviceGroup.setOptlock(group.getOptlock());
-
-                      return deviceGroup;
-                  }
-            ).collect(Collectors.toList())
+                  .map(DeviceGroupImpl::new)
+            .collect(Collectors.toList())
         );
 
         // Return result

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/group/UserGroup.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/group/UserGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupImpl.java
@@ -37,7 +37,7 @@ public class UserGroupImpl extends AbstractKapuaNamedEntity implements UserGroup
      * Constructor.
      *
      * @param scopeId the scope {@link KapuaId}
-     * @since 1.0.0
+     * @since 2.1.0
      */
     public UserGroupImpl(KapuaId scopeId) {
         super(scopeId);
@@ -47,12 +47,33 @@ public class UserGroupImpl extends AbstractKapuaNamedEntity implements UserGroup
      * Clone constructor.
      *
      * @param userGroup the {@link Group} to clone.
-     * @since 1.0.0
+     * @since 2.1.0
      */
     public UserGroupImpl(UserGroup userGroup) {
         super(userGroup);
 
         setTagIds(userGroup.getTagIds());
+    }
+
+    /**
+     * Map constructor
+     *
+     * @param group The {@link Group} to map
+     * @since 2.1.0
+     */
+    public UserGroupImpl(Group group) {
+        setScopeId(group.getScopeId());
+        setId(group.getId());
+        setCreatedBy(group.getCreatedBy());
+        setCreatedOn(group.getCreatedOn());
+        setModifiedBy(group.getModifiedBy());
+        setModifiedOn(group.getModifiedOn());
+        setTagIds(group.getTagIds());
+        setName(group.getName());
+        setDescription(group.getDescription());
+        setEntityAttributes(group.getEntityAttributes());
+        setEntityProperties(group.getEntityProperties());
+        setOptlock(group.getOptlock());
     }
 
     @Override

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/group/internal/UserGroupServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -106,11 +106,8 @@ public class UserGroupServiceImpl implements UserGroupService {
         // Do create
         Group group = KapuaSecurityUtils.doPrivileged(() -> groupService.create(groupCreator));
 
-        // Convert
-        UserGroup userGroup = mapToUserGroup(group);
-
         // Return result
-        return userGroup;
+        return new UserGroupImpl(group);
     }
 
     @Override
@@ -132,11 +129,8 @@ public class UserGroupServiceImpl implements UserGroupService {
         // Do update
         Group updatedGroup = KapuaSecurityUtils.doPrivileged(() -> groupService.update(group));
 
-        // Convert
-        UserGroup updatedUserGroup = mapToUserGroup(updatedGroup);
-
         // Return result
-        return updatedUserGroup;
+        return new UserGroupImpl(updatedGroup);
     }
 
     @Override
@@ -152,7 +146,7 @@ public class UserGroupServiceImpl implements UserGroupService {
         }
 
         // Convert
-        UserGroup userGroup = mapToUserGroup(group);
+        UserGroup userGroup = new UserGroupImpl(group);
 
         // Validate post-conditions
         userGroupServiceValidationUtils.validateFindPostConditions(userGroup);
@@ -239,12 +233,8 @@ public class UserGroupServiceImpl implements UserGroupService {
         userGroups.addItems(
             groups.getItems()
                   .stream()
-                  .map((group)-> {
-                      UserGroup userGroup = mapToUserGroup(group);
-
-                      return userGroup;
-                  }
-            ).collect(Collectors.toList())
+                  .map(UserGroupImpl::new)
+            .collect(Collectors.toList())
         );
 
         // Return result
@@ -293,17 +283,5 @@ public class UserGroupServiceImpl implements UserGroupService {
 
         // Do delete
         KapuaSecurityUtils.doPrivileged(() -> groupService.delete(scopeId, userGroupId));
-    }
-
-    private static UserGroup mapToUserGroup(Group group) {
-        UserGroup userGroup = new UserGroupImpl(group.getScopeId());
-        userGroup.setId(group.getId());
-        userGroup.setTagIds(group.getTagIds());
-        userGroup.setName(group.getName());
-        userGroup.setDescription(group.getDescription());
-        userGroup.setEntityAttributes(group.getEntityAttributes());
-        userGroup.setEntityProperties(group.getEntityProperties());
-        userGroup.setOptlock(group.getOptlock());
-        return userGroup;
     }
 }


### PR DESCRIPTION
This PR fixes missing audit fields (`createdBy`, `createdOn`, `modifiedBy`, `modifiedOn`) missing when returning `DeviceGroup` and `UserGroup`

**Related Issue**
_None_

**Description of the solution adopted**
Fixed conversion from `Group` to `DeviceGroup`/`UserGroup`

**Screenshots**
_None_

**Any side note on the changes made**
_None_