### PR TITLE
:bug: [GitHub] Fixed java-version for Kapua Release Github Workflow

### DIFF
--- a/.github/workflows/kapua-release.yaml
+++ b/.github/workflows/kapua-release.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - uses: actions/setup-node@v5 # Installs Node and NPM
         with:
           node-version: 16
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD


### PR DESCRIPTION
This PR fixes the java-version for Kapua Release workflow.
This was not changed in #4374

**Related Issue**
This PR adds to the work done in #4374

**Description of the solution adopted**
Changed `java-version` used from `11` to `17`

**Screenshots**
_None_

**Any side note on the changes made**
_None_