### PR TITLE
:sparkles: [Datastore] Add configurable client pooling for Elasticsearch backend (port)

### DIFF
--- a/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -14,6 +14,7 @@
 #
 # Provider
 datastore.elasticsearch.provider=org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClientProvider
+datastore.elasticsearch.pool.size=1
 datastore.elasticsearch.module=datastore-elasticsearch-client
 
 #

--- a/qa/integration/src/test/resources/kapua-datastore-embedded-server-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-embedded-server-setting.properties
@@ -17,3 +17,4 @@ datastore.elasticsearch.rest.node=127.0.0.1
 datastore.elasticsearch.rest.port=9200
 datastore.elasticsearch.transport.node=127.0.0.1
 datastore.elasticsearch.transport.port=9300
+datastore.elasticsearch.pool.size=1

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientConfiguration.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientConfiguration.java
@@ -27,6 +27,7 @@ public class ElasticsearchClientConfiguration {
 
     private String moduleName;
     private String providerClassName;
+    private int poolSize;
     private String clusterName;
     private List<ElasticsearchNode> nodes;
     private String username;
@@ -74,6 +75,26 @@ public class ElasticsearchClientConfiguration {
      */
     public ElasticsearchClientConfiguration setProviderClassName(String providerClassName) {
         this.providerClassName = providerClassName;
+        return this;
+    }
+
+    /** Gets the size of the client pool.
+    *
+    * @return the size of the provider pool.
+    * @since 1.6.0
+    */
+    public int getPoolSize() {
+        return this.poolSize;
+    }
+
+    /** Sets the size of the client pool.
+     *
+     * @param poolSize The size of the client pool
+     * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
+     * @since 1.6.0
+     */
+    public ElasticsearchClientConfiguration setPoolSize(int poolSize) {
+        this.poolSize = poolSize;
         return this;
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreClientFactory.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreClientFactory.java
@@ -23,6 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Manages the {@link ElasticsearchClientProvider} as a singleton for the message store.
@@ -33,7 +36,12 @@ public class DatastoreClientFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatastoreClientFactory.class);
 
-    private static ElasticsearchClientProvider<?> elasticsearchClientProviderInstance;
+    private static List<ElasticsearchClientProvider<?>> elasticsearchClientProviderInstances;
+
+    private static volatile boolean initialized;
+    private static volatile boolean closed = true;
+
+    private static AtomicInteger nextProviderIndex = new AtomicInteger(0);
 
     private DatastoreClientFactory() {
     }
@@ -46,32 +54,53 @@ public class DatastoreClientFactory {
      * @return An Elasticsearch client.
      */
     public static ElasticsearchClientProvider<?> getInstance() {
-        if (elasticsearchClientProviderInstance == null) {
+        if (!closed) {
+            LOG.warn("Datastore client factory: closing the pool failed at a previous stage, trying to close before init.");
+            close();
+        }
+        if (!initialized || !closed) {
             synchronized (DatastoreClientFactory.class) {
-                if (elasticsearchClientProviderInstance == null) {
-
+                if (!closed) {
+                    throw new DatastoreInternalError(null, "EDatastore client factory: closing the pool failed at a previous stage, can't init");
+                }
+                if (!initialized) {
                     ElasticsearchClientProvider<?> elasticsearchClientProvider;
                     try {
+                        initialized = false;
                         ElasticsearchClientConfiguration esClientConfiguration = DatastoreElasticsearchClientConfiguration.getInstance();
-
+                        int poolSize = esClientConfiguration.getPoolSize();
+                        if (poolSize >= 1) {
+                            LOG.info("Datastore client factory: configured pool of size {}", poolSize);
+                        } else {
+                            LOG.warn("Datastore client factory: configured pool of size {} is invalid, set to default 1", poolSize);
+                            poolSize = 1;
+                        }
                         Class<ElasticsearchClientProvider<?>> providerClass = (Class<ElasticsearchClientProvider<?>>) Class.forName(esClientConfiguration.getProviderClassName());
                         Constructor<?> constructor = providerClass.getConstructor();
-                        elasticsearchClientProvider = (ElasticsearchClientProvider<?>) constructor.newInstance();
+                        elasticsearchClientProviderInstances = new ArrayList<>(poolSize);
+                        for (int i=0; i < poolSize; i++) {
+                            elasticsearchClientProvider = (ElasticsearchClientProvider<?>) constructor.newInstance();
+                            elasticsearchClientProvider
+                                    .withClientConfiguration(esClientConfiguration)
+                                    .withModelContext(new ModelContextImpl())
+                                    .withModelConverter(new QueryConverterImpl())
+                                    .init();
 
-                        elasticsearchClientProvider
-                                .withClientConfiguration(esClientConfiguration)
-                                .withModelContext(new ModelContextImpl())
-                                .withModelConverter(new QueryConverterImpl())
-                                .init();
+                            elasticsearchClientProviderInstances.add(elasticsearchClientProvider);
+                        }
+                        initialized = true;
                     } catch (Exception e) {
-                        throw new DatastoreInternalError(e, "Cannot instantiate Elasticsearch Client");
+                        // Try close immediately. Use closePool to avoid synchronize again
+                        closePool();
+                        throw new DatastoreInternalError(e, "Datastore client factory: cannot instantiate Elasticsearch Client Pool");
                     }
-
-                    elasticsearchClientProviderInstance = elasticsearchClientProvider;
                 }
             }
         }
-
+        // Calculate the index of the client to return from the pool in a round robin fashion to evenly distribute requests. 
+        int providerIndex = Math.abs(nextProviderIndex.getAndAdd(1) % elasticsearchClientProviderInstances.size());
+        LOG.debug("Datastore client factory: assign request to client of index {} in a pool of {} (initialized {}, closed {})", providerIndex, elasticsearchClientProviderInstances.size(), initialized, closed);
+        ElasticsearchClientProvider<?> elasticsearchClientProviderInstance = elasticsearchClientProviderInstances.get(providerIndex);
         return elasticsearchClientProviderInstance;
     }
 
@@ -92,19 +121,33 @@ public class DatastoreClientFactory {
      * @since 1.0.0
      */
     public static void close() {
-        if (elasticsearchClientProviderInstance != null) {
+        if (elasticsearchClientProviderInstances != null) {
             synchronized (DatastoreClientFactory.class) {
-                if (elasticsearchClientProviderInstance != null) {
-                    try {
-                        elasticsearchClientProviderInstance.close();
-                    } catch (Exception e) {
-                        LOG.error("Unable to close ElasticsearchClientProvider instance.", e);
-                    } finally {
-                        elasticsearchClientProviderInstance = null;
-                    }
-                }
+                closePool();
             }
         }
     }
 
+    private static void closePool() {
+        if (elasticsearchClientProviderInstances != null) {
+            try {
+                initialized = false;
+                closed = false;
+                int size = elasticsearchClientProviderInstances.size();
+                for (int i=0; i < size; i++) {
+                    if (elasticsearchClientProviderInstances.get(i) != null) {
+                        elasticsearchClientProviderInstances.get(i).close();
+                        elasticsearchClientProviderInstances.set(i, null);
+                    }
+                }
+                elasticsearchClientProviderInstances.clear();
+                elasticsearchClientProviderInstances = null;
+                closed = true;
+            } catch (Exception e) {
+                LOG.error("Datastore client factory: unable to close all clients.", e);
+            }
+        } else {
+            closed = true;
+        }
+    }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
@@ -28,6 +28,7 @@ public class DatastoreElasticsearchClientConfiguration extends ElasticsearchClie
 
     public DatastoreElasticsearchClientConfiguration() {
         setProviderClassName(ELASTICSEARCH_CLIENT_SETTINGS.getString(DatastoreElasticsearchClientSettingsKey.PROVIDER));
+        setPoolSize(ELASTICSEARCH_CLIENT_SETTINGS.getInt(DatastoreElasticsearchClientSettingsKey.POOL_SIZE));
         setModuleName(ELASTICSEARCH_CLIENT_SETTINGS.getString(DatastoreElasticsearchClientSettingsKey.MODULE));
 
         setClusterName(ELASTICSEARCH_CLIENT_SETTINGS.getString(DatastoreElasticsearchClientSettingsKey.CLUSTER));

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
@@ -28,6 +28,12 @@ public enum DatastoreElasticsearchClientSettingsKey implements SettingKey {
      */
     PROVIDER("datastore.elasticsearch.provider"),
     /**
+     * Number of clients in the pool.
+     *
+     * @since 1.6.0
+    */
+    POOL_SIZE("datastore.elasticsearch.pool.size"),
+    /**
      * The name of the module which is managing the {@link org.eclipse.kapua.service.elasticsearch.client.ElasticsearchClient}.
      *
      * @since 1.3.0

--- a/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -15,6 +15,10 @@
 # Provider
 #datastore.elasticsearch.provider=org.eclipse.kapua.service.elasticsearch.client.transport.TransportElasticsearchClientProvider
 datastore.elasticsearch.provider=org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClientProvider
+# Number of Elasticsearch clients to allocate to the datastore, minimum is one. The size depends upon the 
+# workload and the computational resources available, usually a value in the range 1-4 works well. Use only 
+# with RestElasticsearchClientProvider, set value to 1 for TransportElasticsearchClientProvider.
+datastore.elasticsearch.pool.size=1
 datastore.elasticsearch.module=datastore-elasticsearch-client
 
 #

--- a/service/datastore/test/src/test/resources/kapua-datastore-embedded-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-embedded-client-setting.properties
@@ -19,3 +19,4 @@ datastore.elasticsearch.transport.node=127.0.0.1
 datastore.elasticsearch.transport.port=9300
 datastore.elasticsearch.rest.node=127.0.0.1
 datastore.elasticsearch.rest.port=9200
+datastore.elasticsearch.pool.size=1

--- a/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
@@ -16,8 +16,8 @@
 # Provider
 #datastore.elasticsearch.provider=org.eclipse.kapua.service.elasticsearch.client.transport.TransportElasticsearchClientProvider
 datastore.elasticsearch.provider=org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClientProvider
+datastore.elasticsearch.pool.size=1
 datastore.elasticsearch.module=datastore-elasticsearch-client
-
 #
 # Connection
 datastore.elasticsearch.cluster=kapua-datastore

--- a/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
@@ -16,6 +16,7 @@
 # Provider
 datastore.elasticsearch.provider=org.eclipse.kapua.service.elasticsearch.client.transport.TransportElasticsearchClientProvider
 #datastore.elasticsearch.provider=org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClientProvider
+datastore.elasticsearch.pool.size=1
 datastore.elasticsearch.module=datastore-elasticsearch-client
 
 #


### PR DESCRIPTION
Brief description of the PR.
With current implementation the Datastore has one single Elasticsearch client to serve al the requests. With high loads this can become a bottleneck. 

**Related Issue**
None

**Description of the solution adopted**
Create a client pool with a configurable size (min 1) to allow more requests to be executed in the same time.

**Screenshots**
None

**Any side note on the changes made**
None