### PR TITLE
✨ [Authentication] Added validation of SessionCredentials

### DIFF
--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -73,6 +73,17 @@ public interface AuthenticationService extends KapuaService {
     void verifyCredentials(LoginCredentials loginCredentials) throws KapuaException;
 
     /**
+     * Verifies the given {@link SessionCredentials}.
+     * <p>
+     * This does not establish a KapuaSession
+     *
+     * @param sessionCredentials The {@link SessionCredentials} to validate.
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    void verifyCredentials(SessionCredentials sessionCredentials) throws KapuaException;
+
+    /**
      * Checks if there is a session that is authenticated.
      *
      * @return {@code true} if session is authenticated, {@code false} otherwise.

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -331,6 +331,33 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
     }
 
     @Override
+    public void verifyCredentials(SessionCredentials sessionCredentials) throws KapuaException {
+        AuthenticationToken shiroAuthenticationToken = doMapToShiro(sessionCredentials);
+
+        // Login the user
+        Subject verifySubject = null;
+        try {
+            // Create custom subject to verify
+            verifySubject =
+                    new Subject
+                            .Builder()
+                            .session(new SimpleSession())
+                            .sessionCreationEnabled(false)
+                            .authenticated(false)
+                            .buildSubject();
+
+            // Login its token
+            verifySubject.login(shiroAuthenticationToken);
+
+            // Logout after verification has occurred
+            verifySubject.logout();
+
+        } catch (ShiroException se) {
+            handleTokenLoginException(se, verifySubject, shiroAuthenticationToken);
+        }
+    }
+
+    @Override
     public void logout()
             throws KapuaException {
         Subject currentUser = SecurityUtils.getSubject();
@@ -375,9 +402,13 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
 
     public AccessToken findAccessToken(String jwt) throws KapuaException {
         try {
-            final JwtContext jwtContext = jwtConsumer.process(jwt);
-            final String tokenIdentifier = Optional.ofNullable(jwtContext.getJwtClaims().getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER, String.class))
-                    .orElseThrow(() -> new AuthenticationException());
+            JwtContext jwtContext = jwtConsumer.process(jwt);
+            String tokenIdentifier =
+                Optional.ofNullable(
+                        jwtContext.getJwtClaims()
+                                  .getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER, String.class)
+                        ).orElseThrow(AuthenticationException::new);
+
             return KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenId(tokenIdentifier));
         } catch (InvalidJwtException | MalformedClaimException e) {
             throw new AuthenticationException();
@@ -533,13 +564,13 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
      */
     private KapuaAuthenticationToken doMapToShiro(AuthenticationCredentials authenticationCredentials) throws KapuaAuthenticationException {
         // Parse login credentials
-        CredentialsConverter credentialsConverter = credentialsConverters
+        CredentialsConverter selectedCredentialsConverter = credentialsConverters
                 .stream()
-                .filter(ch -> ch.canProcess(authenticationCredentials))
+                .filter(credentialsConverter -> credentialsConverter.canProcess(authenticationCredentials))
                 .findFirst()
                 .orElseThrow(() -> new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_CREDENTIALS_TYPE_PROVIDED));
 
-        return credentialsConverter.convertToShiro(authenticationCredentials);
+        return selectedCredentialsConverter.convertToShiro(authenticationCredentials);
     }
 
     private void handleTokenLoginException(ShiroException se, Subject currentSubject, AuthenticationToken authenticationToken) throws KapuaException {


### PR DESCRIPTION
This PR adds the capability to validate SessionCredentials without establish a KapuaSession

**Related Issue**
_None_

**Description of the solution adopted**
Similarly to `AuthenticationService.verifyCredentials(LoginCredentials)` a `AuthenticationService.verifyCredentials(SessionCredentials)` method has been added.

**Screenshots**
_None_

**Any side note on the changes made**
_None_