### PR TITLE
🐛 [Core] Added null check on serviceConfigurationManager to prevent NPE 

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceBase.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceBase.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalStateException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.model.config.metatype.EmptyTocd;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
@@ -38,9 +39,7 @@ import org.eclipse.kapua.storage.TxManager;
  *
  * @since 2.0.0
  */
-public class KapuaConfigurableServiceBase
-        implements KapuaConfigurableService,
-        KapuaService {
+public class KapuaConfigurableServiceBase implements KapuaConfigurableService, KapuaService {
 
     protected final TxManager txManager;
     protected final ServiceConfigurationManager serviceConfigurationManager;
@@ -53,37 +52,51 @@ public class KapuaConfigurableServiceBase
             ServiceConfigurationManager serviceConfigurationManager,
             String authorizationDomain,
             AuthorizationService authorizationService,
-            PermissionFactory permissionFactory) {
+            PermissionFactory permissionFactory
+    ) {
         this.txManager = txManager;
-        this.serviceConfigurationManager = serviceConfigurationManager;
         this.domain = authorizationDomain;
+        this.serviceConfigurationManager = serviceConfigurationManager;
         this.authorizationService = authorizationService;
         this.permissionFactory = permissionFactory;
+
+        if (serviceConfigurationManager == null) {
+            throw new KapuaIllegalStateException("ServiceConfigurationManager not available! Check KapuaModule configuration!");
+        }
     }
 
     @Override
     public boolean isServiceEnabled(KapuaId scopeId) throws KapuaException {
+        //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
 
+        //
+        // Check service enabled
         return txManager.execute(tx -> serviceConfigurationManager.isServiceEnabled(tx, scopeId));
     }
 
     @Override
     public KapuaTocd getConfigMetadata(KapuaId scopeId) throws KapuaException {
+        //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
 
+        //
         // Check access
         if (!authorizationService.isPermitted(permissionFactory.newPermission(domain, Actions.read, scopeId))) {
             //Temporary, use Optional instead
             return new EmptyTocd();
         }
+
+        //
+        // Do get
         return serviceConfigurationManager.getConfigMetadata(scopeId, true).orElse(null);
     }
 
     @Override
     public Map<String, Object> getConfigValues(KapuaId scopeId) throws KapuaException {
+        //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
 
@@ -91,17 +104,25 @@ public class KapuaConfigurableServiceBase
         if (!authorizationService.isPermitted(permissionFactory.newPermission(domain, Actions.read, scopeId))) {
             return Collections.emptyMap();
         }
+
+        //
+        // Do get
         return serviceConfigurationManager.getConfigValues(scopeId, true);
     }
 
     @Override
     public void setConfigValues(KapuaId scopeId, KapuaId parentId, Map<String, Object> values) throws KapuaException {
+        //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(values, "values");
 
+        //
+        // Check access
         authorizationService.checkPermission(permissionFactory.newPermission(domain, Actions.write, scopeId));
 
+        //
+        // Do set
         serviceConfigurationManager.setConfigValues(scopeId, Optional.ofNullable(parentId), values);
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -72,15 +72,22 @@ public class DeviceConnectionServiceImpl extends KapuaConfigurableServiceBase im
      */
     @Inject
     public DeviceConnectionServiceImpl(
-            Map<Class<?>, ServiceConfigurationManager> serviceConfigurationManagersByServiceClass,
+            ServiceConfigurationManager serviceConfigurationManager,
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
             DeviceConnectionFactory entityFactory,
             @Named("DeviceRegistryTransactionManager") TxManager txManager,
             DeviceConnectionRepository repository,
             Map<String, DeviceConnectionCredentialAdapter> availableDeviceConnectionAdapters,
-            EventStorer eventStorer) {
-        super(txManager, serviceConfigurationManagersByServiceClass.get(DeviceConnectionService.class), Domains.DEVICE_CONNECTION, authorizationService, permissionFactory);
+            EventStorer eventStorer
+    ) {
+        super(
+            txManager,
+            serviceConfigurationManager,
+            Domains.DEVICE_CONNECTION,
+            authorizationService,
+            permissionFactory
+        );
         this.entityFactory = entityFactory;
         this.repository = repository;
         this.availableDeviceConnectionAdapters = availableDeviceConnectionAdapters;

--- a/service/device/registry/test/src/test/java/org/eclipse/kapua/service/device/registry/test/DeviceRegistryLocatorConfiguration.java
+++ b/service/device/registry/test/src/test/java/org/eclipse/kapua/service/device/registry/test/DeviceRegistryLocatorConfiguration.java
@@ -160,7 +160,7 @@ public class DeviceRegistryLocatorConfiguration {
                 classServiceConfigurationManagerMap.put(DeviceConnectionService.class, Mockito.mock(ServiceConfigurationManager.class));
 
                 final DeviceConnectionService deviceConnectionService = new DeviceConnectionServiceImpl(
-                        classServiceConfigurationManagerMap,
+                        classServiceConfigurationManagerMap.get(DeviceConnectionService.class),
                         mockedAuthorization,
                         permissionFactory,
                         new DeviceConnectionFactoryImpl(),

--- a/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/TagLocatorConfiguration.java
+++ b/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/TagLocatorConfiguration.java
@@ -154,7 +154,7 @@ public class TagLocatorConfiguration {
                 classServiceConfigurationManagerMap.put(DeviceConnectionService.class, Mockito.mock(ServiceConfigurationManager.class));
 
                 final DeviceConnectionServiceImpl deviceConnectionService = new DeviceConnectionServiceImpl(
-                        classServiceConfigurationManagerMap,
+                        classServiceConfigurationManagerMap.get(DeviceConnectionService.class),
                         mockedAuthorization,
                         permissionFactory,
                         new DeviceConnectionFactoryImpl(),


### PR DESCRIPTION
This PR fixes a NPE in `KapuaConfigurableServiceBase` when `serviceConfigurationManager` is not correctly initialised and the Map of available ServiceConfigurationManages does not contain the requested entry.

**Related Issue**
_None_

**Description of the solution adopted**
Added a `null` check on init.

**Screenshots**
_None_

**Any side note on the changes made**
Fixed init of `DeviceConnectionServiceImpl` to be the same as other ServiceImpls init