### PR TITLE
:hammer: [Datastore] Improve comments for maxIndexedMetrics in datastore-settings configuration file

### DIFF
--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingsKey.java
@@ -116,7 +116,7 @@ public enum DatastoreSettingsKey implements SettingKey {
      */
     MAX_LIMIT_VALUE("datastore.query.limit.max"),
     /**
-     * Elasticsearch max number of field mappings for the message index
+     * Elasticsearch max number of indexed metrics for the message index
      */
     CONFIG_MESSAGES_INDEX_MAX_INDEXED_METRICS("datastore.index.message.maxIndexedMetrics");
 

--- a/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-settings.properties
@@ -46,7 +46,7 @@ datastore.index.prefix=
 #
 #maximum value for limit parameter
 datastore.query.limit.max=10000
-
+#
 # Defines the max number of metrics of a message that are indexed to support queries. If defined 
 # it must be greater or equal than zero (the case for zero is when messages have no metrics but 
 # just a body). If left undefined the number of metrics depends on Elastic search defaults.


### PR DESCRIPTION
Brief description of the PR.
Updated the description of the parameter `datastore.index.message.maxIndexedMetrics` in datastore-settings properties file to better describe its semantics.

**Related Issue**
None

**Description of the solution adopted**
The number of indexed metrics is not equal to the max number of mapped fields so the description of the parameter has been changed consistently.

**Screenshots**
None

**Any side note on the changes made**
None
