### PR TITLE
:bug: [Datastore] fix update of Elasticsearch field mappings triggered at every message store

### DIFF
--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageElasticsearchRepository.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageElasticsearchRepository.java
@@ -105,17 +105,17 @@ public class MessageElasticsearchRepository extends DatastoreElasticSearchReposi
 
         final String indexName = indexResolver(messageToStore.getScopeId(), messageTime);
 
-        if (!metricsByIndex.containsKey(indexName)) {
-            synchronized (DatastoreMessage.class) {
+        synchronized (DatastoreMessage.class) {
+            if (!metricsByIndex.containsKey(indexName)) {
                 doUpsertIndex(indexName);
                 doUpsertMappings(indexName, metrics);
                 metricsByIndex.put(indexName, metrics);
-            }
-        } else {
-            final Map<String, Metric> newMetrics = getMessageMappingDiffs(metricsByIndex.get(indexName), metrics);
-            synchronized (DatastoreMessage.class) {
-                doUpsertMappings(indexName, metrics);
-                metricsByIndex.get(indexName).putAll(newMetrics);
+            } else {
+                final Map<String, Metric> newMetrics = getMessageMappingDiffs(metricsByIndex.get(indexName), metrics);
+                if (newMetrics != null && !newMetrics.isEmpty()) {
+                    doUpsertMappings(indexName, metrics);
+                    metricsByIndex.get(indexName).putAll(newMetrics);
+                }
             }
         }
         final InsertRequest insertRequest = new InsertRequest(idExtractor(messageToStore).toString(), indexName, messageToStore);


### PR DESCRIPTION
Brief description of the PR.
At each new message stored, a full update of the field mappings matching the message metrics is executed regardless the fact the fields are already mapped by previous messages. When there are no new metrics in the message there is no need to update the mappings.
 
**Related Issue**
None

**Description of the solution adopted**
The mappings are update either full when the index is not yet mapped in cache or by delta when new metrics (in addition to the ones already mapped) are detected as part of the message processing. Since usually the schema of messages is pretty stable in time this should save lots of updates and accesses to Eleasticsearch. 

**Screenshots**
None

**Any side note on the changes made**
None
