### PR TITLE
:arrow_up: [GitHub Actions] Upgraded GitHub Actions to Node 24 compatible actions

### DIFF
--- a/.github/actions/runTestsTaggedAs/action.yaml
+++ b/.github/actions/runTestsTaggedAs/action.yaml
@@ -47,4 +47,4 @@ runs:
       shell: bash
 
     - name: Code coverage results upload
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6

--- a/.github/actions/saveBuiltKapuaArtifacts/action.yaml
+++ b/.github/actions/saveBuiltKapuaArtifacts/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
 
     - name: Save built Kapua artifacts
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ~/.m2/kapua-repository/org/eclipse/kapua
         key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts

--- a/.github/actions/setUpMavenCaches/action.yaml
+++ b/.github/actions/setUpMavenCaches/action.yaml
@@ -10,7 +10,7 @@ runs:
   steps:
     - name: Cache Maven repository - External dependencies # Cache of external Maven dependencies to speed up build time
       id: cache-maven-external-deps
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2/repository/
         key: ${{ runner.os }}-maven-develop-dependencies
@@ -18,7 +18,7 @@ runs:
     - name: Cache Maven repository - Kapua artifacts # Cache of built Kapua artifacts be reused in other jobs
       if: ${{ inputs.kapua-artifact-cache-enabled == 'true' }}
       id: cache-maven-kapua-artifacts
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ~/.m2/kapua-repository/org/eclipse/kapua
         key: ${{ runner.os }}-maven-${{ github.run_number }}-kapua-artifacts

--- a/.github/actions/setUpRunner/action.yaml
+++ b/.github/actions/setUpRunner/action.yaml
@@ -9,13 +9,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 11
 
     - name: Setup Node 16
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 16
 

--- a/.github/workflows/kapua-ci.yaml
+++ b/.github/workflows/kapua-ci.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - name: Set up Maven caches
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - name: Set up Maven caches
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -95,7 +95,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -112,7 +112,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -129,7 +129,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -146,7 +146,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -163,7 +163,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -180,7 +180,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -197,7 +197,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -214,7 +214,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -231,7 +231,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -265,7 +265,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -282,7 +282,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -299,7 +299,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -316,7 +316,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -333,7 +333,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -350,7 +350,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -367,7 +367,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -384,7 +384,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -401,7 +401,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -419,7 +419,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs
@@ -437,7 +437,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
       - uses: ./.github/actions/runTestsTaggedAs

--- a/.github/workflows/kapua-release.yaml
+++ b/.github/workflows/kapua-release.yaml
@@ -21,19 +21,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4 # Checks out a copy of the repository on the ubuntu-latest machine
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5 # Checks out a copy of the repository on the ubuntu-latest machine
+      - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 11
-      - uses: actions/setup-node@v4 # Installs Node and NPM
+      - uses: actions/setup-node@v5 # Installs Node and NPM
         with:
           node-version: 16
       - name: Install Swagger CLI # Installs Swagger CLI to bundle OpenAPI files
         run: 'npm install -g @apidevtools/swagger-cli'
 
       - name: Set up Java and Maven Central credentials
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 11

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up runner
         uses: ./.github/actions/setUpRunner

--- a/.github/workflows/sonarCloud-scan.yaml
+++ b/.github/workflows/sonarCloud-scan.yaml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository # Checks out a copy of the repository on the runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up runner
         uses: ./.github/actions/setUpRunner
@@ -32,7 +32,7 @@ jobs:
           kapua-artifact-cache-enabled: 'false'
 
       - name: Cache SonarQube packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar


### PR DESCRIPTION
This PR upgrades the version of GitHub Actions used by the project to version compatible with Node 24, due to deprecation of Node 20 actions

See [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for more informations

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded versions of GitHub Actions to Node 24 compatible versions

**Screenshots**
_None_

**Any side note on the changes made**
_None_