### PR TITLE
:recycle: [Project] Refactored Broker Consumers Maven Packaging

### DIFF
--- a/assembly/consumer/lifecycle/descriptors/kapua-consumer-lifecycle.xml
+++ b/assembly/consumer/lifecycle/descriptors/kapua-consumer-lifecycle.xml
@@ -22,13 +22,19 @@
         <format>tar.gz</format>
     </formats>
 
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory/>
+
+            <includes>
+                <include>${pom.groupId}:kapua-consumer-lifecycle-app</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
     <files>
         <file>
             <source>${project.basedir}/entrypoint/run-consumer-lifecycle</source>
-            <fileMode>0755</fileMode>
-        </file>
-        <file>
-            <source>${project.basedir}/../../../consumer/lifecycle-app/target/kapua-consumer-lifecycle-${project.version}-app.jar</source>
             <fileMode>0755</fileMode>
         </file>
     </files>

--- a/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
+++ b/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
@@ -26,4 +26,4 @@ JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DE
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
 
-exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-lifecycle-2.1.0-SNAPSHOT-app.jar
+exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-lifecycle-app-2.1.0-SNAPSHOT-app.jar

--- a/assembly/consumer/lifecycle/pom.xml
+++ b/assembly/consumer/lifecycle/pom.xml
@@ -30,6 +30,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-consumer-lifecycle-app</artifactId>
+            <classifier>app</classifier>
         </dependency>
     </dependencies>
 
@@ -46,6 +47,31 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Import dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kapua</groupId>
+                                    <artifactId>kapua-consumer-lifecycle-app</artifactId>
+                                    <classifier>app</classifier>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile>

--- a/assembly/consumer/pom.xml
+++ b/assembly/consumer/pom.xml
@@ -26,10 +26,6 @@
     <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
-    <properties>
-        <docker.account>kapua</docker.account>
-    </properties>
-
     <modules>
         <module>lifecycle</module>
         <module>telemetry</module>

--- a/assembly/consumer/telemetry/descriptors/kapua-consumer-telemetry.xml
+++ b/assembly/consumer/telemetry/descriptors/kapua-consumer-telemetry.xml
@@ -22,13 +22,19 @@
         <format>tar.gz</format>
     </formats>
 
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory/>
+
+            <includes>
+                <include>${pom.groupId}:kapua-consumer-telemetry-app</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
     <files>
         <file>
             <source>${project.basedir}/entrypoint/run-consumer-telemetry</source>
-            <fileMode>0755</fileMode>
-        </file>
-        <file>
-            <source>${project.basedir}/../../../consumer/telemetry-app/target/kapua-consumer-telemetry-${project.version}-app.jar</source>
             <fileMode>0755</fileMode>
         </file>
     </files>

--- a/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
+++ b/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
@@ -26,4 +26,4 @@ JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DE
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
 
-exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-telemetry-2.1.0-SNAPSHOT-app.jar
+exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-consumer-telemetry-app-2.1.0-SNAPSHOT-app.jar

--- a/assembly/consumer/telemetry/pom.xml
+++ b/assembly/consumer/telemetry/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-consumer-telemetry-app</artifactId>
+            <classifier>app</classifier>
         </dependency>
     </dependencies>
 
@@ -47,6 +48,31 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Import dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kapua</groupId>
+                                    <artifactId>kapua-consumer-telemetry-app</artifactId>
+                                    <classifier>app</classifier>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile>

--- a/assembly/service/authentication/descriptors/kapua-service-authentication.xml
+++ b/assembly/service/authentication/descriptors/kapua-service-authentication.xml
@@ -22,13 +22,19 @@
         <format>tar.gz</format>
     </formats>
 
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory/>
+
+            <includes>
+                <include>${pom.groupId}:kapua-service-authentication-app</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
     <files>
         <file>
             <source>${project.basedir}/entrypoint/run-service-authentication</source>
-            <fileMode>0755</fileMode>
-        </file>
-        <file>
-            <source>${project.basedir}/../../../service/authentication-app/target/kapua-service-authentication-${project.version}-app.jar</source>
             <fileMode>0755</fileMode>
         </file>
     </files>

--- a/assembly/service/authentication/entrypoint/run-service-authentication
+++ b/assembly/service/authentication/entrypoint/run-service-authentication
@@ -24,4 +24,4 @@ JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbcConnectionUrlResolver=${DB_RESOLVER:-DE
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.jdbc.driver=${DB_DRIVER:-org.h2.Driver}"
 JAVA_OPTS="${JAVA_OPTS} -Dcommons.db.connection.additionalOptions=${DB_CONNECTION_ADDITIONAL_OPTIONS}"
 
-exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-service-authentication-2.1.0-SNAPSHOT-app.jar
+exec java ${JAVA_OPTS} ${DEBUG_OPTS} ${JMX_OPTS} -jar kapua-service-authentication-app-2.1.0-SNAPSHOT-app.jar

--- a/assembly/service/authentication/pom.xml
+++ b/assembly/service/authentication/pom.xml
@@ -30,6 +30,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-service-authentication-app</artifactId>
+            <classifier>app</classifier>
         </dependency>
     </dependencies>
 
@@ -46,6 +47,31 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Import dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kapua</groupId>
+                                    <artifactId>kapua-service-authentication-app</artifactId>
+                                    <classifier>app</classifier>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile>

--- a/assembly/service/pom.xml
+++ b/assembly/service/pom.xml
@@ -26,10 +26,6 @@
     <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
-    <properties>
-        <docker.account>kapua</docker.account>
-    </properties>
-
     <modules>
         <module>authentication</module>
     </modules>

--- a/consumer/lifecycle-app/pom.xml
+++ b/consumer/lifecycle-app/pom.xml
@@ -456,9 +456,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
                             <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>app</shadedClassifierName>
+
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
@@ -553,7 +556,6 @@
                                                     </transformer>
                                  -->
                             </transformers>
-                            <outputFile>${project.build.directory}/kapua-consumer-lifecycle-${project.version}-app.jar</outputFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/consumer/telemetry-app/pom.xml
+++ b/consumer/telemetry-app/pom.xml
@@ -411,7 +411,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
                             <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>app</shadedClassifierName>
+
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
@@ -463,8 +468,6 @@
                                     <resource>META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports</resource>
                                 </transformer>
                             </transformers>
-                            <artifactSet/>
-                            <outputFile>${project.build.directory}/kapua-consumer-telemetry-${project.version}-app.jar</outputFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1120,6 +1120,12 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-service-authentication-app</artifactId>
+                <version>${project.version}</version>
+                <classifier>app</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-service-camel</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -638,6 +638,12 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-consumer-lifecycle-app</artifactId>
+                <version>${project.version}</version>
+                <classifier>app</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-consumer-telemetry</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,12 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-consumer-telemetry-app</artifactId>
+                <version>${project.version}</version>
+                <classifier>app</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-client-security</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/service/authentication-app/pom.xml
+++ b/service/authentication-app/pom.xml
@@ -327,7 +327,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
                             <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>app</shadedClassifierName>
+
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
@@ -379,7 +384,6 @@
                                     <resource>META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports</resource>
                                 </transformer>
                             </transformers>
-                            <outputFile>${project.build.directory}/kapua-service-authentication-${project.version}-app.jar</outputFile>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR refactors the packaging of Broker Consumer Lifecycle and Consumer Telemetry to be more Maven-friendly.

**Related Issue**
_None_

**Description of the solution adopted**
- Fixed packaging of `kapua-consumer-lifecycle-app` module to correctly use `classifier`
- Fixed packaging of `kapua-consumer-telemetry-app` module to correctly use `classifier`
- Fixed importing of Broker Consumer uber jars in their respective assemblies.

**Screenshots**
_None_

**Any side note on the changes made**
_None_