### PR TITLE
⬆️ [Dependencies] Upgraded io.netty dependencies to 4.1.136.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <liquibase.version>3.6.3</liquibase.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.135.Final</netty.version>
+        <netty.version>4.1.136.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <ow2-asm.version>9.4</ow2-asm.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>


### PR DESCRIPTION
Upgraded io.netty dependencies to 4.1.136.Final to solve follwing CVEs:

io.netty:netty-codec: CVE-2026-59901

io.netty:netty-handler-ssl-ocsp: CVE-2026-56820

io.netty:netty-codec-http2: CVE-2026-59900

io.nett:netty-handler-ssl-ocsp: CVE-2026-56822

io.netty:netty-codec-http: CVE-2026-59899

io.netty:netty-codec-http: CVE-2026-56746

io.netty:netty-handler-ssl-ocsp: CVE-2026-56821

io.netty:netty-codec-http: CVE-2026-59898

io.netty:netty-codec-stomp: CVE-2026-59920

io.netty:netty-codec-http: CVE-2026-59921

io.netty:netty-codec-haproxy: CVE-2026-59919