### PR TITLE
:bug: [Project] Aligned kapua-assembly-java-base-17 maven config to java-base

### DIFF
--- a/assembly/java-base-17/pom.xml
+++ b/assembly/java-base-17/pom.xml
@@ -22,13 +22,26 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-assembly-java-base-17</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
 
     <properties>
         <docker.base.image>rockylinux:9-minimal</docker.base.image>
         <jolokia.agent.url>https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.3.4/jolokia-jvm-1.3.4-agent.jar</jolokia.agent.url>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <excludeArtifacts>${project.artifactId}</excludeArtifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>


### PR DESCRIPTION
Added few missing configurations to `kapua-assembly-java-base-17` module. These configuration were added while the module was under development and they haven been added in the development branch

**Related Issue**
_None_

**Description of the solution adopted**
Added following missing maven module configurations
- `central-publishing-maven-plugin` exclusion from published artifacts
- explicit `project.artifact.name` to be used by `central-publishing-maven-plugin`

**Screenshots**
_None_

**Any side note on the changes made**
_None_