### PR TITLE
:sparkles: [Project] Kapua Artifact release via GitHub Actions

### DIFF
--- a/.github/workflows/kapua-release.yaml
+++ b/.github/workflows/kapua-release.yaml
@@ -9,6 +9,9 @@ on:
 #      - release-2.0.x
 #      - develop
 
+permissions:
+  contents: read
+
 env:
   BUILD_OPTS: ""
   MAVEN_OPTS: "-Xmx4096m"

--- a/.github/workflows/kapua-release.yaml
+++ b/.github/workflows/kapua-release.yaml
@@ -1,15 +1,13 @@
-#name: Kapua Release
-
-#on:
-#  release:
-#    types: [published]
-
-name: Kapua Snapshot Release
+name: Eclipse Kapua Artifacts Release
 
 on:
-  push:
-    branches:
-      - release-1.6.13-P1
+  release:
+    types: [published]
+#  push:
+#    branches:
+#      - release-1.6.x
+#      - release-2.0.x
+#      - develop
 
 env:
   BUILD_OPTS: ""

--- a/.github/workflows/kapua-release.yaml
+++ b/.github/workflows/kapua-release.yaml
@@ -1,0 +1,53 @@
+#name: Kapua Release
+
+#on:
+#  release:
+#    types: [published]
+
+name: Kapua Snapshot Release
+
+on:
+  push:
+    branches:
+      - release-1.6.13-P1
+
+env:
+  BUILD_OPTS: ""
+  MAVEN_OPTS: "-Xmx4096m"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4 # Checks out a copy of the repository on the ubuntu-latest machine
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 11
+      - uses: actions/setup-node@v4 # Installs Node and NPM
+        with:
+          node-version: 16
+      - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
+        run: 'npm install -g @apidevtools/swagger-cli'
+
+      - name: Set up Java and Maven Central credentials
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 11
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+#      - name: Set project version from tag
+#        run: mvn --batch-mode versions:set -DnewVersion=${{ github.event.release.tag_name }} -DgenerateBackupPoms=false
+
+      - name: Publish to Central
+        run: mvn -B clean deploy -DskipTests -Pjavadoc,sing
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -307,6 +307,14 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -12,10 +12,11 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-assembly</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-assembly-api</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/assembly/broker-artemis/pom.xml
+++ b/assembly/broker-artemis/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-assembly-broker-artemis</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -228,6 +228,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
         Eurotech
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-assembly-console</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/assembly/consumer/lifecycle/pom.xml
+++ b/assembly/consumer/lifecycle/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-assembly-consumer-lifecycle</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/assembly/consumer/pom.xml
+++ b/assembly/consumer/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-assembly-consumer</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/assembly/consumer/telemetry/pom.xml
+++ b/assembly/consumer/telemetry/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-assembly-consumer-telemetry</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/assembly/events-broker/pom.xml
+++ b/assembly/events-broker/pom.xml
@@ -87,6 +87,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/assembly/events-broker/pom.xml
+++ b/assembly/events-broker/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-assembly-events-broker</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/assembly/java-base/pom.xml
+++ b/assembly/java-base/pom.xml
@@ -22,13 +22,25 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-java-base</artifactId>
+    <packaging>pom</packaging>
 
     <properties>
         <docker.base.image>rockylinux:9-minimal</docker.base.image>
         <jolokia.agent.url>https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.3.4/jolokia-jvm-1.3.4-agent.jar</jolokia.agent.url>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/assembly/java-base/pom.xml
+++ b/assembly/java-base/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
         Eurotech
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-assembly-java-base</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -22,12 +22,24 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-jetty-base</artifactId>
+    <packaging>pom</packaging>
 
     <properties>
         <jetty.url>https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/jetty-distribution-${jetty.version}.tar.gz</jetty.url>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
         Eurotech
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-assembly-jetty-base</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/assembly/job-engine/pom.xml
+++ b/assembly/job-engine/pom.xml
@@ -67,6 +67,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
     <profiles>

--- a/assembly/job-engine/pom.xml
+++ b/assembly/job-engine/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-assembly-job-engine</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
         Eurotech
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-assembly</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -74,6 +74,16 @@
     </profiles>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/assembly/service/authentication/pom.xml
+++ b/assembly/service/authentication/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-assembly-service-authentication</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/assembly/service/pom.xml
+++ b/assembly/service/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,8 +22,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-service</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <properties>
         <docker.account>kapua</docker.account>

--- a/assembly/sql/pom.xml
+++ b/assembly/sql/pom.xml
@@ -25,6 +25,18 @@
     <packaging>pom</packaging>
     <artifactId>kapua-assembly-sql</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>release</id>

--- a/assembly/sql/pom.xml
+++ b/assembly/sql/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
         Eurotech
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,8 +23,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-sql</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <build>
         <plugins>

--- a/broker/artemis/plugin/pom.xml
+++ b/broker/artemis/plugin/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-broker-artemis</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-broker-artemis-plugin</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- ActiveMQ Artemis -->

--- a/broker/artemis/pom.xml
+++ b/broker/artemis/pom.xml
@@ -21,9 +21,10 @@
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-broker-artemis</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>plugin</module>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -21,9 +21,10 @@
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-broker</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>artemis</module>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
         Eurotech
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -24,6 +25,7 @@
 
     <groupId>org.eclipse.kapua.build</groupId>
     <artifactId>kapua-build-tools</artifactId>
+    <name>${project.artifactId}</name>
     <version>2.1.0-SNAPSHOT</version>
 
     <properties>

--- a/client/gateway/api/pom.xml
+++ b/client/gateway/api/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,9 +24,9 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <artifactId>kapua-client-gateway-api</artifactId>
     <name>Eclipse Kapua :: Gateway Client :: API</name>
     <description>The gateway client API definition</description>
-    <artifactId>kapua-client-gateway-api</artifactId>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/client/gateway/features/karaf/pom.xml
+++ b/client/gateway/features/karaf/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Red Hat Inc - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,8 +23,8 @@
         <relativePath>..</relativePath>
     </parent>
 
-    <name>Eclipse Kapua :: Gateway Client :: Features :: Karaf</name>
     <artifactId>kapua-client-gateway-feature-karaf</artifactId>
+    <name>Eclipse Kapua :: Gateway Client :: Features :: Karaf</name>
     <packaging>feature</packaging>
 
     <properties>

--- a/client/gateway/features/pom.xml
+++ b/client/gateway/features/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Red Hat Inc - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,8 +22,8 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <name>Eclipse Kapua :: Gateway Client :: Features</name>
     <artifactId>kapua-client-gateway-features</artifactId>
+    <name>Eclipse Kapua :: Gateway Client :: Features</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/client/gateway/pom.xml
+++ b/client/gateway/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Red Hat Inc - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-client-gateway</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/client/gateway/profile/kura/pom.xml
+++ b/client/gateway/profile/kura/pom.xml
@@ -12,9 +12,9 @@
         Red Hat Inc - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -24,9 +24,9 @@
         <relativePath>../..</relativePath>
     </parent>
 
+    <artifactId>kapua-client-gateway-profile-kura</artifactId>
     <name>Eclipse Kapua :: Gateway Client :: Profile :: Eclipse Kura</name>
     <description>The Eclipse Kura™ communication stack profile</description>
-    <artifactId>kapua-client-gateway-profile-kura</artifactId>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/client/gateway/provider/fuse/pom.xml
+++ b/client/gateway/provider/fuse/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,9 +24,9 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <artifactId>kapua-client-gateway-provider-fuse</artifactId>
     <name>Eclipse Kapua :: Gateway Client :: Provider :: FUSE MQTT</name>
     <description>An MQTT client implementation based on FUSE MQTT</description>
-    <artifactId>kapua-client-gateway-provider-fuse</artifactId>
     <packaging>bundle</packaging>
 
     <properties>

--- a/client/gateway/provider/mqtt/pom.xml
+++ b/client/gateway/provider/mqtt/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,9 +24,9 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <artifactId>kapua-client-gateway-provider-mqtt</artifactId>
     <name>Eclipse Kapua :: Gateway Client :: Provider :: Core MQTT</name>
     <description>Abstract base classes for implementing MQTT based clients</description>
-    <artifactId>kapua-client-gateway-provider-mqtt</artifactId>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/client/gateway/provider/paho/pom.xml
+++ b/client/gateway/provider/paho/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,9 +24,9 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <artifactId>kapua-client-gateway-provider-paho</artifactId>
     <name>Eclipse Kapua :: Gateway Client :: Provider :: Eclipse Paho</name>
     <description>An MQTT client implementation based on Eclipse Paho</description>
-    <artifactId>kapua-client-gateway-provider-paho</artifactId>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/client/gateway/provider/pom.xml
+++ b/client/gateway/provider/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Red Hat Inc - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,8 +23,8 @@
         <relativePath>..</relativePath>
     </parent>
 
-    <name>Eclipse Kapua :: Gateway Client :: Provider</name>
     <artifactId>kapua-client-gateway-provider</artifactId>
+    <name>Eclipse Kapua :: Gateway Client :: Provider</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/client/gateway/spi/pom.xml
+++ b/client/gateway/spi/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,12 +24,11 @@
         <relativePath>..</relativePath>
     </parent>
 
-    <name>Eclipse Kapua :: Gateway Client :: SPI</name>
     <artifactId>kapua-client-gateway-spi</artifactId>
+    <name>Eclipse Kapua :: Gateway Client :: SPI</name>
     <packaging>bundle</packaging>
 
     <dependencies>
-
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-client-gateway-api</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Red Hat Inc - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-client</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/client/security/pom.xml
+++ b/client/security/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-client-security</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- ActiveMQ Artemis -->

--- a/commons-rest/errors/pom.xml
+++ b/commons-rest/errors/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-commons-rest</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -22,6 +23,8 @@
     </parent>
 
     <artifactId>kapua-commons-rest-errors</artifactId>
+    <name>${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/commons-rest/filters/pom.xml
+++ b/commons-rest/filters/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-commons-rest</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -22,6 +23,8 @@
     </parent>
 
     <artifactId>kapua-commons-rest-filters</artifactId>
+    <name>${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/commons-rest/model/pom.xml
+++ b/commons-rest/model/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-commons-rest-model</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Internal dependencies -->

--- a/commons-rest/pom.xml
+++ b/commons-rest/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -22,7 +23,9 @@
     </parent>
 
     <artifactId>kapua-commons-rest</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
+
     <modules>
         <module>model</module>
         <module>errors</module>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,8 @@
     </parent>
 
     <artifactId>kapua-commons</artifactId>
+    <name>${project.artifactId}</name>
+
     <build>
         <resources>
             <resource>

--- a/console/core/pom.xml
+++ b/console/core/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-core</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/core/pom.xml
+++ b/console/core/pom.xml
@@ -245,6 +245,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/console/module/about/pom.xml
+++ b/console/module/about/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-about</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/about/pom.xml
+++ b/console/module/about/pom.xml
@@ -45,6 +45,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -88,6 +88,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-account</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/api/pom.xml
+++ b/console/module/api/pom.xml
@@ -74,6 +74,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/api/pom.xml
+++ b/console/module/api/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/console/module/authentication/pom.xml
+++ b/console/module/authentication/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-authentication</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/authentication/pom.xml
+++ b/console/module/authentication/pom.xml
@@ -57,6 +57,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/authorization/pom.xml
+++ b/console/module/authorization/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-authorization</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/authorization/pom.xml
+++ b/console/module/authorization/pom.xml
@@ -58,6 +58,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/certificate/pom.xml
+++ b/console/module/certificate/pom.xml
@@ -45,6 +45,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/certificate/pom.xml
+++ b/console/module/certificate/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-certificate</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/data/pom.xml
+++ b/console/module/data/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-data</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/data/pom.xml
+++ b/console/module/data/pom.xml
@@ -71,6 +71,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/device/pom.xml
+++ b/console/module/device/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-device</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/device/pom.xml
+++ b/console/module/device/pom.xml
@@ -92,6 +92,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/console/module/endpoint/pom.xml
+++ b/console/module/endpoint/pom.xml
@@ -61,6 +61,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/endpoint/pom.xml
+++ b/console/module/endpoint/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-endpoint</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/job/pom.xml
+++ b/console/module/job/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-job</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/job/pom.xml
+++ b/console/module/job/pom.xml
@@ -71,6 +71,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/pom.xml
+++ b/console/module/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-console</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/console/module/tag/pom.xml
+++ b/console/module/tag/pom.xml
@@ -60,6 +60,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/tag/pom.xml
+++ b/console/module/tag/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-tag</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/user/pom.xml
+++ b/console/module/user/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-user</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/module/user/pom.xml
+++ b/console/module/user/pom.xml
@@ -68,6 +68,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/console/module/welcome/pom.xml
+++ b/console/module/welcome/pom.xml
@@ -46,6 +46,15 @@
                     </i18nMessagesBundles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/console/module/welcome/pom.xml
+++ b/console/module/welcome/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console-module-welcome</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Console modules -->

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -255,6 +255,16 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-console</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -22,6 +22,7 @@
     </parent>
 
     <artifactId>kapua-console-web</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>war</packaging>
 
     <properties>

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -294,6 +294,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+
         </plugins>
         <pluginManagement>
             <plugins>

--- a/consumer/lifecycle-app/pom.xml
+++ b/consumer/lifecycle-app/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-consumer-lifecycle-app</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
 

--- a/consumer/lifecycle/pom.xml
+++ b/consumer/lifecycle/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-consumer</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-consumer-lifecycle</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,9 +23,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
-
     <artifactId>kapua-consumer</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>lifecycle</module>

--- a/consumer/telemetry-app/pom.xml
+++ b/consumer/telemetry-app/pom.xml
@@ -15,14 +15,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-consumer</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-consumer-telemetry-app</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/consumer/telemetry/pom.xml
+++ b/consumer/telemetry/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-consumer</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-consumer-telemetry</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/deployment/commons/pom.xml
+++ b/deployment/commons/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-deployment-commons</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <build>

--- a/deployment/commons/pom.xml
+++ b/deployment/commons/pom.xml
@@ -24,4 +24,16 @@
 
     <artifactId>kapua-deployment-commons</artifactId>
     <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/deployment/docker/pom.xml
+++ b/deployment/docker/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-docker</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <build>

--- a/deployment/docker/pom.xml
+++ b/deployment/docker/pom.xml
@@ -25,4 +25,16 @@
     <artifactId>kapua-docker</artifactId>
     <packaging>pom</packaging>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/deployment/minishift/pom.xml
+++ b/deployment/minishift/pom.xml
@@ -25,4 +25,16 @@
     <artifactId>kapua-minishift</artifactId>
     <packaging>pom</packaging>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/deployment/minishift/pom.xml
+++ b/deployment/minishift/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-minishift</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <build>

--- a/deployment/openshift/pom.xml
+++ b/deployment/openshift/pom.xml
@@ -22,7 +22,19 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-openshift</artifactId>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/deployment/openshift/pom.xml
+++ b/deployment/openshift/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-openshift</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <build>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -32,4 +32,16 @@
         <module>openshift</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-deployment</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/dev-tools/cucumber-reports/pom.xml
+++ b/dev-tools/cucumber-reports/pom.xml
@@ -12,10 +12,11 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-dev-tools</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-cucumber-reports</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <build>

--- a/dev-tools/cucumber-reports/pom.xml
+++ b/dev-tools/cucumber-reports/pom.xml
@@ -48,6 +48,14 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -12,9 +12,9 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-dev-tools</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -30,4 +30,16 @@
         <module>cucumber-reports</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/extras/device-group-migrator/pom.xml
+++ b/extras/device-group-migrator/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-group-migrator</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- -->

--- a/extras/encryption-migrator/pom.xml
+++ b/extras/encryption-migrator/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-extras</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-encryption-migrator</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- -->

--- a/extras/es-migrator/pom.xml
+++ b/extras/es-migrator/pom.xml
@@ -14,13 +14,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-extras</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
     <artifactId>kapua-es-migrator</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/extras/foreignkeys/pom.xml
+++ b/extras/foreignkeys/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-extras</artifactId>
@@ -21,4 +23,6 @@
     </parent>
 
     <artifactId>kapua-foreignkeys</artifactId>
+    <name>${project.artifactId}</name>
+
 </project>

--- a/extras/liquibase-tool/pom.xml
+++ b/extras/liquibase-tool/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-extras</artifactId>
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-liquibase-tool</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- -->

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-extras</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/job-engine/api/pom.xml
+++ b/job-engine/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-job-engine-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/job-engine/app/core/pom.xml
+++ b/job-engine/app/core/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-job-engine-app-core</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/job-engine/app/pom.xml
+++ b/job-engine/app/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-job-engine-app</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/job-engine/app/resources/pom.xml
+++ b/job-engine/app/resources/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-job-engine-app</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-job-engine-app-resources</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/job-engine/app/web/pom.xml
+++ b/job-engine/app/web/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-job-engine-app</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-job-engine-app-web</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>war</packaging>
 
     <dependencies>

--- a/job-engine/client/pom.xml
+++ b/job-engine/client/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-job-engine-client</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/job-engine/commons/pom.xml
+++ b/job-engine/commons/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-job-engine-commons</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/job-engine/jbatch/pom.xml
+++ b/job-engine/jbatch/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-job-engine-jbatch</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- -->

--- a/job-engine/pom.xml
+++ b/job-engine/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-job-engine</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -16,6 +16,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-locator</artifactId>
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-locator-guice</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Internal dependencies -->

--- a/locator/pom.xml
+++ b/locator/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-locator</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/message/api/pom.xml
+++ b/message/api/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-message-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Internal dependencies -->

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-message</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/plug-ins/pom.xml
+++ b/plug-ins/pom.xml
@@ -13,9 +13,9 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -24,9 +24,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
-
     <artifactId>kapua-plug-ins</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>sso</module>

--- a/plug-ins/sso/openid-connect/api/pom.xml
+++ b/plug-ins/sso/openid-connect/api/pom.xml
@@ -13,7 +13,8 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -24,6 +25,7 @@
     </parent>
 
     <artifactId>kapua-openid-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/plug-ins/sso/openid-connect/pom.xml
+++ b/plug-ins/sso/openid-connect/pom.xml
@@ -13,9 +13,9 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -24,9 +24,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
-
     <artifactId>kapua-openid-connect</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/plug-ins/sso/openid-connect/provider-generic/pom.xml
+++ b/plug-ins/sso/openid-connect/provider-generic/pom.xml
@@ -13,9 +13,9 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -25,6 +25,7 @@
     </parent>
 
     <artifactId>kapua-openid-provider-generic</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/plug-ins/sso/openid-connect/provider-keycloak/pom.xml
+++ b/plug-ins/sso/openid-connect/provider-keycloak/pom.xml
@@ -13,9 +13,9 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -25,6 +25,7 @@
     </parent>
 
     <artifactId>kapua-openid-provider-keycloak</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/plug-ins/sso/openid-connect/provider/pom.xml
+++ b/plug-ins/sso/openid-connect/provider/pom.xml
@@ -13,7 +13,8 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -24,6 +25,7 @@
     </parent>
 
     <artifactId>kapua-openid-provider</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Kapua Dependencies-->

--- a/plug-ins/sso/pom.xml
+++ b/plug-ins/sso/pom.xml
@@ -13,7 +13,8 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
@@ -24,9 +25,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
-
     <artifactId>kapua-sso</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>openid-connect</module>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
 
         <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
-        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <checkstyle.version>7.6.1</checkstyle.version>
         <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
@@ -336,6 +336,7 @@
                     <version>${central-publishing-maven-plugin.version}</version>
                     <extensions>true</extensions>
                     <configuration>
+                        <deploymentName>Eclipse Kapua ${project.version}</deploymentName>
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>true</autoPublish>
                         <waitUntil>published</waitUntil>

--- a/pom.xml
+++ b/pom.xml
@@ -2791,7 +2791,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
 
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
                             <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
@@ -2940,11 +2940,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2747,6 +2747,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,6 @@
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -252,18 +251,6 @@
                     <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
                         <source>${javadoc-plugin.maven.compiler.source}</source>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>${maven-release-plugin.version}</version>
-                    <configuration>
-                        <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <releaseProfiles>javadoc,deploy,release,!console</releaseProfiles>
-                        <goals>deploy</goals>
-                        <preparationGoals>clean install</preparationGoals>
-                        <tagNameFormat>@{project.version}</tagNameFormat>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
         <maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
 
         <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
         <checkstyle.version>7.6.1</checkstyle.version>
         <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
@@ -209,6 +210,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven-deploy-plugin.version}</version>
+                    <configuration>
+                        <!-- Disable 'deploy-default' plugin execution -->
+                        <skip>true</skip>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -304,6 +309,11 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>${maven-bundle-plugin.version}</version>
@@ -321,15 +331,18 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>${nexus-staging-maven-plugin.version}</version>
-                </plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${central-publishing-maven-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <publishingServerId>central</publishingServerId>
+                        <autoPublish>true</autoPublish>
+                        <waitUntil>published</waitUntil>
 
-                <plugin>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>docker-maven-plugin</artifactId>
-                    <version>${docker-maven-plugin.version}</version>
+                        <centralBaseUrl>https://central.sonatype.com</centralBaseUrl>
+                        <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -350,6 +363,7 @@
                         <password>${db.password}</password>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
@@ -372,6 +386,7 @@
                         </execution>
                     </executions>
                 </plugin>
+
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
@@ -525,6 +540,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>${central-publishing-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>de.dentrassi.maven</groupId>
@@ -2634,6 +2654,7 @@
                 <artifactId>spring-security-core</artifactId>
                 <version>${spring-security.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-crypto</artifactId>
@@ -2756,28 +2777,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <!-- Profile used only during deploy. -->
-        <profile>
-            <id>deploy</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>central</serverId>
-                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
-
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                            <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
-                            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -2925,7 +2924,7 @@
         </snapshotRepository>
         <repository>
             <id>central</id>
-            <url>https://ossrh-staging-api.central.sonatype.com/service/local/</url>
+            <url>https://central.sonatype.com/</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
         <maven-frontend-plugin.version>1.8.0</maven-frontend-plugin.version>
-        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
@@ -2747,12 +2747,6 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
-                                <configuration>
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2790,7 +2790,7 @@
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
+                            <serverId>central</serverId>
                             <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
 
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
@@ -2939,11 +2939,11 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
+            <id>central</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
+            <id>central</id>
             <url>https://ossrh-staging-api.central.sonatype.com/service/local/</url>
         </repository>
     </distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2740,9 +2740,9 @@
             </modules>
         </profile>
 
-        <!-- Profile used only during release process. -->
+        <!-- Profile used only during release process to sign artifacts. -->
         <profile>
-            <id>release</id>
+            <id>sing</id>
             <build>
                 <plugins>
                     <plugin>

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-qa-common</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -23,6 +23,18 @@
 
     <artifactId>kapua-qa-common</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- -->
         <!-- Required service interfaces -->

--- a/qa/integration-steps/pom.xml
+++ b/qa/integration-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-qa-integration-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/qa/integration-steps/pom.xml
+++ b/qa/integration-steps/pom.xml
@@ -23,6 +23,18 @@
 
     <artifactId>kapua-qa-integration-steps</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -12,18 +12,23 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>kapua-qa-integration</artifactId>
+    <name>${project.artifactId}</name>
+
     <properties>
         <maven.toolchain.jdk.version>${kapua-client.maven.toolchain.jdk.version}</maven.toolchain.jdk.version>
     </properties>
-    <artifactId>kapua-qa-integration</artifactId>
 
     <build>
         <plugins>

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -25,6 +25,18 @@
     </properties>
     <artifactId>kapua-qa-integration</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
 
         <dependency>

--- a/qa/markers/pom.xml
+++ b/qa/markers/pom.xml
@@ -26,6 +26,18 @@
         <maven.test.skip>true</maven.test.skip>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/qa/markers/pom.xml
+++ b/qa/markers/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-qa-markers</artifactId>
+    <name>${project.artifactId}</name>
 
     <properties>
         <maven.test.skip>true</maven.test.skip>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-qa</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -32,4 +32,16 @@
         <module>markers</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,7 +23,7 @@
     </parent>
 
     <artifactId>kapua-rest-api-core</artifactId>
-    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Moxy for object marshalling unmarshalling -->

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-rest-api</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/rest-api/resources/pom.xml
+++ b/rest-api/resources/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,7 +23,7 @@
     </parent>
 
     <artifactId>kapua-rest-api-resources</artifactId>
-    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,10 +23,10 @@
     </parent>
 
     <artifactId>kapua-rest-api-web</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>war</packaging>
 
     <dependencies>
-
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>

--- a/service/account/api/pom.xml
+++ b/service/account/api/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-account-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/account/pom.xml
+++ b/service/account/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua-service</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-account</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/account/test-steps/pom.xml
+++ b/service/account/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-account-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/account/test-steps/pom.xml
+++ b/service/account/test-steps/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-account-test-steps</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/service/account/test/pom.xml
+++ b/service/account/test/pom.xml
@@ -25,6 +25,18 @@
 
     <artifactId>kapua-account-test</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- Test dependencies -->
         <dependency>

--- a/service/account/test/pom.xml
+++ b/service/account/test/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-account-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/api/pom.xml
+++ b/service/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,9 +23,9 @@
     </parent>
 
     <artifactId>kapua-service-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
-
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>

--- a/service/authentication-app/pom.xml
+++ b/service/authentication-app/pom.xml
@@ -14,14 +14,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-service</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-service-authentication-app</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/authentication/pom.xml
+++ b/service/authentication/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-authentication</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/camel/pom.xml
+++ b/service/camel/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-service-camel</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/client/pom.xml
+++ b/service/client/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-client</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/commons/elasticsearch/client-api/pom.xml
+++ b/service/commons/elasticsearch/client-api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-elasticsearch-client-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/commons/elasticsearch/client-rest/pom.xml
+++ b/service/commons/elasticsearch/client-rest/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-elasticsearch-client-rest</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/commons/elasticsearch/pom.xml
+++ b/service/commons/elasticsearch/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-elasticsearch</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/commons/pom.xml
+++ b/service/commons/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-commons</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/commons/storable/api/pom.xml
+++ b/service/commons/storable/api/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-storable-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Base Service API-->

--- a/service/commons/storable/internal/pom.xml
+++ b/service/commons/storable/internal/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-storable-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented Interface-->

--- a/service/commons/storable/pom.xml
+++ b/service/commons/storable/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-storable</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/commons/utils/api/pom.xml
+++ b/service/commons/utils/api/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-commons-utils-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Internal Dependencies-->

--- a/service/commons/utils/internal/pom.xml
+++ b/service/commons/utils/internal/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-commons-utils-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented Interface-->

--- a/service/commons/utils/pom.xml
+++ b/service/commons/utils/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service-commons-utils</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/datastore/api/pom.xml
+++ b/service/datastore/api/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/datastore/internal/pom.xml
+++ b/service/datastore/internal/pom.xml
@@ -13,7 +13,8 @@
         Red Hat Inc
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -24,6 +25,7 @@
     </parent>
 
     <artifactId>kapua-datastore-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/datastore/pom.xml
+++ b/service/datastore/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-datastore</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/datastore/test-steps/pom.xml
+++ b/service/datastore/test-steps/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-datastore-test-steps</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/service/datastore/test-steps/pom.xml
+++ b/service/datastore/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-datastore-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/datastore/test/pom.xml
+++ b/service/datastore/test/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-datastore-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/datastore/test/pom.xml
+++ b/service/datastore/test/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-datastore-test</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Test dependencies -->

--- a/service/device/api/pom.xml
+++ b/service/device/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/authentication/pom.xml
+++ b/service/device/authentication/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-authentication</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/call/api/pom.xml
+++ b/service/device/call/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-call-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/call/kura/pom.xml
+++ b/service/device/call/kura/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-call-kura</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/call/pom.xml
+++ b/service/device/call/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua-device</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-device-call</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/commons/pom.xml
+++ b/service/device/commons/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/device/management/all/api/pom.xml
+++ b/service/device/management/all/api/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-all-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/all/internal/pom.xml
+++ b/service/device/management/all/internal/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-all-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/all/job/pom.xml
+++ b/service/device/management/all/job/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-all-job</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/all/pom.xml
+++ b/service/device/management/all/pom.xml
@@ -22,8 +22,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-device-management-all</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/management/api/pom.xml
+++ b/service/device/management/api/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/asset-store/api/pom.xml
+++ b/service/device/management/asset-store/api/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-asset-store-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/asset-store/dummy/pom.xml
+++ b/service/device/management/asset-store/dummy/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-asset-store-dummy</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/asset-store/pom.xml
+++ b/service/device/management/asset-store/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-asset-store</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/device/management/asset/api/pom.xml
+++ b/service/device/management/asset/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-asset-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/device/management/asset/internal/pom.xml
+++ b/service/device/management/asset/internal/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-management-asset-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/management/asset/job/pom.xml
+++ b/service/device/management/asset/job/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-asset-job</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/asset/pom.xml
+++ b/service/device/management/asset/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,8 +22,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-device-management-asset</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/management/bundle/api/pom.xml
+++ b/service/device/management/bundle/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-bundle-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/device/management/bundle/internal/pom.xml
+++ b/service/device/management/bundle/internal/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-management-bundle-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/management/bundle/job/pom.xml
+++ b/service/device/management/bundle/job/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-bundle-job</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/bundle/pom.xml
+++ b/service/device/management/bundle/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,8 +22,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-device-management-bundle</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/management/command/api/pom.xml
+++ b/service/device/management/command/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-command-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/device/management/command/internal/pom.xml
+++ b/service/device/management/command/internal/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-management-command-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/management/command/job/pom.xml
+++ b/service/device/management/command/job/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-command-job</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/command/pom.xml
+++ b/service/device/management/command/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,9 +21,10 @@
         <artifactId>kapua-device-management</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-device-management-command</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/management/configuration-store/api/pom.xml
+++ b/service/device/management/configuration-store/api/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-configuration-store-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/configuration-store/dummy/pom.xml
+++ b/service/device/management/configuration-store/dummy/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-configuration-store-dummy</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/configuration-store/pom.xml
+++ b/service/device/management/configuration-store/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-configuration-store</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/device/management/configuration/api/pom.xml
+++ b/service/device/management/configuration/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-configuration-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/device/management/configuration/internal/pom.xml
+++ b/service/device/management/configuration/internal/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-management-configuration-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/management/configuration/job/pom.xml
+++ b/service/device/management/configuration/job/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-configuration-job</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/configuration/message-api/pom.xml
+++ b/service/device/management/configuration/message-api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-configuration-message-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/device/management/configuration/pom.xml
+++ b/service/device/management/configuration/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,8 +23,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-device-management-configuration</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/management/inventory/api/pom.xml
+++ b/service/device/management/inventory/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-inventory-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/inventory/internal/pom.xml
+++ b/service/device/management/inventory/internal/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-inventory-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/management/inventory/job/pom.xml
+++ b/service/device/management/inventory/job/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-inventory</artifactId>
@@ -22,6 +23,8 @@
     </parent>
 
     <artifactId>kapua-device-management-inventory-job</artifactId>
+    <name>${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/device/management/inventory/pom.xml
+++ b/service/device/management/inventory/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-inventory</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/device/management/job/api/pom.xml
+++ b/service/device/management/job/api/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-device-management-job</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-job-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/job/internal/pom.xml
+++ b/service/device/management/job/internal/pom.xml
@@ -15,6 +15,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-device-management-job</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -22,7 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-job-internal</artifactId>
-
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/management/job/pom.xml
+++ b/service/device/management/job/pom.xml
@@ -15,14 +15,16 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-device-management-job</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/management/keystore/api/pom.xml
+++ b/service/device/management/keystore/api/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-keystore</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-keystore-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/keystore/internal/pom.xml
+++ b/service/device/management/keystore/internal/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-keystore-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/management/keystore/job/pom.xml
+++ b/service/device/management/keystore/job/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-keystore-job</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/keystore/pom.xml
+++ b/service/device/management/keystore/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-keystore</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/device/management/packages/api/pom.xml
+++ b/service/device/management/packages/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-packages-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/device/management/packages/internal/pom.xml
+++ b/service/device/management/packages/internal/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-management-packages-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/device/management/packages/job/pom.xml
+++ b/service/device/management/packages/job/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-packages-job</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/packages/pom.xml
+++ b/service/device/management/packages/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,8 +22,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-device-management-packages</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/management/pom.xml
+++ b/service/device/management/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/device/management/registry/api/pom.xml
+++ b/service/device/management/registry/api/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-registry-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/device/management/registry/internal/pom.xml
+++ b/service/device/management/registry/internal/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-registry-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/registry/pom.xml
+++ b/service/device/management/registry/pom.xml
@@ -22,8 +22,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-device-management-registry</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/management/request/api/pom.xml
+++ b/service/device/management/request/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device-management-request-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/device/management/request/internal/pom.xml
+++ b/service/device/management/request/internal/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-management-request-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/device/management/request/pom.xml
+++ b/service/device/management/request/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,8 +22,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-device-management-request</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/pom.xml
+++ b/service/device/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-device</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/device/registry/api/pom.xml
+++ b/service/device/registry/api/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>

--- a/service/device/registry/internal/pom.xml
+++ b/service/device/registry/internal/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>

--- a/service/device/registry/pom.xml
+++ b/service/device/registry/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua-device</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-device-registry</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/device/registry/test-steps/pom.xml
+++ b/service/device/registry/test-steps/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-device-registry-test-steps</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/service/device/registry/test-steps/pom.xml
+++ b/service/device/registry/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-registry-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/device/registry/test/pom.xml
+++ b/service/device/registry/test/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-device-registry-test</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Test dependencies -->

--- a/service/device/registry/test/pom.xml
+++ b/service/device/registry/test/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-device-registry-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/endpoint/api/pom.xml
+++ b/service/endpoint/api/pom.xml
@@ -14,15 +14,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-endpoint</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-endpoint-api</artifactId>
-
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/endpoint/internal/pom.xml
+++ b/service/endpoint/internal/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-endpoint-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/endpoint/pom.xml
+++ b/service/endpoint/pom.xml
@@ -21,9 +21,10 @@
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-endpoint</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/endpoint/test-steps/pom.xml
+++ b/service/endpoint/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-endpoint</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-endpoint-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/endpoint/test-steps/pom.xml
+++ b/service/endpoint/test-steps/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-endpoint-test-steps</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/service/job/api/pom.xml
+++ b/service/job/api/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
@@ -24,7 +26,6 @@
     <name>${project.artifactId}</name>
 
     <dependencies>
-
         <!-- Extended service interfaces -->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/job/pom.xml
+++ b/service/job/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua-service</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-job</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/job/test-steps/pom.xml
+++ b/service/job/test-steps/pom.xml
@@ -25,6 +25,18 @@
 
     <artifactId>kapua-job-test-steps</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/job/test-steps/pom.xml
+++ b/service/job/test-steps/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-job-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/job/test/pom.xml
+++ b/service/job/test/pom.xml
@@ -23,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-job-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/job/test/pom.xml
+++ b/service/job/test/pom.xml
@@ -24,6 +24,18 @@
 
     <artifactId>kapua-job-test</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-service</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/scheduler/api/pom.xml
+++ b/service/scheduler/api/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>

--- a/service/scheduler/pom.xml
+++ b/service/scheduler/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua-service</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-scheduler</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/scheduler/quartz/pom.xml
+++ b/service/scheduler/quartz/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-scheduler-quartz</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Implemented service interfaces -->

--- a/service/scheduler/test-steps/pom.xml
+++ b/service/scheduler/test-steps/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-scheduler-test-steps</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/service/scheduler/test-steps/pom.xml
+++ b/service/scheduler/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-scheduler-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/scheduler/test/pom.xml
+++ b/service/scheduler/test/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-scheduler-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/scheduler/test/pom.xml
+++ b/service/scheduler/test/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-scheduler-test</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Test dependencies -->

--- a/service/security/authentication/api/pom.xml
+++ b/service/security/authentication/api/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-authentication</artifactId>

--- a/service/security/authentication/pom.xml
+++ b/service/security/authentication/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua-security</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-security-authentication</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/security/authorization/api/pom.xml
+++ b/service/security/authorization/api/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-authorization</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-security-authorization-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->
@@ -29,11 +32,6 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-service-api</artifactId>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.eclipse.kapua</groupId>-->
-<!--            <artifactId>kapua-user-api</artifactId>-->
-<!--        </dependency>-->
-
 
         <!-- -->
         <!-- Test Dependencies-->

--- a/service/security/authorization/pom.xml
+++ b/service/security/authorization/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua-security</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-security-authorization</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/security/certificate/api/pom.xml
+++ b/service/security/certificate/api/pom.xml
@@ -15,14 +15,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-security-certificate</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-security-certificate-api</artifactId>
+    <name>${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/security/certificate/internal/pom.xml
+++ b/service/security/certificate/internal/pom.xml
@@ -15,14 +15,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-security-certificate</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-security-certificate-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/security/certificate/pom.xml
+++ b/service/security/certificate/pom.xml
@@ -15,19 +15,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-security</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-security-certificate</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
+
     <modules>
         <module>api</module>
         <module>internal</module>
     </modules>
-
 
 </project>

--- a/service/security/pom.xml
+++ b/service/security/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,8 +23,9 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-security</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>authentication</module>

--- a/service/security/registration/api/pom.xml
+++ b/service/security/registration/api/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-security-registration-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/security/registration/pom.xml
+++ b/service/security/registration/pom.xml
@@ -12,7 +12,8 @@
         Red Hat Inc - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-security-registration</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/service/security/registration/simple/pom.xml
+++ b/service/security/registration/simple/pom.xml
@@ -13,7 +13,8 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -24,9 +25,9 @@
     </parent>
 
     <artifactId>kapua-security-registration-simple</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
-
         <!-- -->
         <!-- Internal dependencies -->
         <dependency>

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-security-shiro</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/security/test-steps/pom.xml
+++ b/service/security/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-security-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/security/test-steps/pom.xml
+++ b/service/security/test-steps/pom.xml
@@ -23,6 +23,18 @@
 
     <artifactId>kapua-security-test-steps</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- Required service interfaces -->
         <dependency>

--- a/service/security/test/pom.xml
+++ b/service/security/test/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-security-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/security/test/pom.xml
+++ b/service/security/test/pom.xml
@@ -25,6 +25,18 @@
 
     <artifactId>kapua-security-test</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- Test dependencies -->
         <dependency>

--- a/service/stream/api/pom.xml
+++ b/service/stream/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-stream-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/stream/internal/pom.xml
+++ b/service/stream/internal/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-stream-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/stream/pom.xml
+++ b/service/stream/pom.xml
@@ -11,18 +11,21 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>kapua-service</artifactId>
         <groupId>org.eclipse.kapua</groupId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-stream</artifactId>
     <name>${project.artifactId}</name>
     <packaging>pom</packaging>
+
     <modules>
         <module>api</module>
         <module>internal</module>

--- a/service/system/api/pom.xml
+++ b/service/system/api/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-system</artifactId>
@@ -21,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-system-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/system/internal/pom.xml
+++ b/service/system/internal/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-system</artifactId>

--- a/service/system/pom.xml
+++ b/service/system/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,10 +21,10 @@
         <artifactId>kapua-service</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-system</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/system/test-steps/pom.xml
+++ b/service/system/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-system</artifactId>

--- a/service/system/test/pom.xml
+++ b/service/system/test/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-system-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Test dependencies -->

--- a/service/tag/api/pom.xml
+++ b/service/tag/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -21,6 +22,7 @@
     </parent>
 
     <artifactId>kapua-tag-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- Extended service interfaces -->

--- a/service/tag/internal/pom.xml
+++ b/service/tag/internal/pom.xml
@@ -11,9 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>

--- a/service/tag/pom.xml
+++ b/service/tag/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,10 +21,10 @@
         <artifactId>kapua-service</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-tag</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/tag/test-steps/pom.xml
+++ b/service/tag/test-steps/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-tag-test-steps</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/service/tag/test-steps/pom.xml
+++ b/service/tag/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-tag-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/tag/test/pom.xml
+++ b/service/tag/test/pom.xml
@@ -25,6 +25,18 @@
 
     <artifactId>kapua-tag-test</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- Test dependencies -->
         <dependency>

--- a/service/tag/test/pom.xml
+++ b/service/tag/test/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-tag-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/user/api/pom.xml
+++ b/service/user/api/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-user-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-user-internal</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- -->

--- a/service/user/pom.xml
+++ b/service/user/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,10 +22,10 @@
         <artifactId>kapua-service</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-user</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>

--- a/service/user/test-steps/pom.xml
+++ b/service/user/test-steps/pom.xml
@@ -11,10 +11,11 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-user-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/service/user/test-steps/pom.xml
+++ b/service/user/test-steps/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-user-test-steps</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/service/user/test/pom.xml
+++ b/service/user/test/pom.xml
@@ -25,6 +25,18 @@
 
     <artifactId>kapua-user-test</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- Test -->
         <dependency>

--- a/service/user/test/pom.xml
+++ b/service/user/test/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-user-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/simulator-kura/pom.xml
+++ b/simulator-kura/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Red Hat Inc - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-simulator-kura</artifactId>
+    <name>${project.artifactId}</name>
     <description>This is a framework for simulating Eclipse Kura IoT gateway instances</description>
 
     <properties>

--- a/translator/api/pom.xml
+++ b/translator/api/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-translator-api</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/translator/kapua/kura/pom.xml
+++ b/translator/kapua/kura/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-translator-kapua-kura</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/translator/kapua/pom.xml
+++ b/translator/kapua/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-translator-kapua</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/translator/kura/jms/pom.xml
+++ b/translator/kura/jms/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-translator-kura-jms</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/translator/kura/mqtt/pom.xml
+++ b/translator/kura/mqtt/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-translator-kura-mqtt</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/translator/kura/pom.xml
+++ b/translator/kura/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-translator-kura</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/translator/pom.xml
+++ b/translator/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,6 +23,7 @@
     </parent>
 
     <artifactId>kapua-translator</artifactId>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/translator/test-steps/pom.xml
+++ b/translator/test-steps/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-translator-test-steps</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/translator/test-steps/pom.xml
+++ b/translator/test-steps/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-translator-test-steps</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/translator/test/pom.xml
+++ b/translator/test/pom.xml
@@ -22,7 +22,18 @@
     </parent>
 
     <artifactId>kapua-translator-test</artifactId>
-    <name>${project.artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Test dependencies -->

--- a/translator/test/pom.xml
+++ b/translator/test/pom.xml
@@ -12,9 +12,11 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
@@ -22,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-translator-test</artifactId>
+    <name>${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/transport/api/pom.xml
+++ b/transport/api/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/transport/jms/pom.xml
+++ b/transport/jms/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-transport-jms</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/transport/mqtt/pom.xml
+++ b/transport/mqtt/pom.xml
@@ -12,7 +12,8 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +24,7 @@
     </parent>
 
     <artifactId>kapua-transport-mqtt</artifactId>
+    <name>${project.artifactId}</name>
 
     <dependencies>
         <!-- -->

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -11,7 +11,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,10 +21,10 @@
         <artifactId>kapua</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
 
     <artifactId>kapua-transport</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <modules>
         <module>api</module>


### PR DESCRIPTION
This PR removes old  `nexus-staging-maven-plugin` usage, switching to newer `central-publishing-maven-plugin` integrated with GitHub Action that performs the Artifact Publishing for releases

**Related Issue**
_None_

**Description of the solution adopted**
- Removed `nexus-staging-maven-plugin` usages
- Added `central-publishing-maven-plugin` and configured project
- Added `Eclipse Kapua Artifacts Release` workflow to perform Artifact release

**Screenshots**
_None_

**Any side note on the changes made**
_None_