### PR TITLE
:bug: [Authorization] Added cleanup of leftover usr_user_group and dvc_device_group records

### DIFF
--- a/extras/foreignkeys/src/main/resources/liquibase/2.1.0/changelog-foreignkeys-2.1.0.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/2.1.0/changelog-foreignkeys-2.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-                   logicalFilePath="KapuaDB/changelog-foreignkeys-2.0.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-2.1.0.xml">
 
     <include relativeToChangelogFile="true" file="./device_group-foreignkey_delete.xml"/>
     <include relativeToChangelogFile="true" file="./user_group-foreignkey_delete.xml"/>

--- a/extras/foreignkeys/src/main/resources/liquibase/2.1.0/device_group-foreignkey_delete.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/2.1.0/device_group-foreignkey_delete.xml
@@ -15,18 +15,33 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-2.1.0.xml">
 
-    <changeSet id="changelog-user_group-foreignkey-2.0.0" author="eurotech">
+    <changeSet id="changelog-device_group-foreignkey-2.1.0-cleanup" author="eurotech">
+
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="usr_user_group"/>
+                <tableExists tableName="dvc_device_group"/>
                 <tableExists tableName="athz_group"/>
             </and>
         </preConditions>
 
-        <addForeignKeyConstraint constraintName="fk_dvc_user_group_group_id"
-                                 baseTableName="usr_user_group"
+        <delete tableName="dvc_device_group">
+            <where>group_id NOT IN (SELECT id FROM athz_group)</where>
+        </delete>
+    </changeSet>
+
+
+    <changeSet id="changelog-device_group-foreignkey-2.1.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="dvc_device_group"/>
+                <tableExists tableName="athz_group"/>
+            </and>
+        </preConditions>
+
+        <addForeignKeyConstraint constraintName="fk_dvc_device_group_group_id"
+                                 baseTableName="dvc_device_group"
                                  baseColumnNames="group_id"
                                  referencedTableName="athz_group"
                                  referencedColumnNames="id"

--- a/extras/foreignkeys/src/main/resources/liquibase/2.1.0/user_group-foreignkey_delete.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/2.1.0/user_group-foreignkey_delete.xml
@@ -17,16 +17,30 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
                    logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
 
-    <changeSet id="changelog-device_group-foreignkey-2.0.0" author="eurotech">
+    <changeSet id="changelog-user_group-foreignkey-2.1.0-cleanup" author="eurotech">
+
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="dvc_device_group"/>
+                <tableExists tableName="usr_user_group"/>
                 <tableExists tableName="athz_group"/>
             </and>
         </preConditions>
 
-        <addForeignKeyConstraint constraintName="fk_dvc_device_group_group_id"
-                                 baseTableName="dvc_device_group"
+        <delete tableName="usr_user_group">
+            <where>group_id NOT IN (SELECT id FROM athz_group)</where>
+        </delete>
+    </changeSet>
+
+    <changeSet id="changelog-user_group-foreignkey-2.1.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="usr_user_group"/>
+                <tableExists tableName="athz_group"/>
+            </and>
+        </preConditions>
+
+        <addForeignKeyConstraint constraintName="fk_dvc_user_group_group_id"
+                                 baseTableName="usr_user_group"
                                  baseColumnNames="group_id"
                                  referencedTableName="athz_group"
                                  referencedColumnNames="id"

--- a/extras/foreignkeys/src/main/resources/liquibase/changelog-foreignkeys-master.post.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/changelog-foreignkeys-master.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2026, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-foreignkeys-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-foreignkeys-1.2.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.3.0/changelog-foreignkeys-1.3.0.xml"/>
-    <include relativeToChangelogFile="true" file="./2.0.0/changelog-foreignkeys-2.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./2.1.0/changelog-foreignkeys-2.1.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR links with the work done in https://github.com/eclipse-kapua/kapua/pull/4411 to add automatic cleanup of leftover rows not requiring manual update

**Related Issue**
Fixup for https://github.com/eclipse-kapua/kapua/pull/4411

**Description of the solution adopted**
Added DELETE query for all IDs that do not match in IDs of existing AccessGroups

**Screenshots**
_None_

**Any side note on the changes made**
Fixed changelog versions