### PR TITLE
:bug: [OpenApi] Fixed definition of LoginInfo that was missing doc for properties - errata

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication.yaml
@@ -56,7 +56,7 @@ components:
           type: array
           items:
             $ref: '../role/role.yaml#/components/schemas/rolePermission'
-        groupPermission:
+        groupPermissions:
           description: The list of Permission assigned to the User via UserGroups
           type: array
           items:


### PR DESCRIPTION
This PR fixes a small error in the recently merged https://github.com/eclipse-kapua/kapua/pull/4377

**Related Issue**
This PR fixes an issue introduced in https://github.com/eclipse-kapua/kapua/pull/4377

**Description of the solution adopted**
Fixed property name of `groupPermissions` field in `loginInfo` schema

**Screenshots**
_None_

**Any side note on the changes made**
_None_