### PR TITLE
:bug: [Datastore] fix message properties of type String mapped to fields of type Text

### DIFF
--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/ElasticsearchRepository.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/ElasticsearchRepository.java
@@ -60,6 +60,9 @@ public abstract class ElasticsearchRepository<
 
     protected abstract StorableId idExtractor(T storable);
 
+    private static final String INDEX_EXPR_SEPARATOR = ",";
+    private static final String INDEX_EXPR_WILDCARD = "*";
+
     protected ElasticsearchRepository(
             ElasticsearchClientProvider elasticsearchClientProviderInstance,
             Class<T> clazz,
@@ -111,7 +114,12 @@ public abstract class ElasticsearchRepository<
     private void synchIndex(String indexName) {
         if (!indexUpserted.containsKey(indexName)) {
             synchronized (clazz) {
-                doUpsertIndex(indexName);
+                // Upsert index only if index name is fully defined
+                if (isFullyDefinedIndex(indexName)) {
+                    doUpsertIndex(indexName);
+                }
+                // Add to cache even the non fully defined so that the next time
+                // the check can be skipped to save processing time.
                 indexUpserted.put(indexName, true);
             }
         }
@@ -237,10 +245,16 @@ public abstract class ElasticsearchRepository<
             // Check existence of the kapua internal indexes
             IndexResponse indexExistsResponse = elasticsearchClientWrapper.isIndexExists(new IndexRequest(indexName));
             if (!indexExistsResponse.isIndexExists()) {
-                elasticsearchClientWrapper.createIndex(indexName, getMappingSchema(indexName));
-                logger.info("Index created: {}", indexExistsResponse);
-                elasticsearchClientWrapper.putMapping(indexName, getIndexSchema());
+                ObjectNode settings = getMappingSchema(indexName);
+                elasticsearchClientWrapper.createIndex(indexName, settings);
+                logger.info("Index created with name: {}, index exists check: {}", indexName, indexExistsResponse);
+                logger.debug("Index created with name: {}, index settings: {}", indexName, settings);
             }
+            // Update base index mappings regardless the index existed or not
+            JsonNode mappings = getIndexSchema();
+            elasticsearchClientWrapper.putMapping(indexName, mappings);
+            logger.info("Index mappings updated for index: {}, index exists check: {}", indexName, indexExistsResponse);
+            logger.debug("Index mappings updated for index: {}, index mappings: {}", indexName, mappings);
         } catch (ClientException | MappingException e) {
             throw new RuntimeException(e);
         }
@@ -285,4 +299,14 @@ public abstract class ElasticsearchRepository<
         }
     }
 
+    /*
+     * Returns false if indexExpression is an index pattern (e.g. 'idx-name-*' or 'idx-name-*, -idx-name-2026-01').
+     * Returns true if indexExpression is a single fully defined index name.
+     */
+    private boolean isFullyDefinedIndex(String indexExpression) {
+        if (indexExpression.contains(INDEX_EXPR_SEPARATOR) || indexExpression.contains(INDEX_EXPR_WILDCARD)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreElasticSearchRepositoryBase.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreElasticSearchRepositoryBase.java
@@ -79,7 +79,6 @@ public abstract class DatastoreElasticSearchRepositoryBase<
                 new KeyValueEntry(SchemaKeys.KEY_REPLICA_NUMBER, idxReplicaNumber)});
         settingsNode.set(SchemaKeys.KEY_INDEX, refreshIntervalNode);
         rootNode.set(SchemaKeys.KEY_SETTINGS, settingsNode);
-        logger.info("Creating index for '{}' - refresh: '{}' - shards: '{}' replicas: '{}': ", idxName, idxRefreshInterval, idxShardNumber, idxReplicaNumber);
         return rootNode;
     }
 


### PR DESCRIPTION
Brief description of the PR.
The problem is caused by an incorrect index configuration that can happen during the initialisation phase of a new index (e.g. for a message index when a new datastore time window starts). If two services, e.g. the broker and the REST API store a message in the same time for the same account when the new index is not yet created, one of the two messages could be stored before the right configuration is set into the index. If this happens, message properties of type `String` will be mapped to Elasticsearch default field type for string a value, i.e. type `Text`, which then lead to errors in datastore queries via the API or the Console. Two symptoms of this issue are:
- the `Data` view in the Console does not return the message data for the current time window (e.g. the current week)
- The search by `clientId` or by `channel` parameters in API `GET /{scopeId}/data/messages` returns an error.

Even in case the problem happens, message data is not lost and can be retrieved using REST APIs like `GET /{scopeId}/data/messages` using the `startDate` and `endDate` parameters.

**Related Issue**
None

**Description of the solution adopted**
Always update base index mappings during the initialisation phase regardless the index was pre-existing or not so that the correct configuration is enforced in every use case.

**Screenshots**
None

**Any side note on the changes made**
Changes are backward compatible. Non need to execute upgrade steps.