### PR TITLE
:bug: [GitHub] Restored actions/setup-java@v5 action which was downgraded in #4374

### DIFF
--- a/.github/actions/setUpRunner/action.yaml
+++ b/.github/actions/setUpRunner/action.yaml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: 17


### PR DESCRIPTION
This PR restores the `actions/setup-java@v5` version which was downgraded by mistake in #4374

**Related Issue**
This was a error introduced in #4374

**Description of the solution adopted**
Restored the correct action version

**Screenshots**
_None_

**Any side note on the changes made**
_None_