### PR TITLE
:sparkles: [Datastore] Add configurable client pooling for Elasticsearch backend

### DIFF
--- a/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -40,4 +40,5 @@ datastore.elasticsearch.ssl.keystore.password=
 datastore.elasticsearch.ssl.keystore.type=jks
 datastore.elasticsearch.ssl.truststore.path=
 datastore.elasticsearch.ssl.truststore.password=
-
+#
+datastore.elasticsearch.pool.size=1

--- a/qa/integration/src/test/resources/kapua-datastore-embedded-server-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-embedded-server-setting.properties
@@ -17,3 +17,4 @@ datastore.elasticsearch.rest.node=127.0.0.1
 datastore.elasticsearch.rest.port=9200
 datastore.elasticsearch.transport.node=127.0.0.1
 datastore.elasticsearch.transport.port=9300
+datastore.elasticsearch.pool.size=1

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientConfiguration.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/configuration/ElasticsearchClientConfiguration.java
@@ -26,12 +26,12 @@ import org.eclipse.kapua.service.elasticsearch.client.ElasticsearchClientWrapper
 public class ElasticsearchClientConfiguration {
 
     private String moduleName;
-    private String providerClassName;
     private String clusterName;
     private List<ElasticsearchNode> nodes;
     private String username;
     private String password;
     private Optional<Integer> numberOfIOThreads;
+    private int poolSize;
 
     private ElasticsearchClientReconnectConfiguration reconnectConfiguration;
     private ElasticsearchClientRequestConfiguration requestConfiguration;
@@ -266,6 +266,29 @@ public class ElasticsearchClientConfiguration {
     public ElasticsearchClientConfiguration setNumberOfIOThreads(Integer numberOfIOThreads) {
         this.numberOfIOThreads = Optional.ofNullable(numberOfIOThreads)
                 .filter(i -> i > 0);
+        return this;
+    }
+
+    /**
+     * Gets the size of the Elasticsearch client pool.
+     *
+     * @return The size of the Elasticsearch client pool.
+     * @since 1.6.0
+     */
+    public int getPoolSize() {
+        return poolSize;
+    }
+
+    /**
+     * Sets the size of the Elasticsearch client pool.
+     *
+     * @param poolSize 
+     *         The size of the Elasticsearch client pool.
+     * @return This {@link ElasticsearchClientConfiguration} to chain method invocation.
+     * @since 1.6.0
+     */
+    public ElasticsearchClientConfiguration setPoolSize(int poolSize) {
+        this.poolSize = poolSize;
         return this;
     }
 }

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
@@ -61,9 +61,10 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
@@ -79,13 +80,15 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
 
     private static final String PROVIDER_CANNOT_CLOSE_CLIENT_MSG = "Cannot close ElasticSearch REST client. Client is already closed or not initialized";
 
-    private RestElasticsearchClientWrapper restElasticsearchClientWrapper;
+    private List<RestElasticsearchClientWrapper> restElasticsearchClientWrappers;
 
     private ElasticsearchClientConfiguration elasticsearchClientConfiguration;
     private ModelContext modelContext;
     private QueryConverter modelConverter;
     private MetricsEsClient metrics;
     private volatile boolean initialized;
+    private volatile boolean closed = true;
+    private AtomicInteger nextClientIndex = new AtomicInteger(0);
 
     @Inject
     public RestElasticsearchClientProvider(MetricsEsClient metricsEsClient) {
@@ -94,10 +97,17 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
 
     @Override
     public RestElasticsearchClientProvider init() throws ClientProviderInitException {
-        if (initialized) {
+        if (!closed) {
+            LOG.warn("Elasticsearch rest client provider: closing the pool failed at a previous stage, trying to close before init.");
+            close();
+        }
+        if (initialized && closed) {
             return this;
         }
         synchronized (RestElasticsearchClientProvider.class) {
+            if (!closed) {
+                throw new ClientProviderInitException("Client pool not closed");
+            }
             if (initialized) { //this check is needed, in addition to the same above, to avoid multiple initializations with multi-threading
                 return this;
             }
@@ -163,8 +173,20 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
 
             // Init Kapua Elasticsearch Client
             try {
-                initClient();
+                int poolSize = elasticsearchClientConfiguration.getPoolSize();
+                if (poolSize >= 1) {
+                    LOG.info("Elasticsearch rest client provider: configured pool of size {}", poolSize);
+                } else {
+                    LOG.warn("Elasticsearch rest client provider: configured pool of size {} is invalid, set to default 1", poolSize);
+                    poolSize = 1;
+                }
+                initClientPool(poolSize);
             } catch (Exception e) {
+                try {
+                    closeClientPool();
+                } catch (IOException ioExc) {
+                    LOG.warn(PROVIDER_CANNOT_CLOSE_CLIENT_MSG, ioExc);
+                }
                 throw new ClientProviderInitException(e, "Cannot init ElasticsearchClientWrapper");
             }
 
@@ -177,7 +199,6 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
 //                    LOG.info(">>> Initializing Elasticsearch REST client... Connecting... Error: {}", e.getMessage(), e);
 //                }
 //            }, getClientReconnectConfiguration().getReconnectDelay(), getClientReconnectConfiguration().getReconnectDelay(), TimeUnit.MILLISECONDS);
-            initialized = true;
             return this;
         }
     }
@@ -193,7 +214,8 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
     public void close() {
         synchronized (RestElasticsearchClientProvider.class) {
             try {
-                closeClient();
+                LOG.info("Elasticsearch rest client provider: closing pool");
+                closeClientPool();
             } catch (IOException e) {
                 LOG.warn(PROVIDER_CANNOT_CLOSE_CLIENT_MSG, e);
             }
@@ -201,14 +223,14 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
     }
 
     /**
-     * Closes the {@link RestClient}.
+     * Closes the {@link RestClient} pool.
      * <p>
      *
      * @throws IOException
      *         see {@link RestClient#close()} javadoc.
-     * @since 1.0.0
+     * @since 2.0.0
      */
-    private void closeClient() throws IOException {
+    private void closeClientPool() throws IOException {
 //        if (reconnectExecutorTask != null) {
 //            reconnectExecutorTask.shutdown();
 //
@@ -222,14 +244,21 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
 //
 //            reconnectExecutorTask = null;
 //        }
-
-        if (restElasticsearchClientWrapper != null) {
-            try {
-                restElasticsearchClientWrapper.close();
-            } finally {
-                restElasticsearchClientWrapper = null;
+        initialized = false;
+        if (restElasticsearchClientWrappers == null) {
+            closed = true;
+            return;
+        }
+        closed = false;
+        for (int i=0; i < restElasticsearchClientWrappers.size(); i++) {
+            if (restElasticsearchClientWrappers.get(i) != null) {
+                restElasticsearchClientWrappers.get(i).close();
+                restElasticsearchClientWrappers.set(i, null);
             }
         }
+        restElasticsearchClientWrappers.clear();
+        restElasticsearchClientWrappers = null;
+        closed = true;
     }
 
     /**
@@ -257,14 +286,26 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
 //    }
 
     /**
-     * Initializes the {@link RestClient} as per {@link ElasticsearchClientConfiguration}.
+     * Initializes the {@link RestClient} pool as per {@link ElasticsearchClientConfiguration}.
      *
-     * @return The initialized {@link RestClient}.
+     * @return The initialized {@link RestClient} pool.
      * @throws ClientInitializationException
      *         if any {@link Exception} occurs while {@link RestClient} initialization.
-     * @since 1.0.0
+     * @since 2.0.0
      */
-    private RestClient initClient() throws ClientInitializationException {
+    private void initClientPool(int poolSize) throws ClientInitializationException {
+        initialized = false;
+        restElasticsearchClientWrappers = new ArrayList<>(poolSize);
+        RestElasticsearchClientWrapper clientPoolItem;
+        for(int i=0; i < poolSize; i++) {
+            clientPoolItem = createClientWrapper();
+            clientPoolItem.init();
+            restElasticsearchClientWrappers.add(clientPoolItem);
+        }
+        initialized = true;
+    }
+
+    private RestElasticsearchClientWrapper createClientWrapper() throws ClientInitializationException {
 
         ElasticsearchClientConfiguration clientConfiguration = getClientConfiguration();
 
@@ -313,7 +354,6 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
             throw new ClientInitializationException(e, "Error while parsing node addresses!");
         }
 
-        // Init internal Elasticsearch client
         RestClientBuilder restClientBuilder = RestClient.builder(hosts.toArray(new HttpHost[0]));
         SSLContext sslContext = null;
         if (sslEnabled) {
@@ -347,18 +387,18 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
                     clientConfiguration.getRequestConfiguration().getSocketTimeoutMillis().ifPresent(timout -> requestConfigBuilder.setSocketTimeout(timout));
                     return requestConfigBuilder;
                 });
-        org.elasticsearch.client.RestClient esRestClientWrapped = restClientBuilder.build();
 
-        // Init Kapua Elasticsearch Client
-        restElasticsearchClientWrapper = new RestElasticsearchClientWrapper(metrics);
-        restElasticsearchClientWrapper
-                .withClientConfiguration(clientConfiguration)
-                .withModelContext(modelContext)
-                .withModelConverter(modelConverter)
-                .withClient(esRestClientWrapped)
-                .init();
+        org.elasticsearch.client.RestClient esRestClientWrapped;
+        esRestClientWrapped = restClientBuilder.build();
 
-        return esRestClientWrapped;
+        // Create Client Wrapper
+        RestElasticsearchClientWrapper wrapper = new RestElasticsearchClientWrapper(metrics);
+        wrapper.withClientConfiguration(clientConfiguration)
+        .withModelContext(modelContext)
+        .withModelConverter(modelConverter)
+        .withClient(esRestClientWrapped);
+
+        return wrapper;
     }
 
     private HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder, SSLContext sslContext, CredentialsProvider credentialsProvider) {
@@ -405,11 +445,11 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
     @Override
     public RestElasticsearchClientWrapper getElasticsearchClient() throws ClientUnavailableException, ClientProviderInitException {
         this.init();
-        if (restElasticsearchClientWrapper == null) {
-            throw new ClientUnavailableException("Client not initialized");
-        }
-
-        return restElasticsearchClientWrapper;
+        // To evenly distribute requests among clients, calculate the index to return in a round robin style.
+        int clientIndex = Math.abs(nextClientIndex.getAndAdd(1) % restElasticsearchClientWrappers.size());
+        LOG.info("Elasticsearch client provider pool get ES client: assign index {} in a pool of {}", clientIndex, restElasticsearchClientWrappers.size());
+        RestElasticsearchClientWrapper clientWrapper = restElasticsearchClientWrappers.get(clientIndex);
+        return clientWrapper;
     }
     // Private methods
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreElasticsearchClientConfiguration.java
@@ -56,6 +56,8 @@ public class DatastoreElasticsearchClientConfiguration extends ElasticsearchClie
 
         setNumberOfIOThreads(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.NUMBER_OF_IO_THREADS, 0));
         getReconnectConfiguration().setReconnectDelay(30000);
+
+        setPoolSize(elasticsearchClientSettings.getInt(DatastoreElasticsearchClientSettingsKey.POOL_SIZE));
     }
 
     public static ElasticsearchClientConfiguration getInstance() {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreElasticsearchClientSettingsKey.java
@@ -136,7 +136,13 @@ public enum DatastoreElasticsearchClientSettingsKey implements SettingKey {
      *
      * @since 2.1.0
      */
-    REQUEST_SOCKET_TIMEOUT_MILLIS("datastore.elasticsearch.request.socket.timeout.millis");
+    REQUEST_SOCKET_TIMEOUT_MILLIS("datastore.elasticsearch.request.socket.timeout.millis"),
+    /**
+     * Elasticsearch client pool size.
+     *
+     * @since 1.6.0
+    */
+    POOL_SIZE("datastore.elasticsearch.pool.size");
 
     /**
      * The key value in the configuration resources.

--- a/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-elasticsearch-client-settings.properties
@@ -40,4 +40,9 @@ datastore.elasticsearch.ssl.keystore.password=
 datastore.elasticsearch.ssl.keystore.type=jks
 datastore.elasticsearch.ssl.truststore.path=
 datastore.elasticsearch.ssl.truststore.password=
-
+#
+# Client pool
+# Number of Elasticsearch clients to allocate to the datastore, minimum is one. The size depends upon the 
+# workload and the computational resources available, first try with values in the range 1-4 and evaluate
+# improvements before increasing further.
+datastore.elasticsearch.pool.size=1

--- a/service/datastore/test/src/test/resources/kapua-datastore-embedded-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-embedded-client-setting.properties
@@ -19,3 +19,4 @@ datastore.elasticsearch.transport.node=127.0.0.1
 datastore.elasticsearch.transport.port=9300
 datastore.elasticsearch.rest.node=127.0.0.1
 datastore.elasticsearch.rest.port=9200
+datastore.elasticsearch.pool.size=1

--- a/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
@@ -41,4 +41,5 @@ datastore.elasticsearch.ssl.keystore.password=
 datastore.elasticsearch.ssl.keystore.type=jks
 datastore.elasticsearch.ssl.truststore.path=
 datastore.elasticsearch.ssl.truststore.password=
-
+#
+datastore.elasticsearch.pool.size=1

--- a/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
@@ -23,11 +23,11 @@ datastore.elasticsearch.password=
 datastore.elasticsearch.client.reconnection_wait_between_exec=15000
 # <=0 ==> use the default
 datastore.elasticsearch.numberOfIOThreads=-1
+datastore.elasticsearch.pool.size=1
 #
 # Requests
 datastore.elasticsearch.request.query.timeout=15000
 datastore.elasticsearch.request.scroll.timeout=60000
-datastore.elasticsearch.request.retry.max=3
 datastore.elasticsearch.request.retry.wait=2500
 # <0 ==> use the default
 datastore.elasticsearch.request.connection.timeout.millis=-1
@@ -42,3 +42,6 @@ datastore.elasticsearch.ssl.keystore.type=jks
 datastore.elasticsearch.ssl.truststore.path=
 datastore.elasticsearch.ssl.truststore.password=
 
+
+datastore.elasticsearch.request.retry.max=3
+datastore.elasticsearch.pool.size=1


### PR DESCRIPTION
Brief description of the PR.
With current implementation the Datastore has one single Elasticsearch client to serve al the requests. With high loads this can become a bottleneck.

Related Issue
None

Description of the solution adopted
Create a client pool with a configurable size (min 1) to allow more requests to be executed in the same time.

Screenshots
None

Any side note on the changes made
None
