### PR TITLE
:fix: add log to Guice Objects initializer and properly handling exception

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventHouseKeeperFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventHouseKeeperFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,13 +18,19 @@ import org.eclipse.kapua.storage.TxManager;
 
 import java.util.List;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 public class ServiceEventHouseKeeperFactoryImpl implements ServiceEventHouseKeeperFactory {
 
     private final EventStoreService eventStoreService;
     private final TxManager txManager;
     private final ServiceEventBus serviceEventBus;
 
-    public ServiceEventHouseKeeperFactoryImpl(EventStoreService eventStoreService, TxManager txManager, ServiceEventBus serviceEventBus) {
+    @Inject
+    public ServiceEventHouseKeeperFactoryImpl(EventStoreService eventStoreService,
+            @Named("CertificateTransactionManager") TxManager txManager,
+            ServiceEventBus serviceEventBus) {
         this.eventStoreService = eventStoreService;
         this.txManager = txManager;
         this.serviceEventBus = serviceEventBus;

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventTransactionalModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventTransactionalModule.java
@@ -54,11 +54,11 @@ public abstract class ServiceEventTransactionalModule implements ServiceModule {
     public ServiceEventTransactionalModule(
             ServiceEventClientConfiguration[] serviceEventClientConfigurations,
             String internalAddress,
-            String subscriptionGroupId,
+            String componentId,
             ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,
             ServiceEventBus serviceEventBus) {
         this.serviceEventBus = serviceEventBus;
-        this.serviceEventClientConfigurations = appendClientId(subscriptionGroupId, serviceEventClientConfigurations);
+        this.serviceEventClientConfigurations = appendComponentId(componentId, serviceEventClientConfigurations);
         this.internalAddress = internalAddress;
         this.houseKeeperFactory = serviceEventTransactionalHousekeeperFactory;
     }
@@ -143,16 +143,16 @@ public abstract class ServiceEventTransactionalModule implements ServiceModule {
         LOGGER.info("Stopping service event transactional module... DONE");
     }
 
-    protected ServiceEventClientConfiguration[] appendClientId(String clientId, ServiceEventClientConfiguration[] configs) {
+    protected ServiceEventClientConfiguration[] appendComponentId(String componentId, ServiceEventClientConfiguration[] configs) {
         return Arrays.stream(configs).map(config -> {
             if (config.getEventListener() == null) {
                 // config for @RaiseServiceEvent
-                LOGGER.debug("Adding config for @RaiseServiceEvent - address: {}, name: {}, listener: {}", config.getAddress(), config.getSubscriberGroup(), config.getEventListener());
+                LOGGER.info("Adding config for @RaiseServiceEvent - address: {}, name: {}, listener: {}", config.getAddress(), config.getSubscriberGroup(), config.getEventListener());
                 return config;
             } else {
                 // config for @ListenServiceEvent
-                String subscriberName = config.getSubscriberGroup() + (clientId == null ? "" : "-" + clientId);
-                LOGGER.debug("Adding config for @ListenServiceEvent - address: {}, name: {}, listener: {}", config.getAddress(), subscriberName, config.getEventListener());
+                String subscriberName = config.getSubscriberGroup() + (componentId == null ? "" : "-" + componentId);
+                LOGGER.info("Adding config for @ListenServiceEvent - address: {}, name: {}, listener: {}", config.getAddress(), subscriberName, config.getEventListener());
                 return new ServiceEventClientConfiguration(config.getAddress(), subscriberName, config.getEventListener());
             }
         }).toArray(ServiceEventClientConfiguration[]::new);

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
@@ -290,8 +290,14 @@ public class GuiceLocatorImpl extends KapuaLocator implements Closeable {
                         LOG.info("Running initializer with priority {} on 'class'.'method': '{}'.'{}'", kv.getKey(), methodAndObject.getValue().getClass().getName(),
                                 methodAndObject.getKey().getName());
                         methodAndObject.getKey().invoke(methodAndObject.getValue());
+                        LOG.info("Running initializer with priority {} on 'class'.'method': '{}'.'{}' (DONE)", kv.getKey(), methodAndObject.getValue().getClass().getName(),
+                                methodAndObject.getKey().getName());
                     } catch (Throwable e) {
-                        throw new RuntimeException(e);
+                        LOG.error("Running initializer ERROR: {}", e.getMessage(), e);
+                        //old code (this doesn't cause the exit of the jvm but breaks the init chain so it's not good in any case IHMO)
+                        //I think it's better to log the error and leave the jvm to proceed with the other initialization
+                        //otherwise a system.exit() it's the right choice?
+                        //throw new RuntimeException(e);
                     }
                 }));
     }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceModule.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,7 @@ import org.eclipse.kapua.service.account.internal.setting.KapuaAccountSettingKey
  *
  * @since 1.0.0
  */
-public class AccountServiceModule extends ServiceEventTransactionalModule implements ServiceModule {
+public class AccountServiceModule extends ServiceEventTransactionalModule {
 
     public AccountServiceModule(
             AccountService accountService,

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/connection/listener/internal/DeviceConnectionEventListenerServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.connection.listener.internal;
 
-import org.eclipse.kapua.commons.core.ServiceModule;
 import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
 import org.eclipse.kapua.commons.event.ServiceEventHouseKeeperFactory;
 import org.eclipse.kapua.commons.event.ServiceEventTransactionalModule;
@@ -20,7 +19,7 @@ import org.eclipse.kapua.commons.event.ServiceInspector;
 import org.eclipse.kapua.event.ServiceEventBus;
 import org.eclipse.kapua.service.device.connection.listener.DeviceConnectionEventListenerService;
 
-public class DeviceConnectionEventListenerServiceModule extends ServiceEventTransactionalModule implements ServiceModule {
+public class DeviceConnectionEventListenerServiceModule extends ServiceEventTransactionalModule {
 
     public DeviceConnectionEventListenerServiceModule(DeviceConnectionEventListenerService deviceConnectionEventListenerService, String eventAddress,
             ServiceEventHouseKeeperFactory serviceEventTransactionalHousekeeperFactory,


### PR DESCRIPTION
Brief description of the PR.
Added few log lines and avoid to throw the exception, if occurs, in the Guice Object initializer loop.

**Related Issue**
None

**Description of the solution adopted**
Added a log to inform when the Object initialization is done (if no error occurs).
Add log line to show exception (if occurs).
Don't throw exception to prevent the initialization chain to stop. The exception has only this undesired effect, the application continue to run without any sign of error/exception.

**Screenshots**
none

**Any side note on the changes made**
none
