### PR TITLE
:arrow_up: [Dependencies]  Upgraded assertj to 3.27.7 - CVE-2026-24400

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <activemq-openwire-legacy.version>5.19.4</activemq-openwire-legacy.version> <!-- CVE-2025-27533 free -->
         <activemq-client.version>5.19.4</activemq-client.version> <!-- CVE-2025-27533 free -->
         <artemis.version>2.53.0</artemis.version>
-        <assertj.version>3.2.0</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <checker-framework.version>3.15.0</checker-framework.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-cli.version>1.4</commons-cli.version>


### PR DESCRIPTION
Upgraded org.assertj dependencies to 3.27.7 to solve following CVEs:

org.assertj:assertj-core: CVE-2026-24400