### PR TITLE
⬆️ [Dependencies] Bump ch.qos.logback dependency to 1.5.34 - CVE-2026-10532

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 
         <!-- Log Dependencies Versions-->
         <log4j-api.version>2.25.2</log4j-api.version>
-        <logback.version>1.5.21</logback.version>
+        <logback.version>1.5.34</logback.version>
         <slf4j.version>2.0.17</slf4j.version>
 
         <!-- Plugins versions -->


### PR DESCRIPTION
Bumped `ch.qos.logback:logback-core` (and `logback-classic`, governed by the same `logback.version` property) from `1.5.21` to `1.5.34` to address CVE-2026-10532.

**Related Issue**
This PR fixes/closes _CVE-2026-10532_

**Description of the solution adopted**
Bumped the `logback.version` property in the root `pom.xml` and confirmed via
`mvn dependency:tree -Dincludes=ch.qos.logback` that the new version resolves in every
affected module (no hardcoded overrides found elsewhere in the repo).
