### PR TITLE
⬆️ [Dependencies] Bumped version of io.netty dependencies to 4.1.137.Final - CVE-2026-75595

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <liquibase.version>3.6.3</liquibase.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.136.Final</netty.version>
+        <netty.version>4.1.137.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <ow2-asm.version>9.4</ow2-asm.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>


### PR DESCRIPTION
Bumped `io.netty` dependencies from `4.1.136.Final` to `4.1.137.Final` to address CVE-2026-75595.

**Related Issue**
This PR fixes/closes _https://nvd.nist.gov/vuln/detail/CVE-2026-75595_

**Description of the solution adopted**
Bumped the `netty.version` property in the root `pom.xml` and confirmed via
`mvn dependency:tree -Dincludes=io.netty` that the new version resolves in every
affected module.

**Screenshots**
N/A