### PR TITLE
:memo: [OpenAPI] Fixing validation errors on OpenAPI documentation

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: accessPermissionCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: accessPermissionQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-accessPermissionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions-accessPermissionId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: accessPermissionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessPermissionId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessPermissionId'
       responses:
         200:
           description: The details of the desired AccessPermission
@@ -46,8 +46,8 @@ paths:
       operationId: accessPermissionDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessPermissionId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessPermissionId'
       responses:
         204:
           description: The AccessPermission has been deleted

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: accessPermissionList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
@@ -48,7 +48,7 @@ paths:
       operationId: accessPermissionCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: accessRoleCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: accessRoleQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-accessRoleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles-accessRoleId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: accessRoleGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessRoleId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessRoleId'
       responses:
         200:
           description: The details of the desired AccessRole
@@ -46,8 +46,8 @@ paths:
       operationId: accessRoleDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessRoleId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessRoleId'
       responses:
         204:
           description: The AccessRole has been deleted

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-roles.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: accessRolesList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
@@ -46,7 +46,7 @@ paths:
       operationId: accessRoleCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: accessInfoGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
       responses:
         200:
           description: The details of the desired AccessInfo
@@ -45,7 +45,7 @@ paths:
       operationId: accessInfoDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/accessInfoId'
       responses:
         204:
           description: The AccessInfo has been deleted

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: accessInfoList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accessInfo.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userIdFilter'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo.yaml
@@ -14,35 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    accessInfoId:
-      description: The ID of the AccessInfo on which to perform the operation
-      name: accessInfoId
-      in: path
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    accessPermissionId:
-      name: accessPermissionId
-      in: path
-      description: The ID of the AccessPermission on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    accessRoleId:
-      name: accessRoleId
-      in: path
-      description: The ID of the AccessRole on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    userId:
-      name: userId
-      in: query
-      description: The ID of the User to use as a filter in the query
-      schema:
-        allOf:
-          - $ref: '../openapi.yaml#/components/schemas/kapuaId'
   schemas:
     accessInfo:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/accounts/accounts-accountId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accounts/accounts-accountId.yaml
@@ -23,7 +23,7 @@ paths:
       operationId: deprecatedAccountGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accounts.yaml#/components/parameters/accountId'
+        - $ref: '../openapi.yaml#/components/parameters/accountId'
       responses:
         200:
           description: The details of the desired Account
@@ -51,7 +51,7 @@ paths:
       operationId: deprecatedAccountUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accounts.yaml#/components/parameters/accountId'
+        - $ref: '../openapi.yaml#/components/parameters/accountId'
       requestBody:
         description: An object containing the new properties for the Account to update
         required: true
@@ -86,7 +86,7 @@ paths:
       operationId: deprecatedAccountDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './accounts.yaml#/components/parameters/accountId'
+        - $ref: '../openapi.yaml#/components/parameters/accountId'
       responses:
         204:
           description: The Account has been deleted
@@ -108,7 +108,7 @@ paths:
       summary: Get a single Account
       operationId: accountGet
       parameters:
-        - $ref: './accounts.yaml#/components/parameters/accountId'
+        - $ref: '../openapi.yaml#/components/parameters/accountId'
       responses:
         200:
           description: The details of the desired Account
@@ -132,7 +132,7 @@ paths:
       summary: Update a single Account
       operationId: accountUpdate
       parameters:
-        - $ref: './accounts.yaml#/components/parameters/accountId'
+        - $ref: '../openapi.yaml#/components/parameters/accountId'
       requestBody:
         description: An object containing the new properties for the Account to update
         required: true
@@ -171,7 +171,7 @@ paths:
       summary: Delete a single Account
       operationId: accountDelete
       parameters:
-        - $ref: './accounts.yaml#/components/parameters/accountId'
+        - $ref: '../openapi.yaml#/components/parameters/accountId'
       responses:
         204:
           description: The Account has been deleted

--- a/rest-api/resources/src/main/resources/openapi/accounts/accounts.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accounts/accounts.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    accountId:
-      name: accountId
-      in: path
-      description: The ID of the Account on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     account:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId-unlock.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId-unlock.yaml
@@ -21,7 +21,7 @@ paths:
       operationId: credentialUnlockDeprecated
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './credential.yaml#/components/parameters/credentialId'
+        - $ref: '../openapi.yaml#/components/parameters/credentialId'
       responses:
         204:
           description: The Credential has been unlocked
@@ -48,7 +48,7 @@ paths:
       operationId: credentialUnlock
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './credential.yaml#/components/parameters/credentialId'
+        - $ref: '../openapi.yaml#/components/parameters/credentialId'
       responses:
         204:
           description: The Credential has been unlocked

--- a/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential-scopeId-credentialId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: credentialGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './credential.yaml#/components/parameters/credentialId'
+        - $ref: '../openapi.yaml#/components/parameters/credentialId'
       responses:
         200:
           description: The details of the desired Credential
@@ -80,7 +80,7 @@ paths:
       operationId: credentialUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './credential.yaml#/components/parameters/credentialId'
+        - $ref: '../openapi.yaml#/components/parameters/credentialId'
       requestBody:
         description: An object containing the new properties for the Credential to update
         content:
@@ -128,7 +128,7 @@ paths:
       operationId: credentialDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './credential.yaml#/components/parameters/credentialId'
+        - $ref: '../openapi.yaml#/components/parameters/credentialId'
       responses:
         204:
           description: The Credential has been deleted

--- a/rest-api/resources/src/main/resources/openapi/credential/credential.yaml
+++ b/rest-api/resources/src/main/resources/openapi/credential/credential.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    credentialId:
-      name: credentialId
-      in: path
-      description: The ID of the Credential on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     credential:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-channelInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel-scopeId-channelInfoId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: channelInfoGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './dataChannel.yaml#/components/parameters/channelInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/channelInfoId'
       responses:
         200:
           description: The desired ChannelInfo

--- a/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataChannel/dataChannel.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    channelInfoId:
-      name: channelInfoId
-      in: path
-      description: The ID of the ChannelInfo on which to perform the operation
-      schema:
-        type: string
-      required: true
   schemas:
     channelInfo:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-clientInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient-scopeId-clientInfoId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: clientInfoGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './dataClient.yaml#/components/parameters/clientInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/clientInfoId'
       responses:
         200:
           description: The desired ClientInfo

--- a/rest-api/resources/src/main/resources/openapi/dataClient/dataClient.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataClient/dataClient.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    clientInfoId:
-      name: clientInfoId
-      in: path
-      description: The ID of the ClientInfo on which to perform the operation
-      schema:
-        type: string
-      required: true
   schemas:
     clientInfo:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-datastoreMessageId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage-scopeId-datastoreMessageId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: dataMessageGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './dataMessage.yaml#/components/parameters/datastoreMessageId'
+        - $ref: '../openapi.yaml#/components/parameters/datastoreMessageId'
       responses:
         200:
           description: The desired DataMessage

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    datastoreMessageId:
-      name: datastoreMessageId
-      in: path
-      description: The ID of the MetricInfo on which to perform the operation
-      schema:
-        type: string
-      required: true
   schemas:
     dataMessage:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-metricInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric-scopeId-metricInfoId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: metricInfoGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './dataMetric.yaml#/components/parameters/metricInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/metricInfoId'
       responses:
         200:
           description: The desired MetricInfo

--- a/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMetric/dataMetric.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    metricInfoId:
-      name: metricInfoId
-      in: path
-      description: The ID of the MetricInfo on which to perform the operation
-      schema:
-        type: string
-      required: true
   schemas:
     metricInfo:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       responses:
         200:
           description: The details of the desired Device
@@ -45,7 +45,7 @@ paths:
       operationId: deviceUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       requestBody:
         description: An object containing the new properties for the Device to update
         content:
@@ -102,7 +102,7 @@ paths:
       operationId: deviceDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       responses:
         204:
           description: The Device has been deleted

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
@@ -30,9 +30,9 @@ paths:
           description: The Tag id to filter results
           schema:
             $ref: '../openapi.yaml#/components/schemas/kapuaId'
-        - $ref: './device.yaml#/components/parameters/clientId'
-        - $ref: '../deviceConnection/deviceConnection.yaml#/components/parameters/connectionStatus'
-        - $ref: './device.yaml#/components/parameters/fetchAttributes'
+        - $ref: '../openapi.yaml#/components/parameters/clientId'
+        - $ref: '../openapi.yaml#/components/parameters/connectionStatus'
+        - $ref: '../openapi.yaml#/components/parameters/fetchAttributes'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - name: sortDir

--- a/rest-api/resources/src/main/resources/openapi/device/device.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device.yaml
@@ -14,34 +14,6 @@ info:
 paths: { }
 
 components:
-  parameters:
-    deviceId:
-      name: deviceId
-      in: path
-      description: The ID of the Device on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    timeout:
-      name: timeout
-      in: query
-      description: The timeout for the request in milliseconds
-      schema:
-        type: integer
-        default: 30000
-    fetchAttributes:
-      name: fetchAttributes
-      in: query
-      schema:
-        type: array
-        items:
-          $ref: '#/components/schemas/fetchAttribute'
-    clientId:
-      name: clientId
-      in: query
-      description: The client id to filter results
-      schema:
-        type: string
   schemas:
     device:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_read.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_read.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceAssetRead
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         description: An object containing the list of Assets to use as a filter
         content:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_settings.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: getDeviceAssetStoreSettings
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       responses:
         200:
           description: The Device Management Settings retrieved
@@ -45,7 +45,7 @@ paths:
       operationId: putDeviceAssetStoreSettings
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       requestBody:
         description: The Device Asset Store Settings for this Device
         content:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_write.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId-_write.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceAssetWrite
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         description: A DeviceAsset list to be updated on the desired Device
         content:

--- a/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceAsset/deviceAsset-scopeId-deviceId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceAssetList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The list of Assets definition of a single Device
@@ -48,8 +48,8 @@ paths:
       operationId: deviceAssetListFiltered
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         description: An object containing the list of Assets to use as a filter. If no DeviceAsset is specified, all DeviceAsset will be read.
         content:

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_start.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_start.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: './deviceBundle.yaml#/components/parameters/bundleId'
+        - $ref: '../openapi.yaml#/components/parameters/bundleId'
         - $ref: '../device/device.yaml#/components/parameters/timeout'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_start.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_start.yaml
@@ -20,9 +20,9 @@ paths:
       operationId: deviceBundleStart
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/bundleId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         204:
           description: The Bundle has been successfully started

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_stop.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_stop.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: './deviceBundle.yaml#/components/parameters/bundleId'
+        - $ref: '../openapi.yaml#/components/parameters/bundleId'
         - $ref: '../device/device.yaml#/components/parameters/timeout'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_stop.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId-_stop.yaml
@@ -20,9 +20,9 @@ paths:
       operationId: deviceBundleStop
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/bundleId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         204:
           description: The Bundle has been successfully stopped

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId.yaml
@@ -20,10 +20,10 @@ paths:
       operationId: deviceBundleList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The list of Bundles installed on a single Device

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    bundleId:
-      name: bundleId
-      in: path
-      description: The ID of the Bundle on which to perform the operation
-      schema:
-        type: string
-      required: true
   schemas:
     deviceBundle:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand-scopeId-deviceId-_execute.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceCommand/deviceCommand-scopeId-deviceId-_execute.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceCommandExecute
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-_settings.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: getDeviceConfigurationsStoreSettings
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       responses:
         200:
           description: The Device Management Settings retrieved
@@ -45,7 +45,7 @@ paths:
       operationId: putDeviceConfigurationsStoreSettings
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       requestBody:
         description: The Device Configurations Store Settings for this Device
         content:

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
@@ -20,9 +20,9 @@ paths:
       operationId: deviceConfigurationRead
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/componentId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The Configuration details of a single Service on a single Device
@@ -50,9 +50,9 @@ paths:
       operationId: deviceConfigurationWrite
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/componentId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../deviceConfiguration/deviceConfiguration.yaml#/components/parameters/componentId'
+        - $ref: '../openapi.yaml#/components/parameters/componentId'
         - $ref: '../device/device.yaml#/components/parameters/timeout'
       responses:
         200:
@@ -51,7 +51,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../deviceConfiguration/deviceConfiguration.yaml#/components/parameters/componentId'
+        - $ref: '../openapi.yaml#/components/parameters/componentId'
         - $ref: '../device/device.yaml#/components/parameters/timeout'
       requestBody:
         content:

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceConfigurationsRead
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The list of the Configurations on a single Device
@@ -49,8 +49,8 @@ paths:
       operationId: deviceConfigurationsWrite
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration.yaml
@@ -14,14 +14,6 @@ info:
 paths: { }
 
 components:
-  parameters:
-    componentId:
-      name: componentId
-      in: path
-      description: The ID of the Component on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     attributeDefinition:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-_disconnect.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-_disconnect.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: connectionDisconnect
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './deviceConnection.yaml#/components/parameters/connectionId'
+        - $ref: '../openapi.yaml#/components/parameters/connectionId'
       responses:
         204:
           description: The disconnection request was sent to the broker

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-options.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId-options.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: connectionOptionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './deviceConnection.yaml#/components/parameters/connectionId'
+        - $ref: '../openapi.yaml#/components/parameters/connectionId'
       responses:
         200:
           description: The Options of the desired Connection
@@ -45,7 +45,7 @@ paths:
       operationId: connectionOptionUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './deviceConnection.yaml#/components/parameters/connectionId'
+        - $ref: '../openapi.yaml#/components/parameters/connectionId'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId-connectionId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: connectionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './deviceConnection.yaml#/components/parameters/connectionId'
+        - $ref: '../openapi.yaml#/components/parameters/connectionId'
       responses:
         200:
           description: The details of the desired Connection

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection-scopeId.yaml
@@ -20,10 +20,10 @@ paths:
       operationId: connectionList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/clientId'
-        - $ref: './deviceConnection.yaml#/components/parameters/clientIp'
-        - $ref: './deviceConnection.yaml#/components/parameters/protocol'
-        - $ref: './deviceConnection.yaml#/components/parameters/connectionStatus'
+        - $ref: '../openapi.yaml#/components/parameters/clientId'
+        - $ref: '../openapi.yaml#/components/parameters/clientIp'
+        - $ref: '../openapi.yaml#/components/parameters/protocol'
+        - $ref: '../openapi.yaml#/components/parameters/connectionStatus'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConnection/deviceConnection.yaml
@@ -14,32 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    connectionId:
-      name: connectionId
-      in: path
-      description: The ID of the Connection on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    connectionStatus:
-      name: status
-      in: query
-      description: The connection status to filter results
-      schema:
-        $ref: './deviceConnection.yaml#/components/schemas/connectionStatus'
-    clientIp:
-      name: clientIp
-      in: query
-      description: The client ip to filter results
-      schema:
-        type: string
-    protocol:
-      name: protocol
-      in: query
-      description: The connection protocol to filter results
-      schema:
-        type: string
   schemas:
     connection:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceEventCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceEventQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-deviceEventId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-deviceEventId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: './deviceEvent.yaml#/components/parameters/deviceEventId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceEventId'
       responses:
         200:
           description: The details of the desired Device Event
@@ -47,7 +47,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: './deviceEvent.yaml#/components/parameters/deviceEventId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceEventId'
       responses:
         204:
           description: The Device Event has been deleted

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-deviceEventId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId-deviceEventId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceEventGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/deviceEventId'
       responses:
         200:
@@ -46,7 +46,7 @@ paths:
       operationId: deviceEventDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/deviceEventId'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceEventList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - name: resource
           in: query
           description: The resource of the DeviceEvent in which to search results

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    deviceEventId:
-      name: deviceEventId
-      in: path
-      description: The ID of the Device Event on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     deviceEvent:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/deviceGroup/deviceGroup-scopeId-deviceGroupId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceGroup/deviceGroup-scopeId-deviceGroupId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceGroupGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './deviceGroup.yaml#/components/parameters/deviceGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceGroupId'
       responses:
         200:
           description: The details of the desired Device Group
@@ -45,7 +45,7 @@ paths:
       operationId: deviceGroupUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './deviceGroup.yaml#/components/parameters/deviceGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceGroupId'
       requestBody:
         description: An object containing the new properties for the Device Group to update
         content:
@@ -82,7 +82,7 @@ paths:
       operationId: deviceGroupDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './deviceGroup.yaml#/components/parameters/deviceGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceGroupId'
       responses:
         204:
           description: The Device Group has been deleted

--- a/rest-api/resources/src/main/resources/openapi/deviceGroup/deviceGroup.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceGroup/deviceGroup.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    deviceGroupId:
-      name: deviceGroupId
-      in: path
-      description: The ID of the Device Group on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     deviceGroup:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceInventory/deviceInventory-scopeId-deviceId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceInventoryGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The inventory from the Device
@@ -47,8 +47,8 @@ paths:
       operationId: deviceInventoryBundleGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The bundle inventory from the Device
@@ -74,8 +74,8 @@ paths:
       operationId: deviceInventoryBundleStart
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:
@@ -102,8 +102,8 @@ paths:
       operationId: deviceInventoryBundleStop
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:
@@ -130,8 +130,8 @@ paths:
       operationId: deviceInventoryImageGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The inventory image from the Device
@@ -157,8 +157,8 @@ paths:
       operationId: deviceInventoryImageDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:
@@ -185,8 +185,8 @@ paths:
       operationId: deviceInventoryContainerGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The container inventory from the Device
@@ -212,8 +212,8 @@ paths:
       operationId: deviceInventoryContainerStart
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:
@@ -240,8 +240,8 @@ paths:
       operationId: deviceInventoryContainerStop
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:
@@ -268,8 +268,8 @@ paths:
       operationId: deviceInventorySystemGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The system packages inventory from the Device
@@ -295,8 +295,8 @@ paths:
       operationId: deviceInventoryPackagesGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The deployment packages inventory from the Device

--- a/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore-scopeId-deviceId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceKeystoresGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The keystores list from the Device
@@ -49,7 +49,7 @@ paths:
       operationId: deviceKeystoreItemsGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - name: keystoreId
           in: query
           description: The keystore id to filter the results.
@@ -60,7 +60,7 @@ paths:
           description: The alias to filter the results.
           schema:
             type: string
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The keystore items from the Device
@@ -88,7 +88,7 @@ paths:
       operationId: deviceKeystoreItemGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - name: keystoreId
           in: query
           description: The keystore id to filter the results.
@@ -101,7 +101,7 @@ paths:
           required: true
           schema:
             type: string
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The keystore item from the Device
@@ -128,7 +128,7 @@ paths:
       operationId: deviceKeystoreItemDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - name: keystoreId
           in: query
           description: The keystore id of the item to delete.
@@ -141,7 +141,7 @@ paths:
           required: true
           schema:
             type: string
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         204:
           description: The keystore item has been deleted
@@ -165,8 +165,8 @@ paths:
       operationId: deviceKeystoreCertificateInfoCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:
@@ -195,8 +195,8 @@ paths:
       operationId: deviceKeystoreCertificateRawCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:
@@ -225,8 +225,8 @@ paths:
       operationId: deviceKeystoreKeypairCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:
@@ -255,8 +255,8 @@ paths:
       operationId: deviceKeystoreCSR
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_count.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceRegistryNotificationCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/operationId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/operationId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-_query.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceRegistryNotificationQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/operationId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/operationId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-notificationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-notificationId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceRegistryNotificationGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/operationId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/operationId'
         - $ref: '../openapi.yaml#/components/parameters/notificationId'
       responses:
         200:
@@ -47,8 +47,8 @@ paths:
       operationId: deviceRegistryNotificationDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/operationId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/operationId'
         - $ref: '../openapi.yaml#/components/parameters/notificationId'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-notificationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId-notificationId.yaml
@@ -22,7 +22,7 @@ paths:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
         - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/operationId'
-        - $ref: './deviceNotification.yaml#/components/parameters/notificationId'
+        - $ref: '../openapi.yaml#/components/parameters/notificationId'
       responses:
         200:
           description: The details of the desired Registry Notification
@@ -49,7 +49,7 @@ paths:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
         - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/operationId'
-        - $ref: './deviceNotification.yaml#/components/parameters/notificationId'
+        - $ref: '../openapi.yaml#/components/parameters/notificationId'
       responses:
         204:
           description: The Registry Notification has been deleted

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification-scopeId-deviceId-operationId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceRegistryNotificationList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/operationId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/operationId'
         - name: resource
           in: query
           description: The resource of the DeviceEvent in which to search results

--- a/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceNotification/deviceNotification.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    notificationId:
-      name: notificationId
-      in: path
-      description: The ID of the Registry Notification on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     deviceNotification:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceRegistryOperationCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceRegistryOperationQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-operationId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId-operationId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceRegistryOperationGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: './deviceOperation.yaml#/components/parameters/operationId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/operationId'
       responses:
         200:
           description: The details of the desired Registry Operation
@@ -46,8 +46,8 @@ paths:
       operationId: deviceRegistryOperationDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: './deviceOperation.yaml#/components/parameters/operationId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/operationId'
       responses:
         204:
           description: The Registry Operation has been deleted

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: deviceRegistryOperationList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - name: resource
           in: query
           description: The resource of the DeviceManagementOperation in which to search results
@@ -31,7 +31,7 @@ paths:
           description: The appId of the DeviceManagementOperation in which to search results
           schema:
             type: string
-        - $ref: '../deviceOperation/deviceOperation.yaml#/components/parameters/status'
+        - $ref: '../openapi.yaml#/components/parameters/status'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - name: sortDir

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation.yaml
@@ -14,20 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    operationId:
-      name: operationId
-      in: path
-      description: The ID of the Registry Operation on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    status:
-      name: status
-      in: query
-      description: The status of the Registry Operation on which to perform the operation
-      schema:
-        $ref: './deviceOperation.yaml#/components/schemas/operationStatus'
   schemas:
     deviceOperation:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: devicePackageDownload
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: devicePackageUninstall
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: devicePackageList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The list of Packages installed on a single Device

--- a/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceRequest/deviceRequest-scopeId-deviceId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceRequestExec
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId-_rollback.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId-_rollback.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: './deviceSnapshot.yaml#/components/parameters/snapshotId'
+        - $ref: '../openapi.yaml#/components/parameters/snapshotId'
         - $ref: '../device/device.yaml#/components/parameters/timeout'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId-_rollback.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId-_rollback.yaml
@@ -20,9 +20,9 @@ paths:
       operationId: deviceSnapshotRollback
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/snapshotId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         204:
           description: The Snapshot has been applied

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: './deviceSnapshot.yaml#/components/parameters/snapshotId'
+        - $ref: '../openapi.yaml#/components/parameters/snapshotId'
         - $ref: '../device/device.yaml#/components/parameters/timeout'
       responses:
         200:

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId-snapshotId.yaml
@@ -20,9 +20,9 @@ paths:
       operationId: deviceSnapshotGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
         - $ref: '../openapi.yaml#/components/parameters/snapshotId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The list of the Configurations related to the given Snapshot on a single Device

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot-scopeId-deviceId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: deviceSnapshotList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/deviceId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       responses:
         200:
           description: The list of Snapshots available on a single Device

--- a/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceSnapshot/deviceSnapshot.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    snapshotId:
-      name: snapshotId
-      description: The ID of the Snapshot on which to perform the operation
-      in: path
-      required: true
-      schema:
-        type: string
   schemas:
     snapshot:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-domainId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain-scopeId-domainId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: domainGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './domain.yaml#/components/parameters/domainId'
+        - $ref: '../openapi.yaml#/components/parameters/domainId'
       responses:
         200:
           description: The details of the desired Domain

--- a/rest-api/resources/src/main/resources/openapi/domain/domain.yaml
+++ b/rest-api/resources/src/main/resources/openapi/domain/domain.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    domainId:
-      name: domainId
-      in: path
-      description: The ID of the Domain on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     domain:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: endpointInfoCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './endpointInfo.yaml#/components/parameters/endpointType'
+        - $ref: '../openapi.yaml#/components/parameters/endpointType'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: endpointInfoQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './endpointInfo.yaml#/components/parameters/endpointType'
+        - $ref: '../openapi.yaml#/components/parameters/endpointType'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: endpointInfoGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './endpointInfo.yaml#/components/parameters/endpointInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/endpointInfoId'
       responses:
         200:
           description: The details of the desired EndpointInfo
@@ -45,7 +45,7 @@ paths:
       operationId: endpointInfoUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './endpointInfo.yaml#/components/parameters/endpointInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/endpointInfoId'
       requestBody:
         description: An object containing the new properties for the EndpointInfo to update
         content:
@@ -90,7 +90,7 @@ paths:
       operationId: endpointInfoDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './endpointInfo.yaml#/components/parameters/endpointInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/endpointInfoId'
       responses:
         204:
           description: The EndpointInfo has been deleted

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
@@ -25,7 +25,7 @@ paths:
           description: The endpointInfo usage to filter results
           schema:
             type: string
-        - $ref: './endpointInfo.yaml#/components/parameters/endpointType'
+        - $ref: '../openapi.yaml#/components/parameters/endpointType'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - name: sortDir

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo.yaml
@@ -14,23 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    endpointInfoId:
-      name: endpointInfoId
-      in: path
-      description: The ID of the EndpointInfo on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    endpointType:
-      name: endpointType
-      in: query
-      description: The type of the Endpoints to query for
-      schema:
-        allOf:
-          - $ref: '#/components/schemas/endpointType'
-          - default: resource
-      required: false
   schemas:
     endpointInfo:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/group/group-scopeId-groupId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group-scopeId-groupId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: groupGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './group.yaml#/components/parameters/groupId'
+        - $ref: '../openapi.yaml#/components/parameters/groupId'
       responses:
         200:
           description: The details of the desired Group
@@ -45,7 +45,7 @@ paths:
       operationId: groupUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './group.yaml#/components/parameters/groupId'
+        - $ref: '../openapi.yaml#/components/parameters/groupId'
       requestBody:
         description: An object containing the new properties for the Group to update
         content:
@@ -82,7 +82,7 @@ paths:
       operationId: groupDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './group.yaml#/components/parameters/groupId'
+        - $ref: '../openapi.yaml#/components/parameters/groupId'
       responses:
         204:
           description: The Group has been deleted

--- a/rest-api/resources/src/main/resources/openapi/group/group.yaml
+++ b/rest-api/resources/src/main/resources/openapi/group/group.yaml
@@ -14,28 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    groupId:
-      name: groupId
-      in: path
-      description: The ID of the Group on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    groupPermissionId:
-      name: groupPermissionId
-      in: path
-      description: The ID of the Group Permission on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    groupRoleId:
-      name: groupRoleId
-      in: path
-      description: The ID of the Group Role on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     group:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId-jobId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId-jobId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       responses:
         200:
           description: The details of the desired Job
@@ -45,7 +45,7 @@ paths:
       operationId: jobUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         description: An object containing the new properties for the Job to update
         content:
@@ -80,7 +80,7 @@ paths:
       operationId: jobDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - name: forced
           in: query
           description: Delete the Job forcibly. It can only be used by the system administrator.

--- a/rest-api/resources/src/main/resources/openapi/job/job.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    jobId:
-      name: jobId
-      in: path
-      description: The ID of the Job on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     job:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId-executionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId-executionId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobEngine.yaml#/components/parameters/executionId'
+        - $ref: '../openapi.yaml#/components/parameters/jobExecutionId'
       responses:
         202:
           description: The Job Engine has received the Resume Execution request
@@ -44,7 +44,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobEngine.yaml#/components/parameters/executionId'
+        - $ref: '../openapi.yaml#/components/parameters/jobExecutionId'
       responses:
         204:
           description: The Job Engine has received the Stop Execution request

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId-executionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId-executionId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobResumeExecution
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/jobExecutionId'
       responses:
         202:
@@ -43,7 +43,7 @@ paths:
       operationId: jobStopExecution
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/jobExecutionId'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine-scopeId-jobId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobStart
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         content:
           application/json:
@@ -48,7 +48,7 @@ paths:
       operationId: jobStop
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       responses:
         202:
           description: The Stop operation has been received by the Job Engine
@@ -70,7 +70,7 @@ paths:
       operationId: jobIsRunning
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       responses:
         200:
           description: An object representing the running status of a Job

--- a/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobEngine/jobEngine.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    executionId:
-      name: executionId
-      in: path
-      description: The ID of the Job Execution on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     jobStartOptions:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobExecutionCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobExecutionQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId-targets.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobExecution.yaml#/components/parameters/executionId'
+        - $ref: '../openapi.yaml#/components/parameters/jobExecutionId'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId-targets.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobExecutionListTarget
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/jobExecutionId'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobExecutionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/jobExecutionId'
       responses:
         200:

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions-executionId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobExecution.yaml#/components/parameters/executionId'
+        - $ref: '../openapi.yaml#/components/parameters/jobExecutionId'
       responses:
         200:
           description: The details of the desired Job Execution

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/job-scopeId-jobId-executions.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobExecutionList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - description: The start date to filter the results.
           name: startDate
           in: query

--- a/rest-api/resources/src/main/resources/openapi/jobExecution/jobExecution.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobExecution/jobExecution.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    executionId:
-      name: executionId
-      in: path
-      description: The ID of the Job Execution on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     jobExecutionStatus:
       description: The status of a job execution

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobStepCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobStepQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-stepId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-stepId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobStepGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/stepId'
       responses:
         200:
@@ -46,7 +46,7 @@ paths:
       operationId: jobStepUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/stepId'
       requestBody:
         description: An object containing the new properties for the Job Step to update
@@ -79,7 +79,7 @@ paths:
       operationId: jobStepDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/stepId'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-stepId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps-stepId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobStep.yaml#/components/parameters/stepId'
+        - $ref: '../openapi.yaml#/components/parameters/stepId'
       responses:
         200:
           description: The details of the desired Job Step
@@ -47,7 +47,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobStep.yaml#/components/parameters/stepId'
+        - $ref: '../openapi.yaml#/components/parameters/stepId'
       requestBody:
         description: An object containing the new properties for the Job Step to update
         content:
@@ -80,7 +80,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobStep.yaml#/components/parameters/stepId'
+        - $ref: '../openapi.yaml#/components/parameters/stepId'
       responses:
         204:
           description: The Job Step has been deleted

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobStepList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - name: name
           in: query
           description: The job step name to filter results
@@ -53,7 +53,7 @@ paths:
       operationId: jobStepCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         description: An object containing the properties for the new Job Step to be created
         content:

--- a/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/jobStep.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    stepId:
-      name: stepId
-      in: path
-      description: The ID of the Job Step on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     jobStepProperty:
       description: Property of a Job's Step

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-jobStepDefinitionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition-scopeId-jobStepDefinitionId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobStepDefinitionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './jobStepDefinition.yaml#/components/parameters/jobStepDefinitionId'
+        - $ref: '../openapi.yaml#/components/parameters/jobStepDefinitionId'
       responses:
         200:
           description: The details of the desired Job Step Definition

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
@@ -14,14 +14,6 @@ info:
 paths: { }
 
 components:
-  parameters:
-    jobStepDefinitionId:
-      name: jobStepDefinitionId
-      in: path
-      description: The ID of the Job Step Definition on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     jobStepDefinitionProperty:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTargetCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTargetQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId-executions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId-executions.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTarget.yaml#/components/parameters/targetId'
+        - $ref: '../openapi.yaml#/components/parameters/targetId'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId-executions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId-executions.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTargetListExecution
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/targetId'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTargetGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/targetId'
       responses:
         200:
@@ -51,7 +51,7 @@ paths:
       operationId: jobTargetDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/targetId'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets-targetId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTarget.yaml#/components/parameters/targetId'
+        - $ref: '../openapi.yaml#/components/parameters/targetId'
       responses:
         200:
           description: The details of the desired Job Target
@@ -52,7 +52,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTarget.yaml#/components/parameters/targetId'
+        - $ref: '../openapi.yaml#/components/parameters/targetId'
       responses:
         204:
           description: The Job Target has been deleted

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: '../jobTarget/jobTarget.yaml#/components/parameters/jobTargetStatus'
+        - $ref: '../openapi.yaml#/components/parameters/jobTargetStatus'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/job-scopeId-jobId-targets.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTargetList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/jobTargetStatus'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
@@ -49,7 +49,7 @@ paths:
       operationId: jobTargetCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         description: An object containing the properties for the new Job Target to be created
         content:

--- a/rest-api/resources/src/main/resources/openapi/jobTarget/jobTarget.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTarget/jobTarget.yaml
@@ -14,21 +14,6 @@ info:
 paths: { }
 
 components:
-  parameters:
-    targetId:
-      name: targetId
-      in: path
-      description: The entity ID of the on which perform the operations
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    jobTargetStatus:
-      name: status
-      in: query
-      description: the status of the job target
-      schema:
-        $ref: '#/components/schemas/jobTargetStatus'
-      required: false
   schemas:
     jobTargetCreator:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTriggerCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTriggerQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-triggerId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-triggerId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTriggerGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/triggerId'
       responses:
         200:
@@ -46,7 +46,7 @@ paths:
       operationId: jobTriggerUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/triggerId'
       requestBody:
         description: An object containing the new properties for the Job Trigger to update
@@ -92,7 +92,7 @@ paths:
       operationId: jobTriggerDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/triggerId'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-triggerId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers-triggerId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTrigger.yaml#/components/parameters/triggerId'
+        - $ref: '../openapi.yaml#/components/parameters/triggerId'
       responses:
         200:
           description: The details of the desired Job Trigger
@@ -47,7 +47,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTrigger.yaml#/components/parameters/triggerId'
+        - $ref: '../openapi.yaml#/components/parameters/triggerId'
       requestBody:
         description: An object containing the new properties for the Job Trigger to update
         content:
@@ -93,7 +93,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTrigger.yaml#/components/parameters/triggerId'
+        - $ref: '../openapi.yaml#/components/parameters/triggerId'
       responses:
         204:
           description: The Job Trigger has been deleted

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/job-scopeId-jobId-triggers.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTriggerList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - name: name
           in: query
           description: The job trigger name to filter results
@@ -53,7 +53,7 @@ paths:
       operationId: jobTriggerCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
       requestBody:
         description: An object containing the properties for the new Job Trigger to be created
         content:

--- a/rest-api/resources/src/main/resources/openapi/jobTrigger/jobTrigger.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTrigger/jobTrigger.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    triggerId:
-      name: triggerId
-      in: path
-      description: The ID of the Job Trigger on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     jobTrigger:
       description: Trigger for the Job

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_count.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTriggerFired.yaml#/components/parameters/triggerId'
+        - $ref: '../openapi.yaml#/components/parameters/triggerId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTriggerFiredCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/triggerId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTriggerFiredQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/triggerId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired-_query.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTriggerFired.yaml#/components/parameters/triggerId'
+        - $ref: '../openapi.yaml#/components/parameters/triggerId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
-        - $ref: './jobTriggerFired.yaml#/components/parameters/triggerId'
+        - $ref: '../openapi.yaml#/components/parameters/triggerId'
         - name: status
           in: query
           description: |

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: jobTriggerFiredList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../job/job.yaml#/components/parameters/jobId'
+        - $ref: '../openapi.yaml#/components/parameters/jobId'
         - $ref: '../openapi.yaml#/components/parameters/triggerId'
         - name: status
           in: query

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/jobTriggerFired.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/jobTriggerFired.yaml
@@ -14,14 +14,6 @@ info:
 paths: { }
 
 components:
-  parameters:
-    triggerId:
-      name: triggerId
-      in: path
-      description: The ID of the Job Trigger on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     firedTrigger:
       allOf:
@@ -38,7 +30,7 @@ components:
             status:
               $ref: './jobTriggerFired.yaml#/components/schemas/firedTriggerStatus'
             triggerId:
-              $ref: './jobTriggerFired.yaml#/components/parameters/triggerId'
+              $ref: '../openapi.yaml#/components/parameters/triggerId'
     firedTriggerListResult:
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaListResult'

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -575,6 +575,162 @@ components:
       schema:
         $ref: '#/components/schemas/kapuaId'
       required: true
+    accountId:
+      name: accountId
+      in: path
+      description: The ID of the Account on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    channelInfoId:
+      name: channelInfoId
+      in: path
+      description: The ID of the ChannelInfo on which to perform the operation
+      schema:
+        type: string
+      required: true
+    clientInfoId:
+      name: clientInfoId
+      in: path
+      description: The ID of the ClientInfo on which to perform the operation
+      schema:
+        type: string
+      required: true
+    datastoreMessageId:
+      name: datastoreMessageId
+      in: path
+      description: The ID of the MetricInfo on which to perform the operation
+      schema:
+        type: string
+      required: true
+    metricInfoId:
+      name: metricInfoId
+      in: path
+      description: The ID of the MetricInfo on which to perform the operation
+      schema:
+        type: string
+      required: true
+    bundleId:
+      name: bundleId
+      in: path
+      description: The ID of the Bundle on which to perform the operation
+      schema:
+        type: string
+      required: true
+    deviceEventId:
+      name: deviceEventId
+      in: path
+      description: The ID of the Device Event on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    deviceGroupId:
+      name: deviceGroupId
+      in: path
+      description: The ID of the Device Group on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    notificationId:
+      name: notificationId
+      in: path
+      description: The ID of the Registry Notification on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    snapshotId:
+      name: snapshotId
+      description: The ID of the Snapshot on which to perform the operation
+      in: path
+      required: true
+      schema:
+        type: string
+    domainId:
+      name: domainId
+      in: path
+      description: The ID of the Domain on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    endpointInfoId:
+      name: endpointInfoId
+      in: path
+      description: The ID of the EndpointInfo on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    endpointType:
+      name: endpointType
+      in: query
+      description: The type of the Endpoints to query for
+      schema:
+        allOf:
+          - $ref: './endpointInfo/endpointInfo.yaml#/components/schemas/endpointType'
+          - default: resource
+      required: false
+    stepId:
+      name: stepId
+      in: path
+      description: The ID of the Job Step on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    jobStepDefinitionId:
+      name: jobStepDefinitionId
+      in: path
+      description: The ID of the Job Step Definition on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    targetId:
+      name: targetId
+      in: path
+      description: The entity ID of the on which perform the operations
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    jobTargetStatus:
+      name: status
+      in: query
+      description: the status of the job target
+      schema:
+        $ref: './jobTarget/jobTarget.yaml#/components/schemas/jobTargetStatus'
+      required: false
+    roleId:
+      name: roleId
+      in: path
+      description: The ID of the Role on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    rolePermissionId:
+      name: rolePermissionId
+      in: path
+      description: The ID of the RolePermission on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    tagId:
+      name: tagId
+      in: path
+      description: The ID of the Tag on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    triggerDefinitionId:
+      name: triggerDefinitionId
+      in: path
+      description: The ID of the Trigger Definition on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    userGroupId:
+      name: userGroupId
+      in: path
+      description: The ID of the User Group on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
     scopeId:
       name: scopeId
       in: path

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -1245,6 +1245,16 @@ components:
       $ref: './authentication/authentication.yaml#/components/schemas/usernamePasswordCredentials'
     jwtCredentials:
       $ref: './authentication/authentication.yaml#/components/schemas/jwtCredentials'
+    username:
+      $ref: './authentication/authentication.yaml#/components/schemas/username'
+    password:
+      $ref: './authentication/authentication.yaml#/components/schemas/password'
+    authenticationCode:
+      $ref: './authentication/authentication.yaml#/components/schemas/authenticationCode'
+    trustKey:
+      $ref: './authentication/authentication.yaml#/components/schemas/trustKey'
+    jwt:
+      $ref: './authentication/authentication.yaml#/components/schemas/jwt'
     ### Credential Entities ###
     credential:
       $ref: './credential/credential.yaml#/components/schemas/credential'
@@ -1353,11 +1363,17 @@ components:
       $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/option'
     attributeDefinition:
       $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/attributeDefinition'
+    deviceConfigurationStoreSettings:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/deviceConfigurationStoreSettings'
     ### Device Connection Entities ###
     connection:
       $ref: './deviceConnection/deviceConnection.yaml#/components/schemas/connection'
     connectionListResult:
       $ref: './deviceConnection/deviceConnection.yaml#/components/schemas/connectionListResult'
+    connectionOptions:
+      $ref: './deviceConnection/deviceConnection.yaml#/components/schemas/connectionOptions'
+    userCouplingMode:
+      $ref: './deviceConnection/deviceConnection.yaml#/components/schemas/userCouplingMode'
     ### Device Event Entities ###
     deviceEvent:
       $ref: './deviceEvent/deviceEvent.yaml#/components/schemas/deviceEvent'
@@ -1533,6 +1549,8 @@ components:
       $ref: './jobTriggerFired/jobTriggerFired.yaml#/components/schemas/firedTrigger'
     firedTriggerListResult:
       $ref: './jobTriggerFired/jobTriggerFired.yaml#/components/schemas/firedTriggerListResult'
+    firedTriggerStatus:
+      $ref: './jobTriggerFired/jobTriggerFired.yaml#/components/schemas/firedTriggerStatus'
     ### Role Entities ###
     role:
       $ref: './role/role.yaml#/components/schemas/role'

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -519,6 +519,62 @@ paths:
 
 components:
   parameters:
+    accessInfoId:
+      description: The ID of the AccessInfo on which to perform the operation
+      name: accessInfoId
+      in: path
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    accessPermissionId:
+      name: accessPermissionId
+      in: path
+      description: The ID of the AccessPermission on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    accessRoleId:
+      name: accessRoleId
+      in: path
+      description: The ID of the AccessRole on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    userIdFilter:
+      name: userId
+      in: query
+      description: The ID of the User to use as a filter in the query
+      schema:
+        allOf:
+          - $ref: '#/components/schemas/kapuaId'
+    userId:
+      name: userId
+      in: path
+      description: The ID of the User on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    componentId:
+      name: componentId
+      in: path
+      description: The ID of the Component on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    triggerId:
+      name: triggerId
+      in: path
+      description: The ID of the Job Trigger on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    jobExecutionId:
+      name: executionId
+      in: path
+      description: The ID of the Job Execution on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
     scopeId:
       name: scopeId
       in: path

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -664,9 +664,11 @@ components:
       in: query
       description: The type of the Endpoints to query for
       schema:
-        allOf:
-          - $ref: './endpointInfo/endpointInfo.yaml#/components/schemas/endpointType'
-          - default: resource
+        type: string
+        enum:
+          - resource
+          - cors
+        default: resource
       required: false
     stepId:
       name: stepId
@@ -694,7 +696,13 @@ components:
       in: query
       description: the status of the job target
       schema:
-        $ref: './jobTarget/jobTarget.yaml#/components/schemas/jobTargetStatus'
+        type: string
+        enum:
+          - PROCESS_OK
+          - PROCESS_FAILED
+          - PROCESS_AWAITING
+          - AWAITING_COMPLETION
+          - NOTIFIED_COMPLETION
       required: false
     roleId:
       name: roleId
@@ -728,6 +736,116 @@ components:
       name: userGroupId
       in: path
       description: The ID of the User Group on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    credentialId:
+      name: credentialId
+      in: path
+      description: The ID of the Credential on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    deviceId:
+      name: deviceId
+      in: path
+      description: The ID of the Device on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    timeout:
+      name: timeout
+      in: query
+      description: The timeout for the request in milliseconds
+      schema:
+        type: integer
+        default: 30000
+    fetchAttributes:
+      name: fetchAttributes
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: './device/device.yaml#/components/schemas/fetchAttribute'
+    clientId:
+      name: clientId
+      in: query
+      description: The client id to filter results
+      schema:
+        type: string
+    connectionId:
+      name: connectionId
+      in: path
+      description: The ID of the Connection on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    connectionStatus:
+      name: status
+      in: query
+      description: The connection status to filter results
+      schema:
+        type: string
+        enum:
+          - 'CONNECTED'
+          - 'DISCONNECTED'
+          - 'MISSING'
+          - 'NULL'
+    clientIp:
+      name: clientIp
+      in: query
+      description: The client ip to filter results
+      schema:
+        type: string
+    protocol:
+      name: protocol
+      in: query
+      description: The connection protocol to filter results
+      schema:
+        type: string
+    operationId:
+      name: operationId
+      in: path
+      description: The ID of the Registry Operation on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    status:
+      name: status
+      in: query
+      description: The status of the Registry Operation on which to perform the operation
+      schema:
+        type: string
+        enum:
+          - RUNNING
+          - COMPLETED
+          - FAILED
+          - STALE
+    groupId:
+      name: groupId
+      in: path
+      description: The ID of the Group on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    groupPermissionId:
+      name: groupPermissionId
+      in: path
+      description: The ID of the Group Permission on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    groupRoleId:
+      name: groupRoleId
+      in: path
+      description: The ID of the Group Role on which to perform the operation
+      schema:
+        $ref: '#/components/schemas/kapuaId'
+      required: true
+    jobId:
+      name: jobId
+      in: path
+      description: The ID of the Job on which to perform the operation
       schema:
         $ref: '#/components/schemas/kapuaId'
       required: true

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId-users.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId-users.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: roleListUsers
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: roleGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
       responses:
         200:
           description: The details of the desired Role
@@ -45,7 +45,7 @@ paths:
       operationId: roleUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
       requestBody:
         description: An object containing the new properties for the Role to update
         content:
@@ -92,7 +92,7 @@ paths:
       operationId: roleDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
       responses:
         204:
           description: The Role has been deleted

--- a/rest-api/resources/src/main/resources/openapi/role/role.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role.yaml
@@ -14,21 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    roleId:
-      name: roleId
-      in: path
-      description: The ID of the Role on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
-    rolePermissionId:
-      name: rolePermissionId
-      in: path
-      description: The ID of the RolePermission on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     role:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: rolePermissionCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: rolePermissionQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-permissionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId-permissionId.yaml
@@ -20,8 +20,8 @@ paths:
       operationId: rolePermissionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
-        - $ref: './role.yaml#/components/parameters/rolePermissionId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/rolePermissionId'
       responses:
         200:
           description: The details of the desired RolePermission
@@ -46,8 +46,8 @@ paths:
       operationId: rolePermissionDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
-        - $ref: './role.yaml#/components/parameters/rolePermissionId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/rolePermissionId'
       responses:
         204:
           description: The RolePermission has been deleted

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: rolePermissionList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
         - name: name
           in: query
           description: The domain name to filter results
@@ -58,7 +58,7 @@ paths:
       operationId: rolePermissionCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/roleId'
       requestBody:
         description: An object containing the properties for the new RolePermission to be created
         content:

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration-scopeId-componentId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: serviceConfigurationRead
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './serviceConfiguration.yaml#/components/parameters/componentId'
+        - $ref: '../openapi.yaml#/components/parameters/componentId'
       responses:
         200:
           description: The Configuration details of a single Service
@@ -45,7 +45,7 @@ paths:
       operationId: serviceConfigurationWrite
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './serviceConfiguration.yaml#/components/parameters/componentId'
+        - $ref: '../openapi.yaml#/components/parameters/componentId'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    componentId:
-      name: componentId
-      in: path
-      description: The ID of the Component on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     attributeDefinition:
       description: The definition for a single configuration value

--- a/rest-api/resources/src/main/resources/openapi/stream/stream-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/stream/stream-scopeId.yaml
@@ -21,7 +21,7 @@ paths:
       description: Publishes a message to a topic composed of [account-name] / [client-id] / [semantic-parts]
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../device/device.yaml#/components/parameters/timeout'
+        - $ref: '../openapi.yaml#/components/parameters/timeout'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-tagId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag-scopeId-tagId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: tagGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './tag.yaml#/components/parameters/tagId'
+        - $ref: '../openapi.yaml#/components/parameters/tagId'
       responses:
         200:
           description: The details of the desired Tag
@@ -45,7 +45,7 @@ paths:
       operationId: tagUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './tag.yaml#/components/parameters/tagId'
+        - $ref: '../openapi.yaml#/components/parameters/tagId'
       requestBody:
         description: An object containing the new properties for the Tag to update
         content:
@@ -92,7 +92,7 @@ paths:
       operationId: tagDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './tag.yaml#/components/parameters/tagId'
+        - $ref: '../openapi.yaml#/components/parameters/tagId'
       responses:
         204:
           description: The Tag has been deleted

--- a/rest-api/resources/src/main/resources/openapi/tag/tag.yaml
+++ b/rest-api/resources/src/main/resources/openapi/tag/tag.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    tagId:
-      name: tagId
-      in: path
-      description: The ID of the Tag on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     tag:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-triggerDefinitionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition-scopeId-triggerDefinitionId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: triggerDefinitionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './triggerDefinition.yaml#/components/parameters/triggerDefinitionId'
+        - $ref: '../openapi.yaml#/components/parameters/triggerDefinitionId'
       responses:
         200:
           description: The details of the desired Trigger Definition

--- a/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition.yaml
+++ b/rest-api/resources/src/main/resources/openapi/triggerDefinition/triggerDefinition.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    triggerDefinitionId:
-      name: triggerDefinitionId
-      in: path
-      description: The ID of the Trigger Definition on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     triggerProperty:
       type: object

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId-userId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       responses:
         200:
           description: The details of the desired User
@@ -45,7 +45,7 @@ paths:
       operationId: userUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       requestBody:
         description: An object containing the new properties for the User to update
         content:
@@ -86,7 +86,7 @@ paths:
       operationId: userDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       responses:
         204:
           description: The User has been deleted

--- a/rest-api/resources/src/main/resources/openapi/user/user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user.yaml
@@ -14,14 +14,6 @@ info:
 paths: { }
 
 components:
-  parameters:
-    userId:
-      name: userId
-      in: path
-      description: The ID of the User on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     user:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/userCredentials/user-credentials-credentialId-_reset.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userCredentials/user-credentials-credentialId-_reset.yaml
@@ -25,7 +25,7 @@ paths:
       operationId: credentialPasswordReset
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../credential/credential.yaml#/components/parameters/credentialId'
+        - $ref: '../openapi.yaml#/components/parameters/credentialId'
       requestBody:
         description: The new password
         content:
@@ -62,7 +62,7 @@ paths:
       operationId: scopeIdCredentialPasswordReset
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../credential/credential.yaml#/components/parameters/credentialId'
+        - $ref: '../openapi.yaml#/components/parameters/credentialId'
       requestBody:
         description: The new password
         content:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupPermissionCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupPermissionQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions-groupPermissionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions-groupPermissionId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupPermissionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
         - $ref: '../group/group.yaml#/components/parameters/groupPermissionId'
       responses:
         200:
@@ -46,7 +46,7 @@ paths:
       operationId: userGroupPermissionDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
         - $ref: '../group/group.yaml#/components/parameters/groupPermissionId'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions-groupPermissionId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions-groupPermissionId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../openapi.yaml#/components/parameters/userGroupId'
-        - $ref: '../group/group.yaml#/components/parameters/groupPermissionId'
+        - $ref: '../openapi.yaml#/components/parameters/groupPermissionId'
       responses:
         200:
           description: The details of the desired User GroupPermission
@@ -47,7 +47,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../openapi.yaml#/components/parameters/userGroupId'
-        - $ref: '../group/group.yaml#/components/parameters/groupPermissionId'
+        - $ref: '../openapi.yaml#/components/parameters/groupPermissionId'
       responses:
         204:
           description: The Group Permission has been deleted

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-permissions.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupPermissionList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/sortParam'
         - $ref: '../openapi.yaml#/components/parameters/sortDir'
@@ -48,7 +48,7 @@ paths:
       operationId: userGroupPermissionCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupRoleCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles-_query.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupRoleQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles-groupRoleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles-groupRoleId.yaml
@@ -21,7 +21,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../openapi.yaml#/components/parameters/userGroupId'
-        - $ref: '../group/group.yaml#/components/parameters/groupRoleId'
+        - $ref: '../openapi.yaml#/components/parameters/groupRoleId'
       responses:
         200:
           description: The details of the desired User Group Role
@@ -47,7 +47,7 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../openapi.yaml#/components/parameters/userGroupId'
-        - $ref: '../group/group.yaml#/components/parameters/groupRoleId'
+        - $ref: '../openapi.yaml#/components/parameters/groupRoleId'
       responses:
         204:
           description: The UserGroupRole has been deleted

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles-groupRoleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles-groupRoleId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupRoleGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
         - $ref: '../group/group.yaml#/components/parameters/groupRoleId'
       responses:
         200:
@@ -46,7 +46,7 @@ paths:
       operationId: userGroupRoleDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
         - $ref: '../group/group.yaml#/components/parameters/groupRoleId'
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId-roles.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupRolesList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
@@ -46,7 +46,7 @@ paths:
       operationId: userGroupRoleCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       requestBody:
         content:
           application/json:

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup-scopeId-userGroupId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userGroupGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       responses:
         200:
           description: The details of the desired User Group
@@ -45,7 +45,7 @@ paths:
       operationId: userGroupUpdate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       requestBody:
         description: An object containing the new properties for the User Group to update
         content:
@@ -82,7 +82,7 @@ paths:
       operationId: userGroupDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: './userGroup.yaml#/components/parameters/userGroupId'
+        - $ref: '../openapi.yaml#/components/parameters/userGroupId'
       responses:
         204:
           description: The User Group has been deleted

--- a/rest-api/resources/src/main/resources/openapi/userGroup/userGroup.yaml
+++ b/rest-api/resources/src/main/resources/openapi/userGroup/userGroup.yaml
@@ -14,14 +14,6 @@ info:
 paths: {}
 
 components:
-  parameters:
-    userGroupId:
-      name: userGroupId
-      in: path
-      description: The ID of the User Group on which to perform the operation
-      schema:
-        $ref: '../openapi.yaml#/components/schemas/kapuaId'
-      required: true
   schemas:
     userGroup:
       allOf:

--- a/rest-api/resources/src/main/resources/openapi/usersCredentials/users-credentials-scopeId-userId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersCredentials/users-credentials-scopeId-userId-_count.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: usersCredentialsCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:
@@ -43,7 +43,7 @@ paths:
       operationId: user_s_CredentialsCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/usersCredentials/users-credentials-scopeId-userId-password-_reset.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersCredentials/users-credentials-scopeId-userId-password-_reset.yaml
@@ -21,7 +21,7 @@ paths:
       operationId: usersCredentialsPasswordReset
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       requestBody:
         description: The new password
         content:

--- a/rest-api/resources/src/main/resources/openapi/usersCredentials/users-credentials-scopeId-userId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersCredentials/users-credentials-scopeId-userId.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: usersCredentialsList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
 
@@ -79,7 +79,7 @@ paths:
       operationId: usersCredentialsCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       requestBody:
         description: An object containing the properties for the new Credential to be created
         content:
@@ -165,7 +165,7 @@ paths:
       operationId: user_s_CredentialsList
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
 
@@ -227,7 +227,7 @@ paths:
       operationId: user_s_CredentialsCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       requestBody:
         description: An object containing the properties for the new Credential to be created
         content:

--- a/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa-disableTrust.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa-disableTrust.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userMfaOptionDisableTrust
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       responses:
         204:
           description: The trusted machine has been disabled for the User

--- a/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/usersMfa/users-scopeId-userId-mfa.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: userMfaOptionGet
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       responses:
         200:
           description: The details of the desired MfaOption
@@ -47,7 +47,7 @@ paths:
       operationId: userMfaOptionCreate
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       responses:
         201:
           description: The MfaOption that has just been created
@@ -87,7 +87,7 @@ paths:
       operationId: userMfaOptionDelete
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
-        - $ref: '../user/user.yaml#/components/parameters/userId'
+        - $ref: '../openapi.yaml#/components/parameters/userId'
       responses:
         204:
           description: The MfaOption has been deleted


### PR DESCRIPTION
## PR Overview

With the goal to fix all validation errors reported by openAPI parser too;, this pr consolidates all OpenAPI components and parameters—previously scattered across ~30 per-module fragment files—into a single root `openapi.yaml`. In doing so, this also fixes a bundler bug uncovered during centralization.

---

## 🛠️ Key Changes

**Centralization & Refactoring**
* Moved ~50 parameter definitions into `openapi.yaml` and repointed all references across the repository tree.
* Deduplicated identical parameter definitions that existed solely due to per-module duplication (e.g., `componentId`, `triggerId`, and jobEngine's `executionId`/`jobExecutionId`).


**Collision Resolution**
* Resolved naming collisions where the same internal key served different contexts across modules (e.g., `userId` was a required path param in `user.yaml`, but an optional query filter in `accessInfo.yaml`).
* **Fix:** Split these into distinct internal keys (`userId` vs. `userIdFilter`).
* *Note: Only internal document keys were updated—wire-level parameter names remain completely unchanged.*


**Bundler Bug Fix**
* Centralizing parameters that reused module-owned enum schemas (`connectionStatus`, `status`, `jobTargetStatus`, `endpointType`) caused `swagger-cli` to anchor shared schemas at invalid positions.
* **Fix:** Inlined the small enums directly and added missing root-level schema aliases for other shared schemas lacking one.



---

## ✅ Verification

* **Source-level diff:** Every parameter's `name`, `in`, `required`, and `description` attributes are preserved exactly. No `paths`, `operationId`, or `responses` were touched.
* **Bundled-document diff:** Evaluated at the fully-dereferenced level across all 319 paths:
* Output is **byte-identical**, with the single exception of `endpointType`'s schema flattening from an equivalent single-branch `allOf` to a flat object (retaining identical `type`, `enum`, and `default` values).