### PR TITLE
🐛 [OpenAPI] Fixed Group and GroupCreator OpenAPI definitions

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/group/group.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group.yaml
@@ -50,6 +50,8 @@ components:
             domain:
               description: The target domain of the group
               type: string
+          required:
+            - domain
           example:
             type: group
             id: Skm7PvmgOh0
@@ -59,6 +61,7 @@ components:
             modifiedOn: '2019-09-13T15:16:09.174Z'
             modifiedBy: AQ
             optlock: 1
+            tagIds: [ Skm7PvmgOh0 ]
             name: group-1
             description: An Access Group
             domain: device
@@ -67,10 +70,18 @@ components:
         - $ref: '../openapi.yaml#/components/schemas/kapuaNamedEntityCreator'
         - type: object
           properties:
+            tagIds:
+              type: array
+              items:
+                allOf:
+                  - $ref: '../openapi.yaml#/components/schemas/kapuaId'
             domain:
               description: The target domain of the group
               type: string
+          required:
+            - domain
           example:
+            tagIds: [ Skm7PvmgOh0 ]
             name: group-1
             description: An Access Group
             domain: device


### PR DESCRIPTION
This PR fixes schema definition of Group and GroupCreator that were missing some properties

**Related Issue**
_None_

**Description of the solution adopted**
- Added missing properties.
- Marked `domain` required attribute
- Improved examples

**Screenshots**
_None_

**Any side note on the changes made**
_None_