### PR TITLE
:bug: [Datastore] Fix log level of debug message should not be info

### DIFF
--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
@@ -447,7 +447,7 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
         this.init();
         // To evenly distribute requests among clients, calculate the index to return in a round robin style.
         int clientIndex = Math.abs(nextClientIndex.getAndAdd(1) % restElasticsearchClientWrappers.size());
-        LOG.info("Elasticsearch client provider pool get ES client: assign index {} in a pool of {}", clientIndex, restElasticsearchClientWrappers.size());
+        LOG.debug("Elasticsearch client provider pool get ES client: assign index {} in a pool of {}", clientIndex, restElasticsearchClientWrappers.size());
         RestElasticsearchClientWrapper clientWrapper = restElasticsearchClientWrappers.get(clientIndex);
         return clientWrapper;
     }


### PR DESCRIPTION
Brief description of the PR.
A message was mistakenly logged with info level instead of debug level
 
**Related Issue**
None

**Description of the solution adopted**
Changed the log level from info to debug

**Screenshots**
None

**Any side note on the changes made**
None
