### PR TITLE
:bug: [Device Management] Fixed DeviceConfiguration AttributeDefinition translation of 'default' property

### DIFF
--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppConfigurationKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppConfigurationKapuaKura.java
@@ -143,7 +143,7 @@ public class TranslatorAppConfigurationKapuaKura extends AbstractTranslatorKapua
         kapuaDefinition.getAD().forEach(kapuaAd -> {
             KapuaTad ad = new KapuaTad();
             ad.setCardinality(kapuaAd.getCardinality());
-            ad.setDefault(ad.getDefault());
+            ad.setDefault(kapuaAd.getDefault());
             ad.setDescription(kapuaAd.getDescription());
             ad.setId(kapuaAd.getId());
             ad.setMax(kapuaAd.getMax());

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
@@ -112,7 +112,7 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
         kuraDefinition.getAD().forEach(kuraAd -> {
             KapuaTad ad = new KapuaTad();
             ad.setCardinality(kuraAd.getCardinality());
-            ad.setDefault(ad.getDefault());
+            ad.setDefault(kuraAd.getDefault());
             ad.setDescription(kuraAd.getDescription());
             ad.setId(kuraAd.getId());
             ad.setMax(kuraAd.getMax());


### PR DESCRIPTION
This PR fixes a small issue in the translation from `KapuaDeviceConfiguration` to `KuraDeviceConfiguration` (and viceversa) of the `default` attribute of an `AttributeDefinition`.

**Related Issue**
_None_

**Description of the solution adopted**
Fixed object used to pass values

**Screenshots**
_None_

**Any side note on the changes made**
_None_