### PR TITLE
:arrow_up: [Dependencies] Bumped version of io.netty dependencies to 4.1.135 - CVE-2026-33870 CVE-2026-33871 CVE-2026-41417 CVE-2026-42578 CVE-2026-42579 CVE-2026-42580 CVE-2026-42581 CVE-2026-42583 CVE-2026-42584 CVE-2026-42585 CVE-2026-42586 CVE-2026-42587 CVE-2026-44248 CVE-2026-44249 CVE-2026-44250 CVE-2026-44890 CVE-2026-44893 CVE-2026-45416 CVE-2026-45536 CVE-2026-45673 CVE-2026-45674 CVE-2026-46340 CVE-2026-47244 CVE-2026-47691 CVE-2026-48006 CVE-2026-48043 CVE-2026-48059 CVE-2026-50010 CVE-2026-50011 CVE-2026-50020 CVE-2026-50560

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <liquibase.version>3.6.3</liquibase.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.130.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <ow2-asm.version>9.4</ow2-asm.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>


### PR DESCRIPTION
This PR bumps the version of Netty dependencies to 4.1.125 to fix following components CVEs:

- io.netty:netty-codec: [CVE-2026-42583](https://github.com/eclipse-kapua/kapua/security/dependabot/236)
- io.netty:netty-codec-dns: [CVE-2026-42579](https://github.com/eclipse-kapua/kapua/security/dependabot/232)
- io.netty:netty-codec-haproxy: [CVE-2026-48059](https://github.com/eclipse-kapua/kapua/security/dependabot/258) [CVE-2026-44893](https://github.com/eclipse-kapua/kapua/security/dependabot/246)
- io.netty:netty-codec-http: [CVE-2026-33870](https://github.com/eclipse-kapua/kapua/security/dependabot/221) [CVE-2026-42585](https://github.com/eclipse-kapua/kapua/security/dependabot/238) [CVE-2026-42580](https://github.com/eclipse-kapua/kapua/security/dependabot/233) [CVE-2026-42587](https://github.com/eclipse-kapua/kapua/security/dependabot/240) [CVE-2026-42581](https://github.com/eclipse-kapua/kapua/security/dependabot/234) [CVE-2026-42584](https://github.com/eclipse-kapua/kapua/security/dependabot/237) [CVE-2026-41417](https://github.com/eclipse-kapua/kapua/security/dependabot/227) [CVE-2026-50020](https://github.com/eclipse-kapua/kapua/security/dependabot/261) 
- io.netty:netty-codec-http2: [CVE-2026-33871](https://github.com/eclipse-kapua/kapua/security/dependabot/220) [CVE-2026-50560](https://github.com/eclipse-kapua/kapua/security/dependabot/260) [CVE-2026-42587](https://github.com/eclipse-kapua/kapua/security/dependabot/239) [CVE-2026-47244](https://github.com/eclipse-kapua/kapua/security/dependabot/255) [CVE-2026-48043](https://github.com/eclipse-kapua/kapua/security/dependabot/257) 
- io.netty:netty-codec-mqtt: [CVE-2026-44248](https://github.com/eclipse-kapua/kapua/security/dependabot/241) 
- io.netty:netty-codec-redis: [CVE-2026-48006](https://github.com/eclipse-kapua/kapua/security/dependabot/256) [CVE-2026-50011](https://github.com/eclipse-kapua/kapua/security/dependabot/259) [CVE-2026-44250](https://github.com/eclipse-kapua/kapua/security/dependabot/244) [CVE-2026-44890](https://github.com/eclipse-kapua/kapua/security/dependabot/245) [CVE-2026-42586](https://github.com/eclipse-kapua/kapua/security/dependabot/235) 
- io.netty:netty-handler: [CVE-2026-44249](https://github.com/eclipse-kapua/kapua/security/dependabot/247) [CVE-2026-50010](https://github.com/eclipse-kapua/kapua/security/dependabot/262) [CVE-2026-45416](https://github.com/eclipse-kapua/kapua/security/dependabot/254) 
- io.netty:netty-handler-proxy: [CVE-2026-42578](https://github.com/eclipse-kapua/kapua/security/dependabot/231) 
- io.netty:netty-resolver-dns: [CVE-2026-45674](https://github.com/eclipse-kapua/kapua/security/dependabot/252) [CVE-2026-47691](https://github.com/eclipse-kapua/kapua/security/dependabot/253) [CVE-2026-45673](https://github.com/eclipse-kapua/kapua/security/dependabot/251) 
- io.netty:netty-transport-native-epoll: [CVE-2026-45536](https://github.com/eclipse-kapua/kapua/security/dependabot/250) 
- io.netty:netty-transport-native-kqueue: [CVE-2026-45536](https://github.com/eclipse-kapua/kapua/security/dependabot/248)
- io.netty:netty-transport-sctp: [CVE-2026-46340](https://github.com/eclipse-kapua/kapua/security/dependabot/249)

**Related Issue**
_None_

**Description of the solution adopted**
Updated the version from 4.1.130 to 4.1.135

**Screenshots**
_None_

**Any side note on the changes made**
_None_