### PR TITLE
:arrow_up: [Dependencies] Bump maven-docker-plugin dependency to 0.48.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <checkstyle.version>7.6.1</checkstyle.version>
         <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
-        <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.48.1</docker-maven-plugin.version>
         <eclipse-lifecycle-mapping.version>1.0.0</eclipse-lifecycle-mapping.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <jacoco.version>0.8.8</jacoco.version>


### PR DESCRIPTION
This PR bumps the version of `maven-docker-plugin` to 0.48.1

**Related Issue**
_None_

**Description of the solution adopted**
Bumped maven plugin version to `0.48.1`

**Screenshots**
_None_

**Any side note on the changes made**
_None_