### PR TITLE
✨ [Extras] Added Device Group to Device Groups migrator tool

### DIFF
--- a/extras/device-group-migrator/README.md
+++ b/extras/device-group-migrator/README.md
@@ -1,0 +1,32 @@
+Kapua Encryption Migrator
+==========
+
+## Introduction
+
+This module contains a Java Application that leverages the Kapua APIs to migrate `Device.groupId` attribute to the new `Device.groupIds` attribute introduced in Kapua 2.1.0
+
+This tool copies the former field data into the new one.
+
+## Background
+
+To improve the Device group-ability and make Access Groups more flexible, now a Device can be assigned with one or more Access Group. 
+
+### Settings
+
+No additional settings to run this migration.
+
+Other useful properties from Kapua
+
+| Name                       | Description                  | Default Value |
+|----------------------------|------------------------------|---------------|
+| commons.db.name            | The target database name     | kapuadb       |
+| commons.db.username        | The target database username | kapua         | 
+| commons.db.password        | The target database password | kapua         | 
+| commons.db.connection.host | The target database host     | 192.168.33.10 |
+| commons.db.connection.port | The target database port     | 3306          | 
+
+#### Example usage
+
+```bash
+java -Dcommons.db.connection.host=somehost -jar kapua-device-group-migrator-2.1.0-SNAPSHOT-app.jar
+```

--- a/extras/device-group-migrator/pom.xml
+++ b/extras/device-group-migrator/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>kapua-extras</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>2.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-device-group-migrator</artifactId>
+
+    <dependencies>
+        <!-- -->
+        <!-- Kapua -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-locator-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-shiro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-api</artifactId>
+        </dependency>
+
+        <!-- -->
+        <!-- External-->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+        </dependency>
+
+        <!-- -->
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/maven/**</exclude>
+                                <exclude>META-INF/DEPENDENCIES</exclude>
+                                <exclude>bundle.properties</exclude>
+                                <exclude>about.*</exclude>
+                                <exclude>OSGI-OPT/**</exclude>
+                                <exclude>LICENSE</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>org.eclipse.kapua.extras.migrator.device.group.Application</mainClass>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                            <addHeader>false</addHeader>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                    </transformers>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>app</shadedClassifierName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/Application.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/Application.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.device.group;
+
+import com.google.common.base.Strings;
+import org.eclipse.kapua.commons.jpa.KapuaJpaTxManagerFactory;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Application {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Application.class.getName());
+
+    private static final SystemSetting SYSTEM_SETTING = SystemSetting.getInstance();
+
+    private Application() {
+    }
+
+    public static void main(String[] args) {
+        LOG.info("Device Group to Device Groups Migration Tool... STARTING");
+        try {
+            printConfiguration();
+
+            LOG.info("Device Group to Device Groups Attribute Migrator...");
+            {
+                new DeviceGroupToGroupsAttributeMigrator(
+                    "kapua-device-group-to-device-groups-migrator",
+                    new KapuaJpaTxManagerFactory(SYSTEM_SETTING.getInt(SystemSettingKey.KAPUA_INSERT_MAX_RETRY))
+                ).migrate();
+            }
+            LOG.info("Device Group to Device Groups Attribute Migrator...DONE!");
+
+        } catch (Exception e) {
+            LOG.info("Device Group to Device Groups Attribute Migrator... ERROR!", e);
+            return;
+        }
+
+        LOG.info("Entity Secret Attribute Migration Tool... DONE!");
+    }
+
+    /**
+     * Prints the JDBC and {@link DeviceGroupToGroupsAttributeMigrator} configuration on startup.
+     *
+     * @since 2.1.0
+     */
+    protected static void printConfiguration() {
+        ConfigurationPrinter configurationPrinter =
+                ConfigurationPrinter.create()
+                        .withLogger(LOG)
+                        .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
+                        .withTitle("Device Group to Device Groups Migration Tool Configuration");
+
+        configurationPrinter
+                .openSection("JDBC Configuration")
+                .addParameter("Resolver", System.getProperty(SystemSettingKey.DB_JDBC_CONNECTION_URL_RESOLVER.key()))
+                .addParameter("Driver", System.getProperty(SystemSettingKey.DB_JDBC_DRIVER.key()))
+                .addParameter("Scheme", System.getProperty(SystemSettingKey.DB_CONNECTION_SCHEME.key()))
+                .addParameter("Host", System.getProperty(SystemSettingKey.DB_CONNECTION_HOST.key()))
+                .addParameter("Port", System.getProperty(SystemSettingKey.DB_CONNECTION_PORT.key()))
+                .addParameter("Database Name", System.getProperty(SystemSettingKey.DB_NAME.key()))
+                .addParameter("Database Schema", System.getProperty(SystemSettingKey.DB_SCHEMA.key()))
+                .addParameter("Username", Strings.isNullOrEmpty(System.getProperty(SystemSettingKey.DB_USERNAME.key())) ? "No" : "Yes")
+                .addParameter("Password", Strings.isNullOrEmpty(System.getProperty(SystemSettingKey.DB_PASSWORD.key())) ? "No" : "Yes")
+                .addParameter("SSL Enabled", System.getProperty(SystemSettingKey.DB_CONNECTION_USE_SSL.key()))
+                .addParameter("SSL Enabled Protocols", System.getProperty(SystemSettingKey.DB_CONNECTION_ENABLED_SSL_PROTOCOL_SUITES.key()))
+                .closeSection();
+
+        configurationPrinter.printLog();
+    }
+}

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsAttributeMigrator.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsAttributeMigrator.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.device.group;
+
+import com.google.common.collect.Sets;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
+import org.eclipse.kapua.commons.jpa.KapuaJpaTxManagerFactory;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceAttributes;
+import org.eclipse.kapua.service.device.registry.DeviceListResult;
+import org.eclipse.kapua.service.device.registry.DeviceQuery;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeviceGroupToGroupsAttributeMigrator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceGroupToGroupsAttributeMigrator.class);
+
+    private DeviceRegistryService deviceRegistryService;
+
+    protected DeviceGroupToGroupsAttributeMigrator(String persistenceUnitName , KapuaJpaTxManagerFactory jpaTxManagerFactory) {
+        this.deviceRegistryService = new DeviceGroupToGroupsMigratorServiceImpl(
+            jpaTxManagerFactory.create(persistenceUnitName),
+            new DeviceGroupToGroupsMigratorJpaRepository(new KapuaJpaRepositoryConfiguration())
+        );
+    }
+
+    public void migrate() throws KapuaException {
+
+        DeviceQuery deviceQuery = new DeviceQueryMigratorImpl();
+        deviceQuery.setScopeId(KapuaId.ANY);
+
+        deviceQuery.setPredicate(
+            deviceQuery.attributePredicate(DeviceAttributes.GROUP_ID, new Object(), AttributePredicate.Operator.NOT_NULL)
+        );
+
+        DeviceListResult devices = deviceRegistryService.query(deviceQuery);
+
+        LOG.info("Found {} Devices that have a Group assigned", devices.getSize());
+
+        try {
+            LOG.info("Migrating Device.groupId to Device.groupIds...");
+
+            for (Device device : devices.getItems()) {
+                LOG.info("    Migrating Device {}/{}...", device.getId(), device.getClientId());
+
+                if (device.getGroupIds().isEmpty()) {
+                    device.setGroupIds(Sets.newHashSet(device.getGroupId()));
+                    LOG.info("    Migrating Device {}/{}... DONE!", device.getId(), device.getClientId());
+                }
+                else {
+                    LOG.info("    Migrating Device {}/{}... Was already migrated!", device.getId(), device.getClientId());
+                }
+
+                deviceRegistryService.update(device);
+            }
+
+            LOG.info("Migrating Device.groupId to Device.groupIds... DONE!");
+        }
+        catch (Exception e) {
+            LOG.info("Migrating Device.groupId to Device.groupIds... ERROR!", e);
+            throw e;
+        }
+    }
+}

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsAttributeMigrator.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsAttributeMigrator.java
@@ -58,13 +58,7 @@ public class DeviceGroupToGroupsAttributeMigrator {
             for (Device device : devices.getItems()) {
                 LOG.info("    Migrating Device {}/{}...", device.getId(), device.getClientId());
 
-                if (device.getGroupIds().isEmpty()) {
-                    device.setGroupIds(Sets.newHashSet(device.getGroupId()));
-                    LOG.info("    Migrating Device {}/{}... DONE!", device.getId(), device.getClientId());
-                }
-                else {
-                    LOG.info("    Migrating Device {}/{}... Was already migrated!", device.getId(), device.getClientId());
-                }
+                device.setGroupIds(Sets.newHashSet(device.getGroupId()));
 
                 deviceRegistryService.update(device);
             }

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsMigratorJpaRepository.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsMigratorJpaRepository.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2026, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.device.group;
+
+import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
+import org.eclipse.kapua.commons.jpa.KapuaUpdatableEntityJpaRepository;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceListResult;
+import org.eclipse.kapua.service.device.registry.DeviceRepository;
+import org.eclipse.kapua.storage.TxContext;
+
+import java.util.Optional;
+
+public class DeviceGroupToGroupsMigratorJpaRepository
+        extends KapuaUpdatableEntityJpaRepository<Device, DeviceMigratorImpl, DeviceListResult>
+        implements DeviceRepository {
+
+    public DeviceGroupToGroupsMigratorJpaRepository(KapuaJpaRepositoryConfiguration jpaRepoConfig) {
+        super(DeviceMigratorImpl.class, Device.TYPE, DeviceListResultMigratorImpl::new, jpaRepoConfig);
+    }
+
+    @Override
+    public Optional<Device> find(TxContext tx, KapuaId scopeId, KapuaId entityId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Device create(TxContext tx, Device entity) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Device delete(TxContext tx, KapuaId scopeId, KapuaId entityId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Device> findByClientId(TxContext tx, KapuaId scopeId, String clientId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Device> findForUpdate(TxContext tx, KapuaId scopeId, KapuaId deviceId) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsMigratorModule.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsMigratorModule.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.device.group;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+
+public class DeviceGroupToGroupsMigratorModule extends AbstractKapuaModule {
+
+    @Override
+    protected void configureModule() {
+    }
+}

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsMigratorServiceImpl.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceGroupToGroupsMigratorServiceImpl.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.device.group;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.config.metatype.KapuaTocd;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceCreator;
+import org.eclipse.kapua.service.device.registry.DeviceListResult;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.device.registry.DeviceRepository;
+import org.eclipse.kapua.storage.TxManager;
+
+import javax.inject.Singleton;
+import java.util.Map;
+
+/**
+ * {@link DeviceRegistryService} implementation.
+ *
+ * @since 2.1.0
+ */
+@Singleton
+public class DeviceGroupToGroupsMigratorServiceImpl implements DeviceRegistryService {
+    private final TxManager txManager;
+    private final DeviceRepository deviceRepository;
+
+    public DeviceGroupToGroupsMigratorServiceImpl(TxManager txManager, DeviceRepository deviceRepository) {
+        this.txManager = txManager;
+        this.deviceRepository = deviceRepository;
+    }
+
+    @Override
+    public Device update(Device device) throws KapuaException {
+        return txManager.execute(tx -> deviceRepository.update(tx, device));
+    }
+
+    @Override
+    public DeviceListResult query(KapuaQuery query) throws KapuaException {
+        return txManager.execute(tx -> deviceRepository.query(tx, query));
+    }
+
+    @Override
+    public Device findByClientId(KapuaId scopeId, String clientId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long count(KapuaQuery query) throws KapuaException {
+        return txManager.execute(tx -> deviceRepository.count(tx, query));
+    }
+
+    // Unsupported methods
+    @Override
+    public Device create(DeviceCreator deviceCreator) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Device find(KapuaId scopeId, KapuaId deviceId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void delete(KapuaId scopeId, KapuaId deviceId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public KapuaTocd getConfigMetadata(KapuaId scopeId) throws KapuaException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Object> getConfigValues(KapuaId scopeId) throws KapuaException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setConfigValues(KapuaId scopeId, KapuaId parentId, Map<String, Object> values) throws KapuaException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceListResultMigratorImpl.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceListResultMigratorImpl.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.device.group;
+
+import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceListResult;
+
+/**
+ * {@link DeviceListResult} implementation.
+ *
+ * @since 2.1.0
+ */
+public class DeviceListResultMigratorImpl extends KapuaListResultImpl<Device> implements DeviceListResult {
+}

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceMigratorImpl.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceMigratorImpl.java
@@ -1,0 +1,399 @@
+/*******************************************************************************
+ * Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.device.group;
+
+import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceExtendedProperty;
+import org.eclipse.kapua.service.device.registry.DeviceStatus;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Basic;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@link Device} implementation.
+ *
+ * @since 2.1.0
+ */
+@Entity(name = "Device")
+@Table(name = "dvc_device")
+public class DeviceMigratorImpl extends AbstractKapuaUpdatableEntity implements Device {
+
+    @Basic
+    @Column(name = "client_id", nullable = false, updatable = false)
+    private String clientId;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "eid", column = @Column(name = "group_id", nullable = true, updatable = true))
+    })
+    private KapuaEid groupId;
+
+    @ElementCollection
+    @CollectionTable(name = "dvc_device_group", joinColumns = @JoinColumn(name = "device_id", referencedColumnName = "id"))
+    @AttributeOverrides({
+            @AttributeOverride(name = "eid", column = @Column(name = "group_id", nullable = false, updatable = false))
+    })
+    private Set<KapuaEid> groupIds;
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    public DeviceMigratorImpl() {
+    }
+
+    @Override
+    public KapuaEid getGroupId() {
+        return groupId;
+    }
+
+    @Override
+    public void setGroupId(KapuaId groupId) {
+        this.groupId = KapuaEid.parseKapuaId(groupId);
+    }
+
+    @Override
+    public Set<KapuaId> getGroupIds() {
+        return new HashSet<>(groupIds);
+    }
+
+    public void setGroupIds(Set<KapuaId> groupIds) {
+        this.groupIds = new HashSet<>();
+
+        for (KapuaId gId : groupIds) {
+            this.groupIds.add(KapuaEid.parseKapuaId(gId));
+        }
+    }
+
+    // Attributes below do not require migration
+    @Override
+    public Set<KapuaId> getTagIds() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTagIds(Set<KapuaId> tagIds) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getClientId() {
+        return clientId;
+    }
+
+    @Override
+    public void setClientId(String clientId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public KapuaId getConnectionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setConnectionId(KapuaId connectionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DeviceConnection getConnection() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DeviceStatus getStatus() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStatus(DeviceStatus status) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getDisplayName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDisplayName(String diplayName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public KapuaId getLastEventId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setLastEventId(KapuaId lastEventId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DeviceEvent getLastEvent() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getSerialNumber() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSerialNumber(String serialNumber) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getModelId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setModelId(String modelId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getModelName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setModelName(String modelName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getImei() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setImei(String imei) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getImsi() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setImsi(String imsi) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getIccid() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setIccid(String iccid) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getBiosVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setBiosVersion(String biosVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getFirmwareVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setFirmwareVersion(String firmwareVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getOsVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setOsVersion(String osVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getJvmVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setJvmVersion(String jvmVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getOsgiFrameworkVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setOsgiFrameworkVersion(String osgiFrameworkVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getApplicationFrameworkVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setApplicationFrameworkVersion(String appFrameworkVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getConnectionInterface() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setConnectionInterface(String connectionInterface) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getConnectionIp() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setConnectionIp(String connectionIp) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getApplicationIdentifiers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setApplicationIdentifiers(String applicationIdentifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getAcceptEncoding() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAcceptEncoding(String acceptEncoding) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCustomAttribute1() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCustomAttribute1(String customAttribute1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCustomAttribute2() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCustomAttribute2(String customAttribute2) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCustomAttribute3() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCustomAttribute3(String customAttribute3) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCustomAttribute4() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCustomAttribute4(String customAttribute4) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCustomAttribute5() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCustomAttribute5(String customAttribute5) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<DeviceExtendedProperty> getExtendedProperties() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addExtendedProperty(DeviceExtendedProperty extendedProperty) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setExtendedProperties(List<DeviceExtendedProperty> extendedProperties) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTamperStatus() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTamperStatus(String tamperStatus) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceQueryMigratorImpl.java
+++ b/extras/device-group-migrator/src/main/java/org/eclipse/kapua/extras/migrator/device/group/DeviceQueryMigratorImpl.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.device.group;
+
+import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.service.device.registry.DeviceMatchPredicate;
+import org.eclipse.kapua.service.device.registry.DeviceQuery;
+
+/**
+ * {@link DeviceQuery} definition.
+ *
+ * @since 2.1.0
+ */
+public class DeviceQueryMigratorImpl extends AbstractKapuaQuery implements DeviceQuery {
+
+    /**
+     * Constructor.
+     *
+     * @since 2.1.0
+     */
+    public DeviceQueryMigratorImpl() {
+        super();
+    }
+
+    @Override
+    public <T> DeviceMatchPredicate<T> matchPredicate(T matchTerm) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/device-group-migrator/src/main/resources/META-INF/persistence.xml
+++ b/extras/device-group-migrator/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+
+    <persistence-unit name="kapua-device-group-to-device-groups-migrator" transaction-type="RESOURCE_LOCAL">
+
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+
+        <class>org.eclipse.kapua.extras.migrator.device.group.DeviceMigratorImpl</class>
+
+        <!-- Base classes and External classes -->
+        <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>
+        <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity</class>
+
+        <properties>
+            <property name="javax.persistence.lock.timeout" value="1000"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/extras/device-group-migrator/src/main/resources/locator.xml
+++ b/extras/device-group-migrator/src/main/resources/locator.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<locator-config>
+    <packages>
+        <package>org.eclipse.kapua.commons</package>
+        <package>org.eclipse.kapua.service</package>
+        <package>org.eclipse.kapua.extras</package>
+        <package>org.eclipse.kapua.model</package>
+    </packages>
+</locator-config>

--- a/extras/device-group-migrator/src/main/resources/logback.xml
+++ b/extras/device-group-migrator/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<!DOCTYPE xml>
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="liquibase" level="WARN"/>
+
+    <root level="${LOGBACK_LOG_LEVEL:-info}">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -25,9 +25,10 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>foreignkeys</module>
-        <module>es-migrator</module>
+        <module>device-group-migrator</module>
         <module>encryption-migrator</module>
+        <module>es-migrator</module>
+        <module>foreignkeys</module>
         <module>liquibase-tool</module>
     </modules>
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidationImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidationImpl.java
@@ -123,9 +123,6 @@ public final class DeviceValidationImpl implements DeviceValidation {
         // .tagIds
         validateTagIds(deviceCreator.getScopeId(), deviceCreator.getTagIds());
 
-        // .groupId
-        validateDeviceCreatorGroupId(deviceCreator);
-
         // .groupIds
         validateGroupIds(deviceCreator.getScopeId(), deviceCreator.getGroupIds());
 
@@ -281,10 +278,6 @@ public final class DeviceValidationImpl implements DeviceValidation {
 
         //
         // Check access
-
-        // Check that current Subject can manage the target Group of the Device
-        // authorizationService.checkPermission(permissionFactory.newPermission(Domains.DEVICE, Actions.write, deviceCreator.getScopeId(), deviceCreator.getGroupId()));
-
         // Check that current Subject can manage all the target Groups
         Set<Permission> groupPermissions = buildSetPermissionsFromGroupIds(Domains.DEVICE, Actions.write, deviceCreator.getScopeId(), deviceCreator.getGroupIds());
         authorizationService.checkPermissions(groupPermissions);
@@ -312,10 +305,8 @@ public final class DeviceValidationImpl implements DeviceValidation {
         ArgumentValidator.notNull(device.getScopeId(), "device.scopeId");
         ArgumentValidator.notNull(device.getId(), "device.id");
 
-        // .groupId
+        // .groupId AND .groupIds
         validateDeviceGroupId(device);
-
-        // .groupIds
         validateGroupIds(device.getScopeId(), device.getGroupIds());
 
         // .tagIds
@@ -480,7 +471,7 @@ public final class DeviceValidationImpl implements DeviceValidation {
     public void validateUpdateInTransaction(TxContext txContext, Device device) throws KapuaException {
 
         // .groupId
-        // checkAccessDeviceGroupId(txContext, device);
+        checkAccessDeviceGroupId(txContext, device);
 
         // .groupIds
         checkAccessDeviceGroupIds(txContext, device);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -12,12 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.internal;
 
+import com.google.common.collect.Sets;
+import org.apache.commons.collections.CollectionUtils;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceBase;
 import org.eclipse.kapua.commons.configuration.ServiceConfigurationManager;
 import org.eclipse.kapua.commons.jpa.EventStorer;
 import org.eclipse.kapua.commons.model.domains.Domains;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -33,9 +38,14 @@ import org.eclipse.kapua.service.device.registry.DeviceQuery;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 import org.eclipse.kapua.service.device.registry.DeviceRepository;
 import org.eclipse.kapua.service.device.registry.common.DeviceValidation;
+import org.eclipse.kapua.storage.TxContext;
 import org.eclipse.kapua.storage.TxManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * {@link DeviceRegistryService} implementation.
@@ -81,6 +91,8 @@ public class DeviceRegistryServiceImpl
 
     @Override
     public Device create(DeviceCreator deviceCreator) throws KapuaException {
+        // Handle legacy DeviceCreator.groupIds usage
+        handleLegacyCreatorGroupIdAttribute(deviceCreator);
 
         // Validate precondition
         deviceValidation.validateCreatePreconditions(deviceCreator);
@@ -141,6 +153,9 @@ public class DeviceRegistryServiceImpl
         // Do update
         return txManager.execute(
             tx -> {
+                // Handle legacy Device.groupIds usage
+                handleLegacyCreatorGroupIdAttribute(tx, device);
+
                 // Validate in-transaction conditions
                 deviceValidation.validateUpdateInTransaction(tx, device);
 
@@ -255,6 +270,75 @@ public class DeviceRegistryServiceImpl
     //
     // Private methods
     //
+
+    /**
+     * Handles legacy use of {@link DeviceCreator#getGroupId()}.
+     *
+     * @param deviceCreator The source {@link DeviceCreator}
+     * @throws KapuaIllegalArgumentException If both {@link DeviceCreator#getGroupIds()} and {@link DeviceCreator#getGroupIds()} are used.
+     * @since 6.1.0
+     */
+    private static void handleLegacyCreatorGroupIdAttribute(DeviceCreator deviceCreator) throws KapuaIllegalArgumentException {
+        ArgumentValidator.notNull(deviceCreator, "deviceCreator");
+
+        if (deviceCreator.getGroupId() != null && !deviceCreator.getGroupIds().isEmpty()) {
+            throw new KapuaIllegalArgumentException("deviceCreator.groupId", deviceCreator.getGroupId().toString());
+        }
+
+        if (deviceCreator.getGroupId() != null) {
+            deviceCreator.setGroupIds(Sets.newHashSet(deviceCreator.getGroupId()));
+        }
+    }
+
+    /**
+     * Handles legacy use of {@link Device#getGroupId()}.
+     *
+     * @param device The source {@link Device}
+     * @since 6.1.0
+     */
+    private void handleLegacyCreatorGroupIdAttribute(TxContext txContext, Device device) throws KapuaIllegalArgumentException, KapuaEntityNotFoundException {
+        ArgumentValidator.notNull(device, "device");
+
+        Optional<Device> optionalCurrentDevice = deviceRepository.find(txContext, device.getScopeId(), device.getId());
+
+        Device currentDevice = optionalCurrentDevice.orElseThrow(() -> new KapuaEntityNotFoundException(Device.TYPE, device.getId()));
+
+        if (
+            Objects.equals(device.getGroupId(), currentDevice.getGroupId()) &&
+            CollectionUtils.isEqualCollection(device.getGroupIds(), currentDevice.getGroupIds())
+        ) {
+            // No changes to the values. Nothing to do
+            return;
+        }
+
+        if (
+            Objects.equals(device.getGroupId(), currentDevice.getGroupId()) &&
+            !CollectionUtils.isEqualCollection(device.getGroupIds(), currentDevice.getGroupIds())
+        ) {
+            // Device.groupIds has been changed. User has already migrated therefore we can remove value for Device.groupId
+            device.setGroupId(null);
+            return;
+        }
+
+        if (
+            !Objects.equals(device.getGroupId(), currentDevice.getGroupId()) &&
+            CollectionUtils.isEqualCollection(device.getGroupIds(), currentDevice.getGroupIds())
+        ) {
+            // Device.groupId has been changed. User is still using legacy Device.groupId and we need to reflect that change into Device.groupIds
+            if (device.getGroupId() == null) {
+                // Device.groupId has been removed
+                device.setGroupIds(Collections.emptySet());
+            }
+            else {
+                // Device.groupId has been added
+                device.setGroupIds(Sets.newHashSet(device.getGroupId()));
+            }
+            return;
+        }
+
+        // If both have been changed, this is a mixed usage, so it is not allowed.
+        throw new KapuaIllegalArgumentException("device.groupId", device.getGroupId() != null ? device.getGroupId().toString() : null);
+    }
 
     private void deleteDeviceByGroupId(KapuaId scopeId, KapuaId groupId) throws KapuaException {
         DeviceQuery query = deviceFactory.newQuery(scopeId);


### PR DESCRIPTION
This PR introduces migrator tool and backward compatibility logic to handle migration of `Device.groupId` to `Device.groupIds`

**Related Issue**
_None_

**Description of the solution adopted**
Added migration tool to copy all currently assigned `Device.groupId` values into the new `Device.groupids` field
Added logic to handle legacy usage of `Device.groupId`

**Screenshots**
_None_

**Any side note on the changes made**
_None_