### PR TITLE
:bug: [OpenAPI] Fixed documentation for UserGroup return types

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions.yaml
@@ -60,7 +60,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../group/group.yaml#/components/schemas/groupPermissionListResult'
+                $ref: '../group/group.yaml#/components/schemas/groupPermission'
         400:
           $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles.yaml
@@ -58,7 +58,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../group/group.yaml#/components/schemas/groupRoleListResult'
+                $ref: '../group/group.yaml#/components/schemas/groupRole'
         400:
           $ref: '../openapi.yaml#/components/responses/illegalArgument'
         401:


### PR DESCRIPTION
Fixed return types for following resources:
- `POST /{scopeId}/userGroups/{userGroupId}/permissions`
- `POST /{scopeId}/userGroups/{userGroupId}/roles`

**Related Issue**
_None_

**Description of the solution adopted**
Fixed wrong return type

**Screenshots**
_None_

**Any side note on the changes made**
_None_