### PR TITLE
Allow overriding download URLs in Docker image builds

### DIFF
--- a/assembly/jetty-base/docker/Dockerfile
+++ b/assembly/jetty-base/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN useradd -u 1000 -g 0 -d '/var/opt/jetty' -s '/sbin/nologin' jetty && \
     rm -f /tmp/jetty.tar.gz && \
     rm -rf /opt/jetty/demo-base && \
     cd /var/opt/jetty && \
-    java -jar /opt/jetty/start.jar --approve-all-licenses --create-startd --add-to-start=http,https,jsp,jstl,websocket,deploy,logging-logback,jmx,ssl,stats && \
+    java -Dmaven.repo.uri=@jetty.maven.repo.uri@ -jar /opt/jetty/start.jar --approve-all-licenses --create-startd --add-to-start=http,https,jsp,jstl,websocket,deploy,logging-logback,jmx,ssl,stats && \
     chown -R 1000:0 /opt/jetty /var/opt/jetty && \
     chmod -R g=u /opt/jetty /var/opt/jetty
 

--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -31,6 +31,7 @@
         <docker.image.name>jetty-base</docker.image.name>
 
         <jetty.url>https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/jetty-distribution-${jetty.version}.tar.gz</jetty.url>
+        <jetty.maven.repo.uri>https://repo1.maven.org/maven2/</jetty.maven.repo.uri>
     </properties>
 
     <build>

--- a/assembly/sql/docker/Dockerfile
+++ b/assembly/sql/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd -u 1001 -g 0 -d '/var/opt/h2' -s '/sbin/nologin' h2 && \
     mkdir -p /var/opt/h2/data && chmod -R a+rw /var/opt/h2 && \
     mkdir -p /opt/h2 && chmod a+r /opt/h2 && \
     cd /opt/h2 && \
-    curl -s https://repo1.maven.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar -o h2.jar
+    curl -s @h2.url@ -o h2.jar
 
 VOLUME /var/opt/h2/data
 

--- a/assembly/sql/pom.xml
+++ b/assembly/sql/pom.xml
@@ -29,6 +29,7 @@
 
     <properties>
         <docker.image.name>kapua-sql</docker.image.name>
+        <h2.url>https://repo1.maven.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar</h2.url>
     </properties>
 
     <build>


### PR DESCRIPTION
I would need to build Kapua in a restricted network environment.

Would it be possible to override the default download endpoints as in the PR?

