### PR TITLE
✨ [Authentication] Added AccessTokenService.findByJwt

### DIFF
--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ package org.eclipse.kapua.service.authentication;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authentication.token.AccessTokenService;
 import org.eclipse.kapua.service.authentication.token.LoginInfo;
 
 /**
@@ -23,7 +24,6 @@ import org.eclipse.kapua.service.authentication.token.LoginInfo;
  * @since 1.0.0
  */
 public interface AuthenticationService extends KapuaService {
-    // Session
 
     /**
      * Logins the provided {@link LoginCredentials}.
@@ -110,7 +110,6 @@ public interface AuthenticationService extends KapuaService {
      * @since 1.0.0
      */
     void logout() throws KapuaException;
-    // Access token
 
     /**
      * Gets the {@link AccessToken} identified by its {@link AccessToken#getTokenId()}.
@@ -120,7 +119,9 @@ public interface AuthenticationService extends KapuaService {
      * @return The found {@link AccessToken} or {@code null} if not present.
      * @throws KapuaException if the provided tokenId (JWT) is not valid in its header or payload content
      * @since 1.0.0
+     * @deprecated Since 2.1.0. It has been moved to {@link AccessTokenService#findByJwt(String)}
      */
+    @Deprecated
     AccessToken findAccessToken(String tokenId) throws KapuaException;
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
@@ -34,17 +34,7 @@ import java.util.Date;
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { //
-        "tokenId", //
-        "userId", //
-        "expiresOn", //
-        "refreshToken", //
-        "refreshExpiresOn", //
-        "invalidatedOn", //
-        "trustKey"  //
-}, //
-        factoryClass = AccessTokenXmlRegistry.class, //
-        factoryMethod = "newAccessToken")
+@XmlType(factoryClass = AccessTokenXmlRegistry.class, factoryMethod = "newAccessToken")
 public interface AccessToken extends KapuaUpdatableEntity, Serializable {
 
     String TYPE = "accessToken";

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,40 +19,42 @@ import org.eclipse.kapua.service.KapuaUpdatableEntityService;
 import org.eclipse.kapua.service.authentication.AuthenticationService;
 
 /**
- * Access token service API
+ * {@link AccessToken} {@link KapuaEntityService} definition.
  *
  * @since 1.0
  */
 public interface AccessTokenService extends KapuaEntityService<AccessToken, AccessTokenCreator>, KapuaUpdatableEntityService<AccessToken> {
 
     /**
-     * Find all access token associated with the given userId.
+     * Finds all {@link AccessToken}s associated with the given userId
      *
-     * @param scopeId
-     * @param userId
-     * @return
+     * @param scopeId The User.scopeId
+     * @param userId The User.id
+     * @return The {@link AccessTokenListResult} with matching results
      * @throws KapuaException
-     * @since 1.0
+     * @since 1.0.0
      */
     AccessTokenListResult findByUserId(KapuaId scopeId, KapuaId userId) throws KapuaException;
 
     /**
-     * Find the access token by the given tokenId.
+     * Finds the {@link AccessToken} by the given {@link AccessToken#getTokenIdentifier()}
      *
-     * @param tokenId
-     * @return
+     * @param tokenIdentifier The {@link AccessToken#getTokenIdentifier()}
+     * @return The found {@link AccessToken} or {@code null}
      * @throws KapuaException
-     * @since 1.0
+     * @since 1.0.0
      */
-    AccessToken findByTokenId(String tokenId) throws KapuaException;
+    AccessToken findByTokenIdentifier(String tokenIdentifier) throws KapuaException;
 
     /**
-     * Invalidated the {@link AccessToken} by its id. After calling this method the token will be no longer valid and a new
+     * Invalidates the {@link AccessToken} by {@link AccessToken#getId()}
+     * <p>
+     * After calling this method the {@link AccessToken} will be no longer valid and a new
      * {@link AuthenticationService#login(org.eclipse.kapua.service.authentication.LoginCredentials)} invocation is required in order to get a new valid {@link AccessToken}.
      *
-     * @param scopeId The {@link KapuaId} scopeId of the {@link AccessToken} to delete.
-     * @param id      The {@link KapuaId} of the {@link AccessToken} to delete.
-     * @since 1.0
+     * @param scopeId The {@link AccessToken#getScopeId()}
+     * @param id      The {@link AccessToken#getId()}
+     * @since 1.0.0
      */
     void invalidate(KapuaId scopeId, KapuaId id) throws KapuaException;
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
@@ -21,7 +21,7 @@ import org.eclipse.kapua.service.authentication.AuthenticationService;
 /**
  * {@link AccessToken} {@link KapuaEntityService} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public interface AccessTokenService extends KapuaEntityService<AccessToken, AccessTokenCreator>, KapuaUpdatableEntityService<AccessToken> {
 
@@ -45,6 +45,28 @@ public interface AccessTokenService extends KapuaEntityService<AccessToken, Acce
      * @since 1.0.0
      */
     AccessToken findByTokenIdentifier(String tokenIdentifier) throws KapuaException;
+
+    /**
+     * Finds the {@link AccessToken} by the given {@link AccessToken#getTokenIdentifier()}
+     *
+     * @param tokenIdentifier The {@link AccessToken#getTokenIdentifier()}
+     * @return The found {@link AccessToken} or {@code null}
+     * @throws KapuaException
+     * @since 1.0.0
+     * @deprecated Since 2.1.0. Please make use of {@link #findByTokenIdentifier(String)}. The name of this method misleads which fields the find is performed on. This method looks at {@link AccessToken#getTokenIdentifier()}, not {@link AccessToken#getTokenId()}. To search by {@link AccessToken#getTokenId()} use {@link #findByJwt(String)}
+     */
+    @Deprecated
+    AccessToken findByTokenId(String tokenIdentifier) throws KapuaException;
+
+    /**
+     * Finds the {@link AccessToken} by the given {@link AccessToken#getTokenId()} aka JWT
+     *
+     * @param jwt The {@link AccessToken#getTokenId()}
+     * @return The found {@link AccessToken} or {@code null}
+     * @throws KapuaException
+     * @since 2.1.0
+     */
+    AccessToken findByJwt(String jwt) throws KapuaException;
 
     /**
      * Invalidates the {@link AccessToken} by {@link AccessToken#getId()}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -409,7 +409,7 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
                                   .getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER, String.class)
                         ).orElseThrow(AuthenticationException::new);
 
-            return KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenId(tokenIdentifier));
+            return KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenIdentifier(tokenIdentifier));
         } catch (InvalidJwtException | MalformedClaimException e) {
             throw new AuthenticationException();
         }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authentication.shiro;
 
 import java.util.Date;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -106,12 +105,7 @@ import org.eclipse.kapua.service.user.UserService;
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
-import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.NumericDate;
-import org.jose4j.jwt.consumer.InvalidJwtException;
-import org.jose4j.jwt.consumer.JwtConsumer;
-import org.jose4j.jwt.consumer.JwtConsumerBuilder;
-import org.jose4j.jwt.consumer.JwtContext;
 import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,8 +144,6 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
     private final Set<CredentialsConverter> credentialsConverters;
     private final KapuaAuthenticationSetting kapuaAuthenticationSetting;
 
-    private final JwtConsumer jwtConsumer;
-
     @Inject
     public AuthenticationServiceShiroImpl(
             CredentialService credentialService,
@@ -171,7 +163,8 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             GroupPermissionService groupPermissionService,
             UserService userService,
             Set<CredentialsConverter> credentialsConverters,
-            KapuaAuthenticationSetting kapuaAuthenticationSetting) {
+            KapuaAuthenticationSetting kapuaAuthenticationSetting
+    ) {
         this.credentialService = credentialService;
         this.mfaOptionService = mfaOptionService;
         this.accessTokenService = accessTokenService;
@@ -190,12 +183,6 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         this.userService = userService;
         this.credentialsConverters = credentialsConverters;
         this.kapuaAuthenticationSetting = kapuaAuthenticationSetting;
-
-        this.jwtConsumer = new JwtConsumerBuilder()
-                .setSkipAllValidators()
-                .setDisableRequireSignature()
-                .setSkipSignatureVerification()
-                .build();
     }
 
     @Override
@@ -390,7 +377,7 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
                 accessToken = kapuaSession.getAccessToken();
 
                 if (accessToken == null) {
-                    accessToken = findAccessToken(jwt);
+                    accessToken = accessTokenService.findByJwt(jwt);
                 }
             }
         } finally {
@@ -400,19 +387,9 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         return accessToken;
     }
 
+    @Override
     public AccessToken findAccessToken(String jwt) throws KapuaException {
-        try {
-            JwtContext jwtContext = jwtConsumer.process(jwt);
-            String tokenIdentifier =
-                Optional.ofNullable(
-                        jwtContext.getJwtClaims()
-                                  .getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER, String.class)
-                        ).orElseThrow(AuthenticationException::new);
-
-            return KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenIdentifier(tokenIdentifier));
-        } catch (InvalidJwtException | MalformedClaimException e) {
-            throw new AuthenticationException();
-        }
+        return accessTokenService.findByJwt(jwt);
     }
 
     @Override
@@ -433,7 +410,7 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         Date now = new Date();
         AccessToken expiredAccessToken;
         try {
-            expiredAccessToken = findAccessToken(tokenId);
+            expiredAccessToken = accessTokenService.findByJwt(tokenId);
         } catch (AuthenticationException e) {
             throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.REFRESH_ERROR, "");
         }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
@@ -140,7 +140,7 @@ public class AccessTokenAuthenticatingRealm extends KapuaAuthenticatingRealm {
             final String tokenIdentifier = Optional.ofNullable(jwtClaims.getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER))
                     .map(s -> (String) s)
                     .orElseThrow(() -> new ShiroException("Missing tokenIdentifier in jwt token"));
-            accessToken = KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenId(tokenIdentifier));
+            accessToken = KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenIdentifier(tokenIdentifier));
         } catch (KapuaException ke) {
             throw new AuthenticationException();
         }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
 import java.util.Date;
-import java.util.Optional;
 
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.ShiroException;
@@ -121,11 +120,11 @@ public class AccessTokenAuthenticatingRealm extends KapuaAuthenticatingRealm {
             jwtClaims = jwtContext.getJwtClaims();
             // FIXME: JWT cert. could be cached to speed-up validation process
         } catch (KapuaException | MalformedClaimException ke) {
-            //As we are swallowing the original exception, let's at least log it
+            // As we are swallowing the original exception, lets at least log it
             logger.error("Error processing Auth Token(KapuaException)", ke);
             throw new AuthenticationException();
         } catch (InvalidJwtException e) {
-            //As we are swallowing the original exception, let's at least log it
+            // As we are swallowing the original exception, lets at least log it
             logger.error("Error processing Auth Token (InvalidJwtException)", e);
             if (e.hasErrorCode(ErrorCodes.EXPIRED)) {
                 throw new ExpiredAccessTokenException();
@@ -137,9 +136,12 @@ public class AccessTokenAuthenticatingRealm extends KapuaAuthenticatingRealm {
         // Find accessToken
         final AccessToken accessToken;
         try {
-            final String tokenIdentifier = Optional.ofNullable(jwtClaims.getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER))
-                    .map(s -> (String) s)
-                    .orElseThrow(() -> new ShiroException("Missing tokenIdentifier in jwt token"));
+            String tokenIdentifier = (String) jwtClaims.getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER);
+
+            if (tokenIdentifier == null) {
+                throw new ShiroException("Missing tokenIdentifier in JWT token");
+            }
+
             accessToken = KapuaSecurityUtils.doPrivileged(() -> accessTokenService.findByTokenIdentifier(tokenIdentifier));
         } catch (KapuaException ke) {
             throw new AuthenticationException();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
@@ -175,18 +175,19 @@ public class AccessTokenServiceImpl implements AccessTokenService {
     }
 
     @Override
-    public AccessToken findByTokenId(String tokenId) throws KapuaException {
+    public AccessToken findByTokenIdentifier(String tokenIdentifier) throws KapuaException {
         // Argument Validation
-        ArgumentValidator.notNull(tokenId, "tokenId");
+        ArgumentValidator.notNull(tokenIdentifier, "tokenIdentifier");
+
         // Do find
-        Optional<AccessToken> accessToken = txManager.execute(tx -> accessTokenRepository.findByTokenId(tx, tokenId));
+        Optional<AccessToken> accessToken = txManager.execute(tx -> accessTokenRepository.findByTokenId(tx, tokenIdentifier));
+
         // Check Access
         if (accessToken.isPresent()) {
             authorizationService.checkPermission(permissionFactory.newPermission(Domains.ACCESS_TOKEN, Actions.read, accessToken.get().getScopeId()));
         }
 
-        return accessToken
-                .orElse(null);
+        return accessToken.orElse(null);
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.token.shiro;
 
+import org.apache.shiro.authc.AuthenticationException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.model.domains.Domains;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
@@ -32,6 +35,11 @@ import org.eclipse.kapua.service.authentication.token.AccessTokenService;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.storage.TxManager;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.jwt.consumer.JwtContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,17 +62,26 @@ public class AccessTokenServiceImpl implements AccessTokenService {
     private final AccessTokenRepository accessTokenRepository;
     private final AccessTokenFactory accessTokenFactory;
 
+    private final JwtConsumer jwtConsumer;
+
     public AccessTokenServiceImpl(
             AuthorizationService authorizationService,
             PermissionFactory permissionFactory,
             TxManager txManager,
             AccessTokenRepository accessTokenRepository,
-            AccessTokenFactory accessTokenFactory) {
+            AccessTokenFactory accessTokenFactory
+    ) {
         this.authorizationService = authorizationService;
         this.permissionFactory = permissionFactory;
         this.txManager = txManager;
         this.accessTokenRepository = accessTokenRepository;
         this.accessTokenFactory = accessTokenFactory;
+
+        this.jwtConsumer = new JwtConsumerBuilder()
+                .setSkipAllValidators()
+                .setDisableRequireSignature()
+                .setSkipSignatureVerification()
+                .build();
     }
 
     @Override
@@ -188,6 +205,36 @@ public class AccessTokenServiceImpl implements AccessTokenService {
         }
 
         return accessToken.orElse(null);
+    }
+
+    @Override
+    public AccessToken findByTokenId(String tokenIdentifier) throws KapuaException {
+        return findByTokenIdentifier(tokenIdentifier);
+    }
+
+    @Override
+    public AccessToken findByJwt(String jwt) throws KapuaException {
+        // Argument Validation
+        ArgumentValidator.notNull(jwt, "jwt");
+
+        // Parse JWT
+        String tokenIdentifier;
+        try {
+            JwtContext jwtContext = jwtConsumer.process(jwt);
+
+            tokenIdentifier = jwtContext
+                .getJwtClaims()
+                .getClaimValue(AccessTokenAttributes.TOKEN_IDENTIFIER, String.class);
+
+            if (tokenIdentifier == null) {
+                throw new KapuaIllegalArgumentException("jwt", jwt);
+            }
+        } catch (InvalidJwtException | MalformedClaimException e) {
+            throw new AuthenticationException();
+        }
+
+        // Do find
+        return KapuaSecurityUtils.doPrivileged(() -> findByTokenIdentifier(tokenIdentifier));
     }
 
     @Override


### PR DESCRIPTION
This PR adds `AccessTokenService.findByJwt` 

**Related Issue**
_None_

**Description of the solution adopted**
Added a method to find an AccessToken by a JWT plain string.

**Screenshots**
_None_

**Any side note on the changes made**
- `AuthenticationService.findAccessToken(String)` has been deprecated and it is replaced by `AccessTokenService.findByJwt(String)`: AccessTokenService is more appropriate service to put it
- `AccessTokenService.findByTokenId(String)` has been deprecated in favour of `AccessTokenService.findByTokenIdentifier(String)`: name of original existing methods misleads with field of AccessToken the search is applied on. Current method looks in `AccessToken.tokenIdentifier` (a UUID) and not `AccessToken.tokenId` (the JWT plain string)
