### PR TITLE
:arrow_up: [Dependencies] Upgraded jackson to 2.18.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <httpcomponents-asyncclient.version>4.1.5</httpcomponents-asyncclient.version>
         <httpcomponents-client.version>4.5.13</httpcomponents-client.version>
         <httpcomponents-core.version>4.4.15</httpcomponents-core.version>
-        <jackson.version>2.15.2</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <javassist.version>3.26.0-GA</javassist.version>
         <javax-annotation-api.version>1.2</javax-annotation-api.version>
         <javax-batch-api.version>1.0.1</javax-batch-api.version>


### PR DESCRIPTION
Upgraded com.fasterxml.jackson.core dependencies to 2.18.9 (or higher) to solve follwing CVEs:

com.fasterxml.jackson.core:jackson-core: No CVE yet. Description: Async parser maxNumberLength bypass via chunked digit accumulation (incomplete fix for GHSA-72hv-8253-57qq) 

com.fasterxml.jackson.core:jackson-databind: CVE-2026-54512

com.fasterxml.jackson.core:jackson-databind: CVE-2026-54512

com.fasterxml.jackson.core:jackson-databind: CVE-2026-59888

com.fasterxml.jackson.core:jackson-databind: CVE-2026-54515

com.fasterxml.jackson.core:jackson-databind: CVE-2026-54514