### PR TITLE
:sparkles: [Datastore] Add parameter to configure max number of metric field mappings in message index

### DIFF
--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/SchemaKeys.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/SchemaKeys.java
@@ -226,5 +226,11 @@ public class SchemaKeys {
      * @since 1.0.0
      */
     public static final String FIELD_NAME_PROPERTIES = "properties";
+    /**
+     * Max number of field mappings of an index.
+     *
+     * @since 1.6.0
+     */
+    public static final String KEY_MAPPING_TOTAL_FIELDS_LIMIT = "mapping.total_fields.limit";
 
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 /**
  * Datastore schema creation/update
@@ -48,6 +49,11 @@ import java.util.Map.Entry;
 public class Schema {
 
     private static final Logger LOG = LoggerFactory.getLogger(Schema.class);
+
+    // If new pre-defined mappings are added in {@link MessageSchema}, update the following value
+    // consistently. Refer to Elasticsearch documentation to find how many mappings need to be
+    // allocated for the new fields based upon their type
+    private static final int PREDEFINED_FIELD_MAPPINGS_COUNT = 23;
 
     /**
      * Synchronize metadata
@@ -251,13 +257,22 @@ public class Schema {
         String idxRefreshInterval = String.format("%ss", DatastoreSettings.getInstance().getLong(DatastoreSettingsKey.INDEX_REFRESH_INTERVAL));
         Integer idxShardNumber = DatastoreSettings.getInstance().getInt(DatastoreSettingsKey.INDEX_SHARD_NUMBER, 1);
         Integer idxReplicaNumber = DatastoreSettings.getInstance().getInt(DatastoreSettingsKey.INDEX_REPLICA_NUMBER, 0);
-
+        Optional<Integer> maxIndexedMetrics = DatastoreSettings.getInstance().getInteger(DatastoreSettingsKey.CONFIG_MESSAGES_INDEX_MAX_INDEXED_METRICS);
+        if (maxIndexedMetrics.isPresent() && maxIndexedMetrics.get() <= 0) {
+            maxIndexedMetrics = Optional.of(0);
+        }
         ObjectNode rootNode = MappingUtils.newObjectNode();
         ObjectNode settingsNode = MappingUtils.newObjectNode();
         ObjectNode refreshIntervalNode = MappingUtils.newObjectNode(new KeyValueEntry[]{
                 new KeyValueEntry(SchemaKeys.KEY_REFRESH_INTERVAL, idxRefreshInterval),
                 new KeyValueEntry(SchemaKeys.KEY_SHARD_NUMBER, idxShardNumber),
                 new KeyValueEntry(SchemaKeys.KEY_REPLICA_NUMBER, idxReplicaNumber)});
+        if (maxIndexedMetrics.isPresent()) {
+            // PREDEFINED_FIELD_MAPPINGS mappings are allocated to predefined indexed fields (e.g. the topic), then each metric takes
+            // two other mappings. One for the metric itself and one more for the type (e.g. {"temp": {"type":"dbl"}})
+            int totalRequiredMappings = PREDEFINED_FIELD_MAPPINGS_COUNT + maxIndexedMetrics.get()*2;
+            MappingUtils.appendField(refreshIntervalNode, SchemaKeys.KEY_MAPPING_TOTAL_FIELDS_LIMIT, totalRequiredMappings);
+        }
         settingsNode.set(SchemaKeys.KEY_INDEX, refreshIntervalNode);
         rootNode.set(SchemaKeys.KEY_SETTINGS, settingsNode);
         LOG.info("Creating index for '{}' - refresh: '{}' - shards: '{}' replicas: '{}': ", idxName, idxRefreshInterval, idxShardNumber, idxReplicaNumber);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
@@ -114,7 +114,11 @@ public enum DatastoreSettingsKey implements SettingKey {
     /**
      * Elasticsearch limit maximum value
      */
-    MAX_LIMIT_VALUE("datastore.query.limit.max");
+    MAX_LIMIT_VALUE("datastore.query.limit.max"),
+    /**
+     * Elasticsearch max number of field mappings for the message index
+     */
+    CONFIG_MESSAGES_INDEX_MAX_INDEXED_METRICS("datastore.index.message.maxIndexedMetrics");
 
     private String key;
 

--- a/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
@@ -46,3 +46,8 @@ datastore.index.prefix=
 #
 #maximum value for limit parameter
 datastore.query.limit.max=10000
+
+# Defines the max number of metrics of a message that are indexed to support queries. If defined 
+# it must be greater or equal than zero (the case for zero is when messages have no metrics but 
+# just a body). If left undefined the number of metrics depends on Elastic search defaults.
+datastore.index.message.maxIndexedMetrics=


### PR DESCRIPTION
Brief description of the PR.
Field mappings are used to index values of message metrics to support queries by metric. Currently, when a new message index is created, the max number of field mappings is set to the default limit (which is currently 1000), this might be not enough for some use cases.  In this PR a parameter is added to configure the maximum number of metrics that can be indexed.

**Related Issue**
None

**Description of the solution adopted**
The parameter sets the limit at the instance level meaning that it holds for all the accounts in the instance. The deployer just needs to configure the number of message metrics that need to be indexed, the business logic determines the number of actual field mappings required. Each time a new message index is created (i.e. at the beginning of the data time window), the configured limit is calculated and applied.

**Screenshots**
None

**Any side note on the changes made**
The new parameter is backward compatible. The default value is null, with null value the business logic does not impose a custom limit and uses the Elasticsearch default.