### PR TITLE
:bug: [Authorization] Added missing database foreign key to prevent Group deletion if associated with entities

### DIFF
--- a/extras/foreignkeys/src/main/resources/liquibase/2.0.0/changelog-foreignkeys-2.0.0.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/2.0.0/changelog-foreignkeys-2.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -14,11 +14,11 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-2.0.0.xml">
 
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-foreignkeys-0.3.0.xml"/>
-    <include relativeToChangelogFile="true" file="./1.2.0/changelog-foreignkeys-1.2.0.xml"/>
-    <include relativeToChangelogFile="true" file="./1.3.0/changelog-foreignkeys-1.3.0.xml"/>
-    <include relativeToChangelogFile="true" file="./2.0.0/changelog-foreignkeys-2.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./device_group-foreignkey_delete.xml"/>
+    <include relativeToChangelogFile="true" file="./user_group-foreignkey_delete.xml"/>
+
 
 </databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/2.0.0/device_group-foreignkey_delete.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/2.0.0/device_group-foreignkey_delete.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-device_group-foreignkey-2.0.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="dvc_device_group"/>
+                <tableExists tableName="athz_group"/>
+            </and>
+        </preConditions>
+
+        <addForeignKeyConstraint constraintName="fk_dvc_device_group_group_id"
+                                 baseTableName="dvc_device_group"
+                                 baseColumnNames="group_id"
+                                 referencedTableName="athz_group"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/2.0.0/user_group-foreignkey_delete.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/2.0.0/user_group-foreignkey_delete.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-user_group-foreignkey-2.0.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="usr_user_group"/>
+                <tableExists tableName="athz_group"/>
+            </and>
+        </preConditions>
+
+        <addForeignKeyConstraint constraintName="fk_dvc_user_group_group_id"
+                                 baseTableName="usr_user_group"
+                                 baseColumnNames="group_id"
+                                 referencedTableName="athz_group"
+                                 referencedColumnNames="id"
+                                 onDelete="RESTRICT"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This PR add the missing Database Foreign Keys between `athz_group` -> `dvc_device_group` and `athz_group` -> `usr_user_group` to prevent deletion of an Access Group if it is still associated with an entity.

**Related Issue**
_None_

**Description of the solution adopted**
Added DB FKs into `kapua-foreignkeys` module

**Screenshots**
_None_

**Any side note on the changes made**
DB cleanup will be required on upgrade to this version