### PR TITLE
:bug: [Broker] Fix broker event handler to server context and add MQTT connected device metric

### DIFF
--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/AppModule.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/AppModule.java
@@ -16,6 +16,8 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.artemis.plugin.security.MetricsSecurityPlugin;
+import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEventHandler;
 import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSetting;
 import org.eclipse.kapua.broker.artemis.plugin.utils.BrokerHostResolver;
 import org.eclipse.kapua.broker.artemis.plugin.utils.BrokerIdResolver;
@@ -66,6 +68,12 @@ public class AppModule extends AbstractKapuaModule {
     @Named("metricModuleName")
     String metricModuleName() {
         return "broker-telemetry";
+    }
+
+    @Provides
+    @Singleton
+    public BrokerEventHandler brokerEventHandler(MetricsSecurityPlugin metricsSecurityPlugin) {
+        return new BrokerEventHandler("ServerPlugin", 0l, 10000l, metricsSecurityPlugin);
     }
 
     @Provides

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/MetricsSecurityPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/MetricsSecurityPlugin.java
@@ -50,6 +50,10 @@ public class MetricsSecurityPlugin {
             String metricModuleName) {
         this.metricsService = metricsService;
         this.metricModuleName = metricModuleName;
+        //leave the initialization of these metrics here. Do not move in the init method.
+        processedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "processed");
+        dequeuedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "dequeued");
+        enqueuedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "enqueued");
     }
 
     public void init(ActiveMQServer server, Gauge<Integer> mapSize, Gauge<Integer> mapByClientSize, Gauge<Integer> aclSize, Gauge<Integer> activeConnection) throws KapuaException {
@@ -61,10 +65,6 @@ public class MetricsSecurityPlugin {
         metricsService.registerGauge(() -> server.getTotalMessageCount(), metricModuleName, LoginMetric.COMPONENT_LOGIN, TOTAL_MESSAGE, MetricsLabel.SIZE);
         metricsService.registerGauge(() -> server.getTotalMessagesAcknowledged(), metricModuleName, LoginMetric.COMPONENT_LOGIN, TOTAL_MESSAGE_ACKNOWLEDGED, MetricsLabel.SIZE);
         metricsService.registerGauge(() -> server.getTotalMessagesAdded(), metricModuleName, LoginMetric.COMPONENT_LOGIN, TOTAL_MESSAGE_ADDED, MetricsLabel.SIZE);
-
-        processedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "processed");
-        dequeuedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "dequeued");
-        enqueuedEvent = metricsService.getCounter(metricModuleName, SECURITY_PLUGIN_EVENT, "enqueued");
     }
 
     public Counter getProcessedEvent() {

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
@@ -143,7 +143,7 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
     }
 
     //TODO SEE EXTERNAL FOR THE LOCK
-    private Subject authenticateInternalConn(ConnectionInfo connectionInfo, String connectionId, String username, String password,
+    protected Subject authenticateInternalConn(ConnectionInfo connectionInfo, String connectionId, String username, String password,
             RemotingConnection remotingConnection) {
         loginMetric.getInternalConnector().getAttempt().inc();
         String usernameToCompare = SystemSetting.getInstance().getString(SystemSettingKey.BROKER_INTERNAL_CONNECTOR_USERNAME);
@@ -173,7 +173,7 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
         }
     }
 
-    private Subject authenticateExternalConn(ConnectionInfo connectionInfo, String connectionId, String username, String password, RemotingConnection remotingConnection) throws Exception {
+    protected Subject authenticateExternalConn(ConnectionInfo connectionInfo, String connectionId, String username, String password, RemotingConnection remotingConnection) throws Exception {
         if (connectionInfo.getClientId()==null) {
             logger.warn("Client Id is null for connection id {} - login denied", connectionId);
             return null;

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/SecurityPlugin.java
@@ -65,10 +65,10 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
 
     protected static Logger logger = LoggerFactory.getLogger(SecurityPlugin.class);
 
-    private final LoginMetric loginMetric;
-    private final PublishMetric publishMetric;
-    private final SubscribeMetric subscribeMetric;
-    private final PluginUtility pluginUtility;
+    protected final LoginMetric loginMetric;
+    protected final PublishMetric publishMetric;
+    protected final SubscribeMetric subscribeMetric;
+    protected final PluginUtility pluginUtility;
 
     protected ServerContext serverContext;
     //to avoid deadlock this field will be initialized by the first internal login call
@@ -117,6 +117,7 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
                         clientId,//clientId
                         clientIp,//clientIp
                         remotingConnection.getTransportConnection().getConnectorConfig().getName(),//connectorName
+                        isDevice(username, remotingConnection),
                         remotingConnection.getProtocolName(),//transportProtocol
                         (String) remotingConnection.getTransportConnection().getConnectorConfig().getCombinedParams().get("sslEnabled"),//sslEnabled
                         getPeerCertificates(remotingConnection));//clientsCertificates
@@ -131,7 +132,14 @@ public class SecurityPlugin implements ActiveMQSecurityManager5 {
         }
     }
 
-    private String extractAndValidateClientId(RemotingConnection remotingConnection) {
+    //useful method to customize the detection of "real devices" connected to the system
+    //(for example to exclude internal connection for lifecycle/datastore consumers)
+    //In that way an accurate value could be exposed through a metric
+    protected boolean isDevice(String username, RemotingConnection remotingConnection) {
+        return true;
+    }
+
+    protected String extractAndValidateClientId(RemotingConnection remotingConnection) {
         String clientId = remotingConnection.getClientID();
         //leave the clientId validation to the DeviceCreator. Here just check for / or ::
         //ArgumentValidator.match(clientId, DeviceValidationRegex.CLIENT_ID, "deviceCreator.clientId");

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerContext.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerContext.java
@@ -19,6 +19,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.artemis.plugin.security.ServerPlugin.Failure;
 import org.eclipse.kapua.broker.artemis.plugin.security.context.SecurityContext;
 import org.eclipse.kapua.broker.artemis.plugin.security.context.SecurityContext.LockType;
+import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEventHandler;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.LoginMetric;
 import org.eclipse.kapua.broker.artemis.plugin.utils.BrokerIdentity;
 import org.eclipse.kapua.client.security.ServiceClient;
@@ -41,6 +42,7 @@ public class ServerContext {
     protected final BrokerIdentity brokerIdentity;
     protected ActiveMQServer server;
     protected AddressAccessTracker addressAccessTracker;
+    protected BrokerEventHandler brokerEventHandler;
 
     @Inject
     public ServerContext(
@@ -48,12 +50,14 @@ public class ServerContext {
             @Named("clusterName") String clusterName,
             BrokerIdentity brokerIdentity,
             SecurityContext securityContext,
-            AddressAccessTracker accessTracker) {
+            AddressAccessTracker accessTracker,
+            BrokerEventHandler brokerEventHandler) {
+        this.authServiceClient = authServiceClient;
         this.clusterName = clusterName;
         this.brokerIdentity = brokerIdentity;
         this.securityContext = securityContext;
         this.addressAccessTracker = accessTracker;
-        this.authServiceClient = authServiceClient;
+        this.brokerEventHandler = brokerEventHandler;
     }
 
     public void init(ActiveMQServer server) throws KapuaException {
@@ -88,6 +92,10 @@ public class ServerContext {
 
     public AddressAccessTracker getAddressAccessTracker() {
         return addressAccessTracker;
+    }
+
+    public BrokerEventHandler getBrokerEventHandler() {
+        return brokerEventHandler;
     }
 
     public void closeConnection(Logger logger, LoginMetric loginMetric, RemotingConnection remotingConnection, String connectionId) {

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/ServerPlugin.java
@@ -32,7 +32,6 @@ import org.eclipse.kapua.broker.artemis.plugin.security.connector.AcceptorHandle
 import org.eclipse.kapua.broker.artemis.plugin.security.context.SecurityContext.LockType;
 import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEvent;
 import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEvent.EventType;
-import org.eclipse.kapua.broker.artemis.plugin.security.event.BrokerEventHandler;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.LoginMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.PublishMetric;
 import org.eclipse.kapua.broker.artemis.plugin.security.metric.SubscribeMetric;
@@ -41,8 +40,6 @@ import org.eclipse.kapua.broker.artemis.plugin.security.setting.BrokerSettingKey
 import org.eclipse.kapua.client.security.context.SessionContext;
 import org.eclipse.kapua.client.security.context.Utils;
 import org.eclipse.kapua.commons.core.ServiceModuleBundle;
-import org.eclipse.kapua.commons.setting.system.SystemSetting;
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -99,7 +96,6 @@ public class ServerPlugin implements ActiveMQServerPlugin {
     private final BrokerSetting brokerSetting;
     private final PluginUtility pluginUtility;
 
-    protected BrokerEventHandler brokerEventHandler;
     protected AcceptorHandler acceptorHandler;
     protected String version;
     protected ServerContext serverContext;
@@ -122,13 +118,10 @@ public class ServerPlugin implements ActiveMQServerPlugin {
     public void registered(ActiveMQServer server) {
         logger.info("registering plugin {}...", this.getClass().getName());
         try {
-            String clusterName = SystemSetting.getInstance().getString(SystemSettingKey.CLUSTER_NAME);
             serverContext.init(server);
-            KapuaLocator kapuaLocator = KapuaLocator.getInstance();
             //metricsSecurityPlugin (singleton) initialized by serverContext.init(server)
-            brokerEventHandler = new BrokerEventHandler("ServerPlugin", 0l, 10000l, kapuaLocator.getComponent(MetricsSecurityPlugin.class));
-            brokerEventHandler.registerConsumer((brokerEvent) -> disconnectClient(brokerEvent));
-            brokerEventHandler.start();
+            serverContext.getBrokerEventHandler().registerConsumer((brokerEvent) -> disconnectClient(brokerEvent));
+            serverContext.getBrokerEventHandler().start();
             acceptorHandler = new AcceptorHandler(server,
                     brokerSetting.getMap(String.class, BrokerSettingKey.ACCEPTORS));
             //init activateCallback to handle acceptor initialization instead of calling it from here
@@ -411,7 +404,7 @@ public class ServerPlugin implements ActiveMQServerPlugin {
             BrokerEvent disconnectEvent = new BrokerEvent(EventType.disconnectClientByConnectionId, sessionContext, sessionContext);
 
             logger.info("Submitting broker event to disconnect clientId: {}, connectionId: {}", fullClientId, sessionContext.getConnectionId());
-            brokerEventHandler.enqueueEvent(disconnectEvent);
+            serverContext.getBrokerEventHandler().enqueueEvent(disconnectEvent);
         } catch (Exception e) {
             logger.warn("Error processing event: {}", e);
         }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/connector/AcceptorHandler.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/connector/AcceptorHandler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * Helper class to handle acceptor lifecycle (add/remove acceptors on demand)
@@ -59,9 +60,23 @@ public class AcceptorHandler {
      * @throws Exception
      */
     public String addAcceptor(String name, String uri) throws Exception {
+        logger.info("adding acceptor {}...", name);
         String previousAcceptor = definedAcceptors.put(name, uri);
         syncAcceptors();
+        logger.info("adding acceptor {}... DONE", name);
         return previousAcceptor;
+    }
+
+    /**
+     * Pause acceptor
+     *
+     * @param name acceptor name
+     * @throws Exception
+     */
+    public void pauseAcceptor(String name) throws Exception {
+        logger.info("Pause acceptor {}...", name);
+        server.getRemotingService().getAcceptor(name).pause();
+        logger.info("Pause acceptor {}... DONE", name);
     }
 
     /**
@@ -72,9 +87,17 @@ public class AcceptorHandler {
      * @throws Exception
      */
     public String removeAcceptor(String name) throws Exception {
+        logger.info("removing acceptor {}...", name);
         String currentAcceptor = definedAcceptors.remove(name);
         syncAcceptors();
+        logger.info("removing acceptor {}... DONE", name);
         return currentAcceptor;
+    }
+
+    public List<String> getAcceptorNames() {
+        return definedAcceptors.keySet()
+            .stream()
+            .collect(Collectors.toList());
     }
 
     /**

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/context/SecurityContext.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/context/SecurityContext.java
@@ -164,6 +164,9 @@ public final class SecurityContext {
                 if (!isInternal) {
                     //fill by full client id context
                     sessionContextMapByClient.put(Utils.getFullClientId(sessionContext), sessionContext);
+                    if (sessionContext.isDevice()) {
+                        loginMetric.getConnectedDevice().incrementAndGet();
+                    }
                 }
                 return true;
             } else {
@@ -233,6 +236,9 @@ public final class SecurityContext {
                     logger.info("Disconnect: stealing - leave session context by clientId: {} - connection id: {} (old connection id: {})",
                             currentSessionContext.getClientId(), currentSessionContext.getConnectionId(), connectionId);
                 }
+            }
+            if (sessionContext.isDevice()) {
+                loginMetric.getConnectedDevice().decrementAndGet();
             }
             return currentSessionContext;
         }

--- a/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/metric/LoginMetric.java
+++ b/broker/artemis/plugin/src/main/java/org/eclipse/kapua/broker/artemis/plugin/security/metric/LoginMetric.java
@@ -14,8 +14,12 @@ package org.eclipse.kapua.broker.artemis.plugin.security.metric;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
+
+import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.metric.MetricsLabel;
 import org.eclipse.kapua.commons.metric.MetricsService;
+
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -28,6 +32,8 @@ public class LoginMetric {
     //action
     private static final String DISCONNECT = "disconnect";
 
+    private static final String CONNECTING_DEVICES = "connecting_devices";
+    private static final String CONNECTED_DEVICES = "connected_devices";
     private static final String INTERNAL_CONNECTOR = "internal_connector";
     private static final String EXTERNAL_CONNECTOR = "external_connector";
     private static final String AUTHENTICATE_FROM_CACHE = "authenticate_from_cache";
@@ -44,6 +50,8 @@ public class LoginMetric {
     private static final String ADD_CONNECTION = "add_connection";
     private static final String REMOVE_CONNECTION = "remove_connection";
 
+    private final AtomicLong connectingDevice;
+    private final AtomicLong connectedDevice;
     private final ActionMetric externalConnector;
     private final ActionMetric internalConnector;
     private final Counter authenticateFromCache;
@@ -65,8 +73,12 @@ public class LoginMetric {
     @Inject
     public LoginMetric(MetricsService metricsService,
                        @Named("metricModuleName")
-                       String metricModuleName) {
+                       String metricModuleName) throws KapuaException {
         // login by connectors
+        connectedDevice = new AtomicLong();
+        metricsService.registerGauge(() -> connectedDevice.get(), COMPONENT_LOGIN, CONNECTED_DEVICES);
+        connectingDevice = new AtomicLong();
+        metricsService.registerGauge(() -> connectingDevice.get(), COMPONENT_LOGIN, CONNECTING_DEVICES);
         externalConnector = new ActionMetric(metricsService, metricModuleName, COMPONENT_LOGIN, EXTERNAL_CONNECTOR);
         authenticateFromCache = metricsService.getCounter(metricModuleName, COMPONENT_LOGIN, AUTHENTICATE_FROM_CACHE);
         internalConnector = new ActionMetric(metricsService, metricModuleName, COMPONENT_LOGIN, INTERNAL_CONNECTOR);
@@ -85,6 +97,14 @@ public class LoginMetric {
         // login time
         externalAddConnection = metricsService.getTimer(metricModuleName, COMPONENT_LOGIN, ADD_CONNECTION, MetricsLabel.TIME, MetricsLabel.SECONDS);
         removeConnection = metricsService.getTimer(metricModuleName, COMPONENT_LOGIN, REMOVE_CONNECTION, MetricsLabel.TIME, MetricsLabel.SECONDS);
+    }
+
+    public AtomicLong getConnectingDevice() {
+        return connectingDevice;
+    }
+
+    public AtomicLong getConnectedDevice() {
+        return connectedDevice;
     }
 
     public Counter getAuthenticateFromCache() {

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/bean/ConnectionInfo.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/bean/ConnectionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,15 +23,17 @@ public class ConnectionInfo {
     private String connectionId;
     private String clientId;
     private String connectorName;
+    private boolean device;
     private String transportProtocol;
     private String clientIp;
     private Boolean sslEnabled;
     private Certificate[] certificates;
 
-    public ConnectionInfo(String connectionId, String clientId, String clientIp, String connectorName, String transportProtocol, String sslEnabledStr, Certificate[] clientCertificates) {
+    public ConnectionInfo(String connectionId, String clientId, String clientIp, String connectorName, boolean device, String transportProtocol, String sslEnabledStr, Certificate[] clientCertificates) {
         this.connectionId = connectionId;
         this.clientId = clientId;
         this.connectorName = connectorName;
+        this.device = device;
         this.transportProtocol = transportProtocol;
         this.clientIp = clientIp;
         certificates = clientCertificates;
@@ -48,6 +50,10 @@ public class ConnectionInfo {
 
     public String getConnectorName() {
         return connectorName;
+    }
+
+    public boolean isDevice() {
+        return device;
     }
 
     public String getTransportProtocol() {

--- a/client/security/src/main/java/org/eclipse/kapua/client/security/context/SessionContext.java
+++ b/client/security/src/main/java/org/eclipse/kapua/client/security/context/SessionContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -44,6 +44,7 @@ public class SessionContext {
     private KapuaId kapuaConnectionId;
     private String brokerHost;
     private String connectorName;
+    private boolean device;
     private String transportProtocol;
     private Certificate[] certificates;
     private KapuaSession kapuaSession;
@@ -71,6 +72,7 @@ public class SessionContext {
         clientId = connectionInfo.getClientId();
         clientIp = connectionInfo.getClientIp();
         connectorName = connectionInfo.getConnectorName();
+        device = connectionInfo.isDevice();
         transportProtocol = connectionInfo.getTransportProtocol();
         certificates = connectionInfo.getCertificates();
         this.properties = new HashMap<>();
@@ -149,6 +151,10 @@ public class SessionContext {
 
     public String getConnectorName() {
         return connectorName;
+    }
+
+    public boolean isDevice() {
+        return device;
     }
 
     public String getTransportProtocol() {


### PR DESCRIPTION
Brief description of the PR.
minor fix to ServerContext and to allow to expose metric with MQTT device connections count.

**Related Issue**
none

**Description of the solution adopted**
A new flag to distinguish between real devices and internal connections is added to ConnectionInfo.
Login process review to add metric to count the real connected device. In this way is possible to separate internal connections and MQTT device connections.

**Screenshots**
none

**Any side note on the changes made**
none